### PR TITLE
fix: 去掉 shell 模式下冗余的 NoneBot logger + 更新 dicepp-shell 文档

### DIFF
--- a/docs/agent/skills/dicepp-shell/QUICKREF.md
+++ b/docs/agent/skills/dicepp-shell/QUICKREF.md
@@ -2,12 +2,12 @@
 
 ## 启动
 ```bash
-python -m DicePP.shell start <session> [--group <id>]
+.venv/bin/dicepp-shell start <session> [--group <id>]
 ```
 
 ## 发送消息
 ```bash
-python -m DicePP.shell send <session> --user <id> --msg "<cmd>" [options]
+.venv/bin/dicepp-shell send <session> --user <id> --msg "<cmd>" [options]
 ```
 
 ### 常用选项
@@ -18,8 +18,8 @@ python -m DicePP.shell send <session> --user <id> --msg "<cmd>" [options]
 
 ## 管理
 ```bash
-python -m DicePP.shell list          # 列出现有会话
-python -m DicePP.shell rm <session>  # 删除会话
+.venv/bin/dicepp-shell list          # 列出现有会话
+.venv/bin/dicepp-shell rm <session>  # 删除会话
 ```
 
 ## 典型命令

--- a/docs/agent/skills/dicepp-shell/SKILL.md
+++ b/docs/agent/skills/dicepp-shell/SKILL.md
@@ -18,29 +18,29 @@ metadata:
 
 ```bash
 # 创建会话
-python -m DicePP.shell start test
+.venv/bin/dicepp-shell start test
 
 # 发送命令（带确定性骰子结果）
-python -m DicePP.shell send test --user player1 --msg ".r 1d20 攻击" --dice 20
+.venv/bin/dicepp-shell send test --user player1 --msg ".r 1d20 攻击" --dice 20
 
 # 清理
-python -m DicePP.shell rm test
+.venv/bin/dicepp-shell rm test
 ```
 
 ### 多步骤场景测试
 
 ```bash
 # 1. 创建专门用于此场景的会话
-python -m DicePP.shell start <scenario_name> --group <group_id>
+.venv/bin/dicepp-shell start <scenario_name> --group <group_id>
 
 # 2. 按顺序执行测试步骤
-python -m DicePP.shell send <scenario_name> --user <user> --msg "<cmd>" [--dice <seq>]
+.venv/bin/dicepp-shell send <scenario_name> --user <user> --msg "<cmd>" [--dice <seq>]
 
 # 3. 查看结果，必要时使用 --json 获取结构化输出
-python -m DicePP.shell send <scenario_name> --user <user> --msg "<cmd>" --json
+.venv/bin/dicepp-shell send <scenario_name> --user <user> --msg "<cmd>" --json
 
 # 4. 完成后清理
-python -m DicePP.shell rm <scenario_name>
+.venv/bin/dicepp-shell rm <scenario_name>
 ```
 
 ### 常用命令速查
@@ -70,26 +70,26 @@ python -m DicePP.shell rm <scenario_name>
 ### 测试战斗流程
 
 ```bash
-python -m DicePP.shell start combat
-python -m DicePP.shell send combat --user DM --msg ".init"
-python -m DicePP.shell send combat --user 战士 --msg ".ri" --dice 18
-python -m DicePP.shell send combat --user 法师 --msg ".ri" --dice 12
-python -m DicePP.shell send combat --user DM --msg ".init next"
-python -m DicePP.shell rm combat
+.venv/bin/dicepp-shell start combat
+.venv/bin/dicepp-shell send combat --user DM --msg ".init"
+.venv/bin/dicepp-shell send combat --user 战士 --msg ".ri" --dice 18
+.venv/bin/dicepp-shell send combat --user 法师 --msg ".ri" --dice 12
+.venv/bin/dicepp-shell send combat --user DM --msg ".init next"
+.venv/bin/dicepp-shell rm combat
 ```
 
 ### 测试角色卡功能
 
 ```bash
-python -m DicePP.shell start char
-python -m DicePP.shell send char --user player1 --msg ".角色卡记录
+.venv/bin/dicepp-shell start char
+.venv/bin/dicepp-shell send char --user player1 --msg ".角色卡记录
 $姓名$ 测试角色
 $等级$ 5
 $生命值$ 50/50
 $生命骰$ 5/5 D10
 $属性$ 16/14/13/10/12/8"
-python -m DicePP.shell send char --user player1 --msg ".状态"
-python -m DicePP.shell rm char
+.venv/bin/dicepp-shell send char --user player1 --msg ".状态"
+.venv/bin/dicepp-shell rm char
 ```
 
 ## 最佳实践
@@ -102,5 +102,5 @@ python -m DicePP.shell rm char
 ## 故障排除
 
 - **会话已存在**: `start` 命令会加载已存在的会话
-- **找不到会话**: 先运行 `python -m DicePP.shell start <name>`
+- **找不到会话**: 先运行 `.venv/bin/dicepp-shell start <name>`
 - **输出乱码**: Windows 终端设置 `chcp 65001`

--- a/src/plugins/DicePP/adapter/nonebot_adapter.py
+++ b/src/plugins/DicePP/adapter/nonebot_adapter.py
@@ -32,7 +32,7 @@ try:
     app: FastAPI = nonebot.get_app()
     app.mount("/dpp", dpp_api)
 except ValueError:
-    dice_log("DPP API is not amounted because NoneBot has not been initialized")
+    pass
 
 command_matcher = on_message(block=False)
 notice_matcher = on_notice()
@@ -347,7 +347,6 @@ try:
     driver = nonebot.get_driver()
 except ValueError:
     driver = None  # type: ignore
-    dice_log("[NB Adapter] NoneBot has not been initialized (driver unavailable)")
 else:
     # 在Bot连接时调用
     @driver.on_bot_connect


### PR DESCRIPTION
## 变更内容

### 1. 去掉 shell 模式下冗余的 logger 输出

`src/plugins/DicePP/adapter/nonebot_adapter.py` 中模块导入时有两行 `dice_log`：
- `DPP API is not amounted because NoneBot has not been initialized`
- `[NB Adapter] NoneBot has not been initialized (driver unavailable)`

这两行在 shell 测试模式下每次命令都会重复输出，干扰测试结果的阅读。正常 Bot 运行时 NoneBot 是可用的，本来就不会触发这两行日志，因此直接删除是安全的。

### 2. 更新 dicepp-shell 技能文档

`docs/agent/skills/dicepp-shell/SKILL.md` 和 `QUICKREF.md` 中所有命令示例从 `python -m DicePP.shell` 更新为 `.venv/bin/dicepp-shell`，与实际使用方式一致（由 pyproject.toml 的 `console_scripts` entry point 自动生成，无需手动设置 PYTHONPATH）。

## 验证

本地测试确认 start / send / rm 命令不再输出那两行 logger：
```
.venv/bin/dicepp-shell start test
.venv/bin/dicepp-shell send test --user p1 --msg ".r 1d20+3" --dice 12
.venv/bin/dicepp-shell rm test
```