### PR TITLE
refactor: persona 模块统一使用 loguru 替代标准库 logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -31,8 +31,8 @@ import nonebot
 from nonebot.log import logger, default_format
 from nonebot.adapters.onebot.v11 import Adapter as OneBot_V11_Adapter
 
-# 日志配置：控制台显示 INFO 及以上（可通过 PERSONA_LOG_LEVEL=DEBUG 调低），错误写入文件
-_log_level = os.environ.get("PERSONA_LOG_LEVEL", "INFO").upper()
+# 日志配置：控制台显示 INFO 及以上（可通过 LOG_LEVEL=DEBUG 调低），错误写入文件
+_log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
 logger.remove()
 logger.add(sys.stderr,
            level=_log_level,

--- a/bot.py
+++ b/bot.py
@@ -31,10 +31,11 @@ import nonebot
 from nonebot.log import logger, default_format
 from nonebot.adapters.onebot.v11 import Adapter as OneBot_V11_Adapter
 
-# 日志配置：控制台显示 INFO 及以上，错误写入文件
+# 日志配置：控制台显示 INFO 及以上（可通过 PERSONA_LOG_LEVEL=DEBUG 调低），错误写入文件
+_log_level = os.environ.get("PERSONA_LOG_LEVEL", "INFO").upper()
 logger.remove()
 logger.add(sys.stderr,
-           level="INFO",
+           level=_log_level,
            format=default_format)
 logger.add("error.log",
            rotation="10 MB",

--- a/src/plugins/DicePP/module/persona/admin.py
+++ b/src/plugins/DicePP/module/persona/admin.py
@@ -5,7 +5,7 @@
 from typing import List, Dict, Any, Optional
 import json
 import time
-import logging
+from nonebot.log import logger
 from datetime import timedelta
 
 from core.bot import Bot
@@ -13,8 +13,6 @@ from core.bot import Bot
 from .factory import PersonaApp
 from .data.store import PersonaDataStore
 from .wall_clock import persona_wall_now
-
-logger = logging.getLogger("persona.admin")
 
 
 class AdminDispatcher:

--- a/src/plugins/DicePP/module/persona/character/loader.py
+++ b/src/plugins/DicePP/module/persona/character/loader.py
@@ -3,14 +3,12 @@
 
 从 YAML 文件加载角色卡
 """
-import logging
+from nonebot.log import logger
 from pathlib import Path
 from typing import Optional
 import yaml
 
 from .models import Character, CharacterBook, LoreEntry, PersonaExtensions
-
-logger = logging.getLogger("persona.character")
 
 
 class CharacterLoader:

--- a/src/plugins/DicePP/module/persona/character/models.py
+++ b/src/plugins/DicePP/module/persona/character/models.py
@@ -3,14 +3,12 @@
 
 兼容 SillyTavern V2 标准的角色卡定义
 """
-import logging
+from nonebot.log import logger
 import random
 from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
-
-logger = logging.getLogger("persona.character")
 
 
 class SharePolicy(str, Enum):

--- a/src/plugins/DicePP/module/persona/chat/context.py
+++ b/src/plugins/DicePP/module/persona/chat/context.py
@@ -3,7 +3,7 @@
 
 组装四层记忆到 LLM 消息列表
 """
-import logging
+from nonebot.log import logger
 from typing import List, Dict, Optional, Any, Tuple
 
 from utils.string import estimate_tokens
@@ -11,8 +11,6 @@ from utils.string import estimate_tokens
 from ..character.models import Character
 from ..data.models import UserProfile
 from ..wall_clock import persona_wall_now
-
-logger = logging.getLogger("persona.context_builder")
 
 
 class ContextBuilder:

--- a/src/plugins/DicePP/module/persona/chat/scoring.py
+++ b/src/plugins/DicePP/module/persona/chat/scoring.py
@@ -5,13 +5,10 @@
 """
 import json
 from typing import List, Dict, Any, Optional
-import logging
-
+from nonebot.log import logger
 from ..data.models import ScoreDeltas, UserProfile, RelationshipState, ModelTier
 from ..llm.router import LLMRouter
 from ..utils.json_helpers import safe_json_loads
-
-logger = logging.getLogger("persona.scoring")
 
 
 class ScoringAgent:

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -11,7 +11,7 @@ from typing import List, Dict, Optional, Any, Tuple, TYPE_CHECKING
 from dataclasses import dataclass
 import asyncio
 import json
-import logging
+from nonebot.log import logger
 import time
 import random
 from collections import deque
@@ -42,8 +42,6 @@ from .billing import BillingPolicy
 
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
-
-logger = logging.getLogger("persona.chat_session")
 
 
 @dataclass

--- a/src/plugins/DicePP/module/persona/command.py
+++ b/src/plugins/DicePP/module/persona/command.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Tuple, Any, Optional, Callable
 import json
 import time
 import asyncio
-import logging
+from nonebot.log import logger
 from datetime import timedelta
 
 from core.bot import Bot
@@ -18,7 +18,6 @@ from core.communication import MessageMetaData
 from core.command.const import DPP_COMMAND_PRIORITY_DEFAULT, DPP_COMMAND_FLAG_FUN
 from utils.logger import dice_log
 
-logger = logging.getLogger("persona.command")
 
 from .factory import PersonaApp, create_persona
 from .exceptions import PersonaInitError

--- a/src/plugins/DicePP/module/persona/data/observation_buffer_repository.py
+++ b/src/plugins/DicePP/module/persona/data/observation_buffer_repository.py
@@ -5,14 +5,12 @@
 """
 import json
 import time
-import logging
+from nonebot.log import logger
 from typing import Dict, Optional, Any
 
 from ..data.store import PersonaDataStore
 from ..data.persist_keys import PERSONA_SK_OBSERVATION_BUFFERS
 from ..life.observation import ObservationBuffer, ObservationExtractor
-
-logger = logging.getLogger("persona.observation_repo")
 
 
 class ObservationBufferRepository:

--- a/src/plugins/DicePP/module/persona/data/store.py
+++ b/src/plugins/DicePP/module/persona/data/store.py
@@ -6,7 +6,7 @@ Persona 数据存储层
 from typing import List, Optional, Dict, Any
 from datetime import datetime, timedelta
 import json
-import logging
+from nonebot.log import logger
 import os
 import base64
 import aiosqlite
@@ -25,8 +25,6 @@ from .models import (
     LLMTraceRecord, DelayedTask, GroupConversation, CharacterState,
 )
 from .migrations import ALL_MIGRATIONS
-
-logger = logging.getLogger("persona.store")
 
 
 class PersonaDataStore:

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -4,8 +4,7 @@
 """
 from typing import Any, Dict, List, Optional
 from dataclasses import dataclass
-import logging
-
+from nonebot.log import logger
 from core.bot import Bot
 
 from .character.loader import CharacterLoader
@@ -36,8 +35,6 @@ from .tools.registry import ToolRegistry, ToolDomain
 from .tools.search_memory import SEARCH_MEMORY_TOOL, search_memory_executor
 from .tools.search_history import SEARCH_HISTORY_TOOL, make_search_history_executor
 from .tools.roll_dice import ROLL_DICE_TOOL, roll_dice_executor
-
-logger = logging.getLogger("persona.factory")
 
 
 @dataclass

--- a/src/plugins/DicePP/module/persona/game/decay.py
+++ b/src/plugins/DicePP/module/persona/game/decay.py
@@ -5,12 +5,10 @@
 """
 from typing import Optional, Tuple, TYPE_CHECKING
 from datetime import datetime
-import logging
-
+from nonebot.log import logger
 from ..data.models import RelationshipState, ScoreDeltas
 from ..wall_clock import persona_wall_now
 
-logger = logging.getLogger("persona.decay")
 
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
@@ -136,7 +134,7 @@ class DecayCalculator:
             f"下限保护后 {actual_decay:.2f} (下限 {floor:.1f})"
         )
 
-        logger.debug("Decay calculated for %s: %s", relationship.user_id, reason)
+        logger.debug("Decay calculated for {}s: {}", relationship.user_id, reason)
         return deltas, reason
 
     def effective_relationship(

--- a/src/plugins/DicePP/module/persona/game/decay.py
+++ b/src/plugins/DicePP/module/persona/game/decay.py
@@ -134,7 +134,7 @@ class DecayCalculator:
             f"下限保护后 {actual_decay:.2f} (下限 {floor:.1f})"
         )
 
-        logger.debug("Decay calculated for {}s: {}", relationship.user_id, reason)
+        logger.debug("Decay calculated for {}: {}", relationship.user_id, reason)
         return deltas, reason
 
     def effective_relationship(

--- a/src/plugins/DicePP/module/persona/gateway/port.py
+++ b/src/plugins/DicePP/module/persona/gateway/port.py
@@ -1,6 +1,6 @@
 """唯一消息发送出口"""
 import asyncio
-import logging
+from nonebot.log import logger
 from typing import Optional, Callable, List, Dict
 
 from core.bot import Bot
@@ -10,8 +10,6 @@ from core.communication import GroupMessagePort, PrivateMessagePort
 from .pipeline import MessagePipeline, SendAction
 from ..tools.context import SendPort
 from ..life.protocols import EventSharePort
-
-logger = logging.getLogger("persona.port")
 
 
 class MessagePort(EventSharePort):
@@ -80,7 +78,7 @@ class MessagePort(EventSharePort):
     ) -> None:
         proxy = getattr(self._bot, "proxy", None)
         if proxy is None:
-            logger.error("Bot.proxy 未配置，丢弃消息: user=%s group=%s", user_id, group_id)
+            logger.error("Bot.proxy 未配置，丢弃消息: user={}s group={}", user_id, group_id)
             return
 
         if group_id:

--- a/src/plugins/DicePP/module/persona/gateway/port.py
+++ b/src/plugins/DicePP/module/persona/gateway/port.py
@@ -78,7 +78,7 @@ class MessagePort(EventSharePort):
     ) -> None:
         proxy = getattr(self._bot, "proxy", None)
         if proxy is None:
-            logger.error("Bot.proxy 未配置，丢弃消息: user={}s group={}", user_id, group_id)
+            logger.error("Bot.proxy 未配置，丢弃消息: user={} group={}", user_id, group_id)
             return
 
         if group_id:

--- a/src/plugins/DicePP/module/persona/life/character_life.py
+++ b/src/plugins/DicePP/module/persona/life/character_life.py
@@ -5,7 +5,7 @@
 事件触发时刻由角色卡 PersonaExtensions.generate_event_times() 决定（日内分钟槽位）。
 """
 import json
-import logging
+from nonebot.log import logger
 import random
 import uuid
 from dataclasses import dataclass
@@ -22,8 +22,6 @@ from .protocols import BoundaryReceiver
 
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
-
-logger = logging.getLogger("persona.character_life")
 
 
 @dataclass
@@ -207,7 +205,7 @@ class CharacterLife:
         self._today_jittered_end = None
         self._regenerate_slots_for_today()
         self._last_event_date = today
-        logger.debug("重置每日事件状态: %s", today)
+        logger.debug("重置每日事件状态: {}", today)
 
     def _cleanup_expired_activities(self) -> None:
         now = self.config.now()
@@ -411,7 +409,7 @@ class CharacterLife:
                     character_state.current_intention = None
                     character_state.intention_created_at = None
                     await self.data_store.update_character_state(character_state)
-                    logger.debug("跨天空清意向: %s", today)
+                    logger.debug("跨天空清意向: {}", today)
             else:
                 character_state = CharacterState(
                     energy=self.config.default_energy,
@@ -568,8 +566,8 @@ class CharacterLife:
 
                 # debug trace
                 logger.debug(
-                    "[chain] %s @ %s depth=%d energy=%d(%+d) mood=%d(%+d) health=%d(%+d) "
-                    "follow_up=%r pending_plan=%r fallback=%s",
+                    "[chain] {} @ {} depth={} energy={}({:+d}) mood={}({:+d}) health={}({:+d}) "
+                    "follow_up={!r} pending_plan={!r} fallback={}",
                     self.character.name, time_str, chain_depth + 1,
                     character_state.energy, ed,
                     character_state.mood, md,
@@ -594,14 +592,14 @@ class CharacterLife:
                 if chain_depth == 1 and not self._chain_triggered_today and not is_fallback:
                     if random.random() < self.config.chain_force_extend_once_prob:
                         is_fallback = True
-                        logger.info("[chain] 触发保底续写: %s", self.character.name)
+                        logger.info("[chain] 触发保底续写: {}", self.character.name)
                         continue
 
                 break
 
             if event_chain:
                 logger.info(
-                    "生成生活事件链: %s... (深度=%d, 保底=%s)",
+                    "生成生活事件链: {}... (深度={}, 保底={})",
                     event_chain[0]["description"][:50],
                     chain_depth,
                     is_fallback,
@@ -609,7 +607,7 @@ class CharacterLife:
             return event_chain
 
         except Exception as e:
-            logger.exception("生成生活事件失败: %s", e)
+            logger.exception("生成生活事件失败: {}", e)
             return []
 
     async def _get_recent_diaries(self, days: int) -> List[str]:

--- a/src/plugins/DicePP/module/persona/life/diary.py
+++ b/src/plugins/DicePP/module/persona/life/diary.py
@@ -4,15 +4,13 @@
 """
 from typing import Optional, List
 from dataclasses import dataclass
-import logging
+from nonebot.log import logger
 from datetime import timedelta
 
 from ..data.store import PersonaDataStore
 from ..character.models import Character
 from ..life.event_agent import EventGenerationAgent
 from ..wall_clock import persona_wall_now
-
-logger = logging.getLogger("persona.diary")
 
 
 @dataclass

--- a/src/plugins/DicePP/module/persona/life/event_agent.py
+++ b/src/plugins/DicePP/module/persona/life/event_agent.py
@@ -9,8 +9,7 @@ from dataclasses import dataclass
 from typing import List, Literal, Optional
 from datetime import datetime
 import json
-import logging
-
+from nonebot.log import logger
 from ..llm import ForcedToolError
 from ..llm.router import LLMRouter
 from ..data.models import ModelTier
@@ -20,8 +19,6 @@ if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
 
 _EVENT_DESCRIPTION_MAX_LEN = 60
-
-logger = logging.getLogger("persona.event_agent")
 
 
 @dataclass
@@ -217,8 +214,8 @@ class EventGenerationAgent:
 
         user_prompt = f"当前时间: {context.current_time.strftime('%H:%M')}{intention_text}{diary_context}{events_context}\n\n请生成一个符合世界观的生活事件，并通过 record_event 工具记录:"
 
-        logger.debug("[prompt:system_event]\n%s", system_prompt)
-        logger.debug("[prompt:user_event]\n%s", user_prompt)
+        logger.debug("[prompt:system_event]\n{}", system_prompt)
+        logger.debug("[prompt:user_event]\n{}", user_prompt)
 
         tools = [
             {
@@ -364,8 +361,8 @@ class EventGenerationAgent:
 
         user_prompt = f"{today_context}{intention_text}\n\n当前事件: {event}\n\n请先思考，然后通过 record_reaction 工具记录你的内心反应、分享欲望、跟进动作和待办计划。"
 
-        logger.debug("[prompt:system_reaction]\n%s", system_prompt)
-        logger.debug("[prompt:user_reaction]\n%s", user_prompt)
+        logger.debug("[prompt:system_reaction]\n{}", system_prompt)
+        logger.debug("[prompt:user_reaction]\n{}", user_prompt)
 
         tools = [
             {
@@ -534,8 +531,8 @@ class EventGenerationAgent:
 
 请写一篇日记总结今天:"""
 
-        logger.debug("[prompt:system_diary]\n%s", system_prompt)
-        logger.debug("[prompt:user_diary]\n%s", user_prompt)
+        logger.debug("[prompt:system_diary]\n{}", system_prompt)
+        logger.debug("[prompt:user_diary]\n{}", user_prompt)
 
         try:
             response = await self.llm_router.generate(
@@ -668,8 +665,8 @@ class EventGenerationAgent:
 
 请调用 record_share_message 工具，传入你要发给对方的消息。"""
 
-        logger.debug("[prompt:system_share]\n%s", system_prompt)
-        logger.debug("[prompt:user_share]\n%s", user_prompt)
+        logger.debug("[prompt:system_share]\n{}", system_prompt)
+        logger.debug("[prompt:user_share]\n{}", user_prompt)
 
         tools = [
             {

--- a/src/plugins/DicePP/module/persona/life/event_share_queue.py
+++ b/src/plugins/DicePP/module/persona/life/event_share_queue.py
@@ -4,12 +4,9 @@
 """
 from typing import List, Dict, Callable, Awaitable
 from datetime import timedelta
-import logging
-
+from nonebot.log import logger
 from ..data.store import PersonaDataStore
 from ..wall_clock import persona_wall_now
-
-logger = logging.getLogger("persona.scheduler")
 
 
 class EventShareTaskQueue:

--- a/src/plugins/DicePP/module/persona/life/observation.py
+++ b/src/plugins/DicePP/module/persona/life/observation.py
@@ -14,13 +14,10 @@ import re
 from dataclasses import dataclass
 from typing import List, Dict, Optional, Set, Any
 from datetime import datetime, timedelta
-import logging
-
+from nonebot.log import logger
 from .event_agent import EventGenerationAgent
 from ..data.store import PersonaDataStore
 from ..utils.json_helpers import safe_json_loads
-
-logger = logging.getLogger("persona.observation")
 
 
 @dataclass

--- a/src/plugins/DicePP/module/persona/life/proactive_scheduler.py
+++ b/src/plugins/DicePP/module/persona/life/proactive_scheduler.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 import asyncio
 import json
 import random
-import logging
+from nonebot.log import logger
 import re
 
 from ..data.store import PersonaDataStore
@@ -25,8 +25,6 @@ from .proactive_config import ProactiveConfig
 if TYPE_CHECKING:
     from .target import TargetSelector
     from ..llm.coordinator import LLMCallCoordinator
-
-logger = logging.getLogger("persona.scheduler")
 
 
 class ProactiveScheduler(BoundaryReceiver):

--- a/src/plugins/DicePP/module/persona/life/simulator.py
+++ b/src/plugins/DicePP/module/persona/life/simulator.py
@@ -6,8 +6,7 @@
 from typing import Optional, Dict, Any, List, TYPE_CHECKING
 from dataclasses import dataclass
 import random
-import logging
-
+from nonebot.log import logger
 from ..data.store import PersonaDataStore
 from ..data.models import RelationshipState, ScoreEvent
 from ..character.models import Character
@@ -20,7 +19,6 @@ from .protocols import EventSharePort
 from .diary import DiaryGenerator
 from .character_life import CharacterLife
 
-logger = logging.getLogger("persona.life_simulator")
 
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig

--- a/src/plugins/DicePP/module/persona/life/target.py
+++ b/src/plugins/DicePP/module/persona/life/target.py
@@ -4,8 +4,7 @@
 组合 force / normal 策略生成候选目标；最终发送前的 mute 与最小间隔检查由调度器负责。
 """
 from typing import TYPE_CHECKING, List, Optional, Set
-import logging
-
+from nonebot.log import logger
 from .models import ShareTarget
 from ..data.store import PersonaDataStore
 from ..game.decay import DecayCalculator
@@ -15,7 +14,6 @@ from .utils import effective_for_proactive
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
 
-logger = logging.getLogger("persona.target_selector")
 
 FORCE_PRIORITY_BASE = 10000
 NORMAL_HIGH_PRIORITY_BASE = 100

--- a/src/plugins/DicePP/module/persona/llm/client.py
+++ b/src/plugins/DicePP/module/persona/llm/client.py
@@ -4,14 +4,13 @@ LLM 客户端封装
 基于 AsyncOpenAI 的异步客户端，支持超时和错误处理
 """
 import asyncio
-import logging
+from nonebot.log import logger
 from typing import List, Dict, Optional, Any, Callable, Awaitable
 import time
 
 # 工具执行器类型别名
 ToolExecutor = Callable[[List[Dict]], Awaitable[List[Dict]]]
 
-logger = logging.getLogger("persona.llm")
 
 _RETRYABLE_KEYWORDS = (
     "rate limit", "429", "service unavailable", "503",

--- a/src/plugins/DicePP/module/persona/llm/coordinator.py
+++ b/src/plugins/DicePP/module/persona/llm/coordinator.py
@@ -13,11 +13,9 @@ buffered merge-retry 状态机：``pending_consumed`` 标记最近一轮 result
 from dataclasses import dataclass
 from typing import Dict, Optional, Callable, Any, Awaitable, TypeVar, Generic, List, Literal
 import asyncio
-import logging
-
+from nonebot.log import logger
 from .router import QuotaExceeded, NonRetryableError
 
-logger = logging.getLogger("persona.llm_call_coordinator")
 
 NON_RETRYABLE_EXCEPTIONS = (QuotaExceeded, NonRetryableError)
 

--- a/src/plugins/DicePP/module/persona/llm/router.py
+++ b/src/plugins/DicePP/module/persona/llm/router.py
@@ -11,15 +11,12 @@ import json
 from typing import List, Dict, Any, Optional, Callable, Awaitable, TYPE_CHECKING
 import time
 import uuid
-import logging
-
+from nonebot.log import logger
 from .client import LLMClient
 from ..data.models import ModelTier, UserLLMConfig
 
 if TYPE_CHECKING:
     from ...core.config.pydantic_models import PersonaConfig
-
-logger = logging.getLogger("persona.llm")
 
 
 class QuotaExceeded(Exception):

--- a/src/plugins/DicePP/module/persona/tools/registry.py
+++ b/src/plugins/DicePP/module/persona/tools/registry.py
@@ -1,12 +1,10 @@
 """工具注册表 — 按 domain 注册/查找/执行"""
 import json
-import logging
+from nonebot.log import logger
 from typing import Dict, List, Callable, Set, Any
 from dataclasses import dataclass
 
 from .context import ToolContext
-
-logger = logging.getLogger("persona.tools")
 
 
 class ToolDomain:

--- a/src/plugins/DicePP/module/persona/tools/roll_dice.py
+++ b/src/plugins/DicePP/module/persona/tools/roll_dice.py
@@ -4,13 +4,10 @@
 将 module.roll 的调用隔离在 persona 模块外部，
 负责异常转换和结果格式化。
 """
-import logging
-
+from nonebot.log import logger
 from module.roll import exec_roll_exp, RollDiceError
 from .context import ToolContext
 from .registry import ToolDef
-
-logger = logging.getLogger("persona.roll_dice")
 
 
 class RollAdapter:

--- a/src/plugins/DicePP/module/persona/utils/json_helpers.py
+++ b/src/plugins/DicePP/module/persona/utils/json_helpers.py
@@ -22,11 +22,9 @@ r"""LLM 响应 JSON 解析的统一容错实现
 from __future__ import annotations
 
 import json
-import logging
+from nonebot.log import logger
 import re
 from typing import Any, Optional
-
-logger = logging.getLogger("persona.json_helpers")
 
 
 def _strip_markdown_fence(text: str) -> str:

--- a/src/plugins/DicePP/module/persona/wall_clock.py
+++ b/src/plugins/DicePP/module/persona/wall_clock.py
@@ -8,10 +8,9 @@
 
 from __future__ import annotations
 
-import logging
+from nonebot.log import logger
 from datetime import datetime
 
-logger = logging.getLogger("persona.wall_clock")
 
 PERSONA_EPOCH = datetime(2000, 1, 1)
 

--- a/tests/unit/persona/test_character_life_phase2.py
+++ b/tests/unit/persona/test_character_life_phase2.py
@@ -359,9 +359,10 @@ class TestCharacterLifePhase2:
     # ── 2.6 debug 日志 ───────────────────────────
 
     @pytest.mark.asyncio
-    async def test_chain_debug_trace_logged(self, life, mock_event_agent, monkeypatch, caplog):
+    async def test_chain_debug_trace_logged(self, life, mock_event_agent, monkeypatch):
         """每次链式步骤输出 debug 级 trace"""
-        import logging
+        from io import StringIO
+        from loguru import logger
         from plugins.DicePP.module.persona.life.event_agent import EventReactionResult
 
         fake_now = datetime(2024, 1, 1, 10, 0, 0)
@@ -377,13 +378,18 @@ class TestCharacterLifePhase2:
             follow_up_action="想继续", pending_plan="新意向",
         ))
 
-        with caplog.at_level(logging.DEBUG, logger="persona.character_life"):
+        output = StringIO()
+        handler_id = logger.add(output, level="DEBUG", format="{message}")
+        try:
             await life.tick()
+        finally:
+            logger.remove(handler_id)
 
-        assert "[chain]" in caplog.text
-        assert "depth=1" in caplog.text
-        assert "follow_up=" in caplog.text
-        assert "pending_plan=" in caplog.text
+        logs = output.getvalue()
+        assert "[chain]" in logs
+        assert "depth=1" in logs
+        assert "follow_up=" in logs
+        assert "pending_plan=" in logs
 
     # ── 边界测试补充（R14-2 / R14-3） ─────────────
 

--- a/tests/unit/persona/test_event_agent.py
+++ b/tests/unit/persona/test_event_agent.py
@@ -453,9 +453,10 @@ class TestGenerateEventReaction:
         assert result.share_desire == 0.5
 
     @pytest.mark.asyncio
-    async def test_share_message_prompt_injection(self, caplog):
+    async def test_share_message_prompt_injection(self):
         """验证分享消息 prompt 注入状态/事件/意向（3.3.2 / 3.3.3）"""
-        import logging
+        from io import StringIO
+        from loguru import logger
         from plugins.DicePP.module.persona.life.event_agent import ShareMessageContext
 
         # 创建真实 EventGenerationAgent，mock llm_router
@@ -482,17 +483,22 @@ class TestGenerateEventReaction:
             current_intention="想喝茶",
         )
 
-        with caplog.at_level(logging.DEBUG, logger="persona.event_agent"):
+        output = StringIO()
+        handler_id = logger.add(output, level="DEBUG", format="{message}")
+        try:
             message = await agent.generate_share_message(context)
+        finally:
+            logger.remove(handler_id)
 
         assert message == "茶很好喝哦"
 
         # 验证分享消息 prompt 注入
-        assert "[prompt:system_share]" in caplog.text
-        assert "[prompt:user_share]" in caplog.text
-        assert "体力: 60/100" in caplog.text
-        assert "当前惦记的事: 想喝茶" in caplog.text
-        assert "泡了茶" in caplog.text
+        logs = output.getvalue()
+        assert "[prompt:system_share]" in logs
+        assert "[prompt:user_share]" in logs
+        assert "体力: 60/100" in logs
+        assert "当前惦记的事: 想喝茶" in logs
+        assert "泡了茶" in logs
 
 
 if __name__ == "__main__":

--- a/tests/unit/persona/test_tool_registry.py
+++ b/tests/unit/persona/test_tool_registry.py
@@ -22,23 +22,27 @@ def _make_registry_with_echo_tool():
 
 
 @pytest.mark.asyncio
-async def test_invalid_json_returns_fallback_result(caplog):
+async def test_invalid_json_returns_fallback_result():
     """非法 JSON 不应让整轮 tool execution 崩溃"""
+    from io import StringIO
+    from loguru import logger
     registry = _make_registry_with_echo_tool()
     ctx = ToolContext(user_id="u1", group_id="g1")
     executor = registry.make_executor_for("chat", ctx=ctx)
 
     tool_calls = [{"id": "call_1", "name": "echo", "arguments": "{not valid json"}]
 
-    with caplog.at_level(logging.WARNING, logger="persona.tools"):
+    output = StringIO()
+    handler_id = logger.add(output, level="WARNING", format="{message}")
+    try:
         results = await executor(tool_calls)
+    finally:
+        logger.remove(handler_id)
 
     assert len(results) == 1
     assert results[0]["tool_call_id"] == "call_1"
     assert "参数解析失败" in results[0]["content"]
-    assert any(
-        "echo 参数解析失败" in record.message for record in caplog.records
-    )
+    assert "echo 参数解析失败" in output.getvalue()
 
 
 @pytest.mark.asyncio
@@ -57,8 +61,10 @@ async def test_valid_json_executes_normally():
 
 
 @pytest.mark.asyncio
-async def test_invalid_json_does_not_block_subsequent_calls(caplog):
+async def test_invalid_json_does_not_block_subsequent_calls():
     """前一个 call 解析失败不应影响后续 call 执行"""
+    from io import StringIO
+    from loguru import logger
     registry = _make_registry_with_echo_tool()
     ctx = ToolContext(user_id="u1", group_id="g1")
     executor = registry.make_executor_for("chat", ctx=ctx)
@@ -68,8 +74,12 @@ async def test_invalid_json_does_not_block_subsequent_calls(caplog):
         {"id": "good", "name": "echo", "arguments": '{"x": 1}'},
     ]
 
-    with caplog.at_level(logging.WARNING, logger="persona.tools"):
+    output = StringIO()
+    handler_id = logger.add(output, level="WARNING", format="{message}")
+    try:
         results = await executor(tool_calls)
+    finally:
+        logger.remove(handler_id)
 
     assert len(results) == 2
     assert results[0]["tool_call_id"] == "bad"


### PR DESCRIPTION
## 变更内容

将 persona 模块的日志系统从标准库 `logging` 统一迁移到 NoneBot 的 `loguru` logger, 消除两套日志系统混用的问题.

### 主要改动

- **27 个 persona 模块文件**: 移除 `import logging` + `logging.getLogger("persona.xxx")`, 改为 `from nonebot.log import logger`
- **日志格式化**: 所有 `%s`/`%d` 格式符改为 loguru 的 `{}` 格式
- **bot.py**: 移除 `LoguruHandler` 桥接代码, 通过 `PERSONA_LOG_LEVEL` 环境变量直接控制 loguru 日志级别
- **测试文件**: 3 个测试中的 `caplog` (标准库 logging fixture) 改为 loguru 的 `logger.add(StringIO())` 捕获方式

## 测试

`uv run pytest tests/` - 1560 passed, 1 skipped