### PR TITLE
feat: persona 分段回复 v4 + review 反馈修复

### DIFF
--- a/config/global.json
+++ b/config/global.json
@@ -107,6 +107,15 @@
     "max_diary_context_chars": 500,
     "lore_token_budget": 300,
 
+    "segment_enabled": true,
+    "segment_target_chars": 30,
+    "segment_max_chars": 80,
+    "segment_soft_limit": 100,
+    "segment_hard_limit": 120,
+    "segment_count_max": 10,
+    "segment_max_delay": 10.0,
+    "segment_round_callbacks_max": 3,
+
     "game_enabled": true,
     "scoring_interval": 5,
 

--- a/docs/agent/rules/CLAUDE.md
+++ b/docs/agent/rules/CLAUDE.md
@@ -73,19 +73,6 @@ uv run python bot.py
 - **交互式验收**：新功能完成前，**必须**使用 `dicepp-shell` 技能进行交互式机器人测试，确认指令行为正确
 - **提交前**：必须跑通 `uv run pytest`，不自动 push
 
-### 常用 dicepp-shell 测试流程
-
-```bash
-# 创建测试会话
-python -m DicePP.shell start <scenario_name>
-
-# 发送命令（可带确定性骰子结果）
-python -m DicePP.shell send <scenario_name> --user <user> --msg "<cmd>" [--dice <seq>]
-
-# 完成后清理
-python -m DicePP.shell rm <scenario_name>
-```
-
 ## 代码风格
 
 - **最小化变更**：只改必要的内容

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -66,6 +66,21 @@
   - fallback 事件携带默认 delta（如 energy=-1, mood=0）兜底，避免状态断层
   - 影响面: `life/character_life.py` 事件生成路径、PersonaConfig 超时项、fallback 构造代码
 
+### [B-260507-d4b350] 消息发送路径统一（合并 send_segmented 与 send_now）
+- 创建: 2026-05-07
+- 问题表现:
+  - 症状: MessagePort 同时存在 send_segmented 与新增的 send_now，行为重复
+  - 现场: 三处 send_segmented 调用方（ChatSession._coordinator_on_result、PersonaApp.send_message、LifeSimulator._send_msg）均为 [make_segment(content, group_id)] 单段形态，与 send_now 行为几乎一致
+  - 影响: 分段路径走 dispatcher → send_now，非分段路径走 send_segmented，形成两套并存的发送路径；语义割裂，可观测性不一致，新调用方需在两个 API 间二选一
+- 工作计划:
+  - 方向: 统一走 SegmentDispatcher 模型，让分段与非分段共享同一调度/失败回调/可观测路径
+  - 步骤:
+    1. 评估 send_segmented 三处调用方能否迁移到 dispatcher（含 life 主动消息的 delay 与失败回调语义）
+    2. 设计统一发送接口（扩展 dispatcher 支持非分段单条消息或并入 send_now）
+    3. 删除 send_segmented，迁移所有调用方，更新测试
+  - 影响面: persona 模块所有出口消息（chat 非分段、PersonaApp.send_message、life 主动消息）；测试 test_message_port、test_life_simulator
+  - 风险: life 主动消息原本是 fire-and-forget 后台 task，迁移 dispatcher 同步等待语义需保留或显式重设计
+
 ### [B-260507-f9ea98] 厂商适配层根据模型类型选择 prompt 注入角色（system/user/developer）
 - 创建: 2026-05-07
 - 问题表现:
@@ -77,4 +92,41 @@
   - 在 ContextBuilder 或厂商适配层加模型类型分支：支持 system/developer 角色的厂商使用对应角色，MiniMax 等保留 user 注入路径
   - 需先观察现有 LLM 是否真的频繁误识 `[内部指令]`，决定是否提前优先级
   - 影响面: ContextBuilder、厂商 adapter、segment dispatcher
+
+### [B-260508-1f1b9e] 消息发送路径统一（合并 send_segmented / send_now / dispatcher）
+- 创建: 2026-05-08
+- 问题表现:
+    - `send_segmented` 三处调用方（`ChatSession._coordinator_on_result`、`PersonaApp.send_message`、`LifeSimulator._send_msg`）当前都是 `[make_segment(content, group_id)]` 单段形态，行为与 `send_now` 重叠
+    - 分段路径走 `dispatcher → send_now`，非分段路径走 `send_segmented`，形成两套并存的发送路径，调度/失败回调/可观测点分裂
+    - 同一"发送"语义有两套实现，未来扩展失败重试、限流、监控时需要双写
+- 工作计划:
+    - 修复方向：评估三处调用方是否都能迁移到 dispatcher（含 life 主动消息的 delay 与失败回调语义）；设计统一发送接口（扩展 dispatcher 支持非分段单条 / 合并到 send_now / 让 send_segmented 内部走 dispatcher）；删除 `send_segmented`，迁移所有调用方，更新测试
+    - 影响面：persona 模块所有出口消息（chat 非分段、`PersonaApp.send_message`、life 主动消息）
+    - 风险点：需保证 life 主动消息行为不退化（delay/失败回调语义一致性）；何时拉起：分段回复主线合入并稳定运行后单独立项推进
+
+### [B-260508-7f130e] proactive_miss_min_score 默认值卡边界(40.0→38.0)
+- 创建: 2026-05-08
+- 问题表现:
+    - 用户好感度 39.9 vs `proactive_miss_min_score` 默认 40.0,卡阈值下永不触发想念消息(pydantic_models.py:127、config/global.json:131 仍为 40.0)
+    - a78174 PR 完成 share_desire 阈值与 greeting_schedule 死配置删除后,miss_min_score 仍未动,边界好感度用户(39-40 区间)体验损失持续累积
+    - 风险与 share_threshold 调整同档(数据驱动数值微调,无 schema 变更),无工程理由继续延后
+- 工作计划:
+    - 调整方向:`proactive_miss_min_score` 默认 40.0 → 38.0,与 share_threshold 同方法线上数据校准
+    - 影响面:pydantic_models.py:127、config/global.json:131、docs/dicepp/persona/config-example.md 默认值表
+    - 风险点:与 `proactive_miss_enabled` / `proactive_miss_min_hours` 联动需复核;何时拉起取决于 1-2 周线上 39-40 区间用户分布与触发率数据
+
+### [B-260508-eb32c9] 好感度阶段-想念-衰减联动重构
+- 创建: 2026-05-08
+- 问题表现:
+    - 当前好感度数值含义模糊：初始值30、想念阈值40、衰减下限50（=初始+20）三者之间无关联，各说各的
+    - 情感节奏不合理：高好感度用户长时间不互动，系统直接扣好感度；应先主动表达想念，被忽视后再伤心减分
+    - 想念消息触发概率使用连续公式 `0.40 + 0.40 * (score/100)`，不够直观，且亲密关系（80+）也无法100%触发
+- 工作计划:
+    - 重构好感度阶段定义，统一数值与行为含义：冷淡(0-20)/疏远(20-40)/友好(40-60)/默契(60-80)/亲密(80-100)
+    - 新增 `last_miss_sent_at` 字段到 `RelationshipState`，实现"开关型"衰减：想念消息发出前不衰减，发出后用户未回应才开始正常衰减
+    - 将想念概率改为阶段固定值：疏远50%/友好70%/默契90%/亲密100%
+    - 调整 `miss_min_score` 配置从40改为20
+    - 更新衰减计算逻辑，衰减下限改为当前阶段下限（取代 `initial_score + floor_offset`）
+    - 亲密用户（80+）长时间不互动最多掉到80，可永久保持亲密阶段
+    - 补充/更新相关测试
 

--- a/src/plugins/DicePP/core/bot/dicebot.py
+++ b/src/plugins/DicePP/core/bot/dicebot.py
@@ -370,6 +370,19 @@ class Bot:
         shutdown的异步版本
         销毁bot对象时触发, 可能是bot断连, 或关闭应用导致的
         """
+        shutdown_results = await asyncio.gather(
+            *[command.shutdown() for command in self.command_dict.values()],
+            return_exceptions=True,
+        )
+        for command, result in zip(self.command_dict.values(), shutdown_results):
+            if isinstance(result, Exception):
+                import traceback
+                tb_str = traceback.format_exception(type(result), result, result.__traceback__)
+                dice_log(
+                    f"[Bot] 命令 {command.__class__.readable_name} shutdown 失败: {result}\n"
+                    f"{''.join(tb_str)}"
+                )
+
         await self.db.close()
 
         if self.tick_task:

--- a/src/plugins/DicePP/core/command/user_cmd.py
+++ b/src/plugins/DicePP/core/command/user_cmd.py
@@ -40,6 +40,15 @@ class UserCommandBase(metaclass=abc.ABCMeta):
         """每天调用一次"""
         return []
 
+    async def shutdown(self) -> None:
+        """Bot 关闭时调用，用于清理资源。
+
+        契约：
+        - 在 db.close 之前调用，可写入存储；
+        - 不应抛异常（抛出的异常会被捕获并记录，但不影响其他命令的关闭）。
+        """
+        pass
+
     @abc.abstractmethod
     def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
         """

--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -7,7 +7,7 @@ Config is loaded hierarchically by ConfigLoader:
 """
 from typing import List
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 
 class PersonaConfig(BaseModel):
@@ -65,6 +65,40 @@ class PersonaConfig(BaseModel):
 
     # ── Phase 5a: 世界书 Token 预算（当前为字符估算值，非精确 token）
     lore_token_budget: int = 300  # 每次对话注入世界书的最大估算 token 数
+
+    # ── 分段回复（Segmented Reply）
+    # LLM 通过 send_reply_segment 工具按段输出，由 SegmentDispatcher 按 delay_before 调度发送
+    segment_enabled: bool = True
+    segment_target_chars: int = Field(
+        default=30, ge=1, description="单段建议字数（写入 system prompt 引导 LLM）"
+    )
+    segment_max_chars: int = Field(
+        default=80, ge=1, description="单段字符上限，超出由 send_reply_segment executor 拒绝"
+    )
+    segment_soft_limit: int = Field(
+        default=100, ge=1, description="单次回复总字数软上限，超出返回 warning"
+    )
+    segment_hard_limit: int = Field(
+        default=120, ge=1, description="单次回复总字数硬上限，超出返回 error 并拒绝该段"
+    )
+    segment_count_max: int = Field(
+        default=10, ge=1, description="单次回复最大段数，超出由 executor 拒绝"
+    )
+    segment_max_delay: float = Field(
+        default=10.0, gt=0, description="单段 delay_before 上限（秒）"
+    )
+    segment_round_callbacks_max: int = Field(
+        default=3, ge=0, description="LLM 不调用 send_reply_segment 时最大纠正注入次数"
+    )
+
+    @model_validator(mode="after")
+    def _validate_segment_limits(self) -> "PersonaConfig":
+        if self.segment_soft_limit > self.segment_hard_limit:
+            raise ValueError(
+                f"segment_soft_limit ({self.segment_soft_limit}) "
+                f"必须 <= segment_hard_limit ({self.segment_hard_limit})"
+            )
+        return self
 
     # ── Phase 4+: 群活跃度（影响主动消息频率，暂未启用）
     # group_activity_decay_days: List[int] = [1, 3, 7]

--- a/src/plugins/DicePP/module/persona/chat/context.py
+++ b/src/plugins/DicePP/module/persona/chat/context.py
@@ -3,6 +3,7 @@
 
 组装四层记忆到 LLM 消息列表
 """
+from dataclasses import dataclass
 from nonebot.log import logger
 from typing import List, Dict, Optional, Any, Tuple
 
@@ -11,6 +12,19 @@ from utils.string import estimate_tokens
 from ..character.models import Character
 from ..data.models import UserProfile
 from ..wall_clock import persona_wall_now
+
+DEFAULT_DELAY_BEFORE = 1.0
+
+
+@dataclass
+class SegmentGuide:
+    """分段回复引导参数，None 表示不注入分段引导。"""
+
+    enabled: bool
+    target_chars: int
+    max_chars: int
+    soft_limit: int
+    hard_limit: int
 
 
 class ContextBuilder:
@@ -22,11 +36,13 @@ class ContextBuilder:
         max_short_term_chars: int = 1500,
         timezone: str = "Asia/Shanghai",
         lore_token_budget: int = 300,
+        segment_guide: Optional[SegmentGuide] = None,
     ):
         self.character = character
         self.max_short_term_chars = max_short_term_chars
         self.timezone = timezone
         self.lore_token_budget = lore_token_budget
+        self.segment_guide = segment_guide
 
     def update_character(self, character: Character) -> None:
         """同步新的角色卡引用"""
@@ -166,6 +182,18 @@ class ContextBuilder:
 
         parts.append(f"你的名字是: {self.character.name}")
         parts.append(f"当前你和用户的关系: {warmth_label}")
+
+        # ── 分段回复引导（仅 chat 路径注入）
+        if self.segment_guide and self.segment_guide.enabled:
+            sg = self.segment_guide
+            guide = (
+                f"【回复规则】\n"
+                f"你必须使用 send_reply_segment 工具发送回复，不要直接在 content 中输出。\n"
+                f"- 每段建议 {sg.target_chars} 字，单段上限 {sg.max_chars} 字\n"
+                f"- 单次回复总字数软上限 {sg.soft_limit} 字，硬上限 {sg.hard_limit} 字\n"
+                f"- 短句 delay_before 用 {DEFAULT_DELAY_BEFORE} 秒，长句用 2–3 秒"
+            )
+            parts.append(guide)
 
         if user_profile and user_profile.facts:
             facts_text = "\n".join([f"- {k}: {v}" for k, v in user_profile.facts.items()])

--- a/src/plugins/DicePP/module/persona/chat/segment_dispatcher.py
+++ b/src/plugins/DicePP/module/persona/chat/segment_dispatcher.py
@@ -1,0 +1,171 @@
+"""SegmentDispatcher: 内存分段调度器，按 target_key 维护独立 asyncio worker。
+
+每个 target_key（群聊 group:{id} / 私聊 user:{id}）拥有独立的 Queue + Event + worker task，
+worker 按 FIFO 顺序同步发送 segment，支持 delay_before  pacing、flush、shutdown。
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from nonebot.log import logger
+
+_DEFAULT_IDLE_SECONDS = 300
+_DEFAULT_MAX_PER_RUN = 20
+
+
+@dataclass
+class SegmentItem:
+    content: str
+    delay_before: float
+    user_id: str
+    group_id: str = ""
+
+
+class SegmentDispatcher:
+    def __init__(
+        self,
+        message_port,
+        idle_seconds: int = _DEFAULT_IDLE_SECONDS,
+        max_per_run: int = _DEFAULT_MAX_PER_RUN,
+    ):
+        self._port = message_port
+        self._idle_seconds = idle_seconds
+        self._max_per_run = max_per_run
+        self._queues: Dict[str, asyncio.Queue] = {}
+        self._wake_events: Dict[str, asyncio.Event] = {}
+        self._workers: Dict[str, asyncio.Task] = {}
+        self._shutting_down = False
+
+    @staticmethod
+    def target_key(user_id: str, group_id: str) -> str:
+        if group_id:
+            return f"group:{group_id}"
+        return f"user:{user_id}"
+
+    def notify(self, target_key: str, segment: Optional[SegmentItem] = None) -> None:
+        if self._shutting_down:
+            return
+
+        if segment is not None:
+            queue = self._queues.get(target_key)
+            if queue is None:
+                queue = asyncio.Queue()
+                self._queues[target_key] = queue
+            queue.put_nowait(segment)
+            # R15: 懒创建 wake_event（与 queue 同样模式），保证 notify→set 永远找得到对象
+            wake_event = self._wake_events.get(target_key)
+            if wake_event is None:
+                wake_event = asyncio.Event()
+                self._wake_events[target_key] = wake_event
+
+        # Ensure a worker exists for this target_key
+        worker = self._workers.get(target_key)
+        if worker is None or worker.done():
+            task = asyncio.create_task(self._worker_loop(target_key))
+            self._workers[target_key] = task
+
+        # Wake a sleeping worker so it can re-evaluate the queue
+        wake_event = self._wake_events.get(target_key)
+        if wake_event is not None:
+            wake_event.set()
+
+    async def flush(self, target_key: str) -> None:
+        queue = self._queues.get(target_key)
+        if queue is None:
+            return
+        # Drain all pending segments
+        while not queue.empty():
+            try:
+                queue.get_nowait()
+                queue.task_done()
+            except asyncio.QueueEmpty:
+                break
+        # Wake sleeping worker so it exits via idle timeout after sending
+        # any segment already dequeued (in-flight segments cannot be recalled).
+        wake_event = self._wake_events.get(target_key)
+        if wake_event is not None:
+            wake_event.set()
+
+    async def shutdown(self) -> None:
+        self._shutting_down = True
+        for target_key, queue in list(self._queues.items()):
+            pending = queue.qsize()
+            if pending > 0:
+                logger.warning(
+                    "segments lost on shutdown: target=%s pending=%s",
+                    target_key,
+                    pending,
+                )
+            # Drain to prevent lingering references
+            while not queue.empty():
+                try:
+                    queue.get_nowait()
+                    queue.task_done()
+                except asyncio.QueueEmpty:
+                    break
+
+        pending_tasks = [
+            task for task in self._workers.values() if not task.done()
+        ]
+        for task in pending_tasks:
+            task.cancel()
+
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        self._queues.clear()
+        self._wake_events.clear()
+        self._workers.clear()
+
+    async def _worker_loop(self, target_key: str) -> None:
+        queue = self._queues.get(target_key)
+        if queue is None:
+            queue = asyncio.Queue()
+            self._queues[target_key] = queue
+
+        # R15: 复用 notify 中懒创建的 wake_event，避免竞态窗口
+        wake_event = self._wake_events.get(target_key)
+        if wake_event is None:
+            wake_event = asyncio.Event()
+            self._wake_events[target_key] = wake_event
+
+        processed = 0
+        try:
+            while processed < self._max_per_run:
+                try:
+                    segment = await asyncio.wait_for(
+                        queue.get(), timeout=self._idle_seconds
+                    )
+                except asyncio.TimeoutError:
+                    break
+
+                try:
+                    delay = max(0.0, segment.delay_before)
+                    if delay > 0:
+                        wake_event.clear()
+                        try:
+                            await asyncio.wait_for(wake_event.wait(), timeout=delay)
+                        except asyncio.TimeoutError:
+                            pass
+
+                    try:
+                        # R11: 显式传 skip_history_record=True，把决策留在分段域
+                        await self._port.send_now(
+                            segment.user_id,
+                            segment.group_id,
+                            segment.content,
+                            skip_history_record=True,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "segment send failed for target=%s", target_key
+                        )
+
+                    processed += 1
+                finally:
+                    queue.task_done()
+        finally:
+            self._workers.pop(target_key, None)
+            self._wake_events.pop(target_key, None)
+            self._queues.pop(target_key, None)

--- a/src/plugins/DicePP/module/persona/chat/segment_state.py
+++ b/src/plugins/DicePP/module/persona/chat/segment_state.py
@@ -1,0 +1,25 @@
+"""SegmentBudgetState: 单次聊天回复的分段预算状态"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(frozen=True)
+class SegmentLimits:
+    """只读分段限制配置"""
+
+    max_chars: int
+    soft_limit: int
+    hard_limit: int
+    count_max: int
+    max_delay: float
+
+
+@dataclass
+class SegmentBudgetState:
+    """可变分段预算状态（单次回复生命周期）"""
+
+    limits: SegmentLimits
+    total_chars: int = 0
+    segment_count: int = 0
+    buffer: List[str] = field(default_factory=list)

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -11,11 +11,12 @@ from typing import List, Dict, Optional, Any, Tuple, TYPE_CHECKING
 from dataclasses import dataclass
 import asyncio
 import json
-from nonebot.log import logger
 import time
 import random
 from collections import deque
 from datetime import datetime, timedelta
+
+from nonebot.log import logger
 
 from utils.string import estimate_tokens
 
@@ -28,6 +29,7 @@ from ..data.models import (
     GroupConversation,
 )
 from ..llm.router import LLMRouter, QuotaExceeded
+from ..llm.client import RoundResult
 from ..character.models import Character
 from ..chat.scoring import ScoringAgent
 from ..chat.context import ContextBuilder
@@ -39,6 +41,8 @@ from ..llm.coordinator import LLMCallCoordinator
 from ..gateway.port import MessagePort
 from ..gateway.pipeline import make_segment
 from .billing import BillingPolicy
+from .segment_dispatcher import SegmentDispatcher, SegmentItem
+from .segment_state import SegmentBudgetState, SegmentLimits
 
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
@@ -62,6 +66,14 @@ class ChatConfig:
     group_context_budget_tokens: float = 2000.0
     group_max_messages: int = 15
     group_single_message_max_tokens: float = 500.0
+    # ── 分段回复配置
+    segment_target_chars: int = 30
+    segment_max_chars: int = 80
+    segment_soft_limit: int = 100
+    segment_hard_limit: int = 120
+    segment_count_max: int = 10
+    segment_max_delay: float = 10.0
+    segment_round_callbacks_max: int = 3
 
     @classmethod
     def from_persona(cls, persona: "PersonaConfig") -> "ChatConfig":
@@ -80,6 +92,13 @@ class ChatConfig:
             group_context_budget_tokens=persona.group_context_budget_tokens,
             group_max_messages=persona.group_max_messages,
             group_single_message_max_tokens=persona.group_single_message_max_tokens,
+            segment_target_chars=persona.segment_target_chars,
+            segment_max_chars=persona.segment_max_chars,
+            segment_soft_limit=persona.segment_soft_limit,
+            segment_hard_limit=persona.segment_hard_limit,
+            segment_count_max=persona.segment_count_max,
+            segment_max_delay=persona.segment_max_delay,
+            segment_round_callbacks_max=persona.segment_round_callbacks_max,
         )
 
 
@@ -90,6 +109,11 @@ class ChatSession:
 
     DIGEST_MAX_MESSAGES = 6
     DIGEST_MAX_CHARS = 80
+
+    class _SegmentedSentinel(str):
+        """标记分段路径的哨兵值，继承 str 以保持与 coordinator 的兼容性。"""
+
+        pass
 
     def __init__(
         self,
@@ -103,6 +127,7 @@ class ChatSession:
         context_builder: ContextBuilder,
         decay_calculator: Optional[DecayCalculator] = None,
         port: Optional[MessagePort] = None,
+        segment_dispatcher: Optional[SegmentDispatcher] = None,
     ):
         self.store = store
         self.router = router
@@ -114,6 +139,7 @@ class ChatSession:
         self.context_builder = context_builder
         self.decay_calculator = decay_calculator
         self.port = port
+        self.segment_dispatcher = segment_dispatcher
         self._pending_messages: Dict[str, deque] = {}
         self._last_messages: Dict[str, Tuple[str, float]] = {}
         self._billing = BillingPolicy(router)
@@ -222,7 +248,7 @@ class ChatSession:
 
     async def _coordinator_chat_call_fn(
         self, user_id: str, group_id: str, messages: List[str]
-    ) -> str:
+    ) -> Optional[str]:
         """coordinator chat 路径的单轮 LLM 调用。"""
         current_message = "\n".join(messages) if messages else ""
 
@@ -240,6 +266,12 @@ class ChatSession:
                 group_id=group_id,
             )
 
+        if isinstance(response, self._SegmentedSentinel):
+            # 分段路径：历史已由 _chat_with_tools 写入，跳过重复持久化
+            await self._update_interaction(user_id, group_id, current_message, str(response))
+            return self._SegmentedSentinel("")
+
+        # 非分段路径：原逻辑
         await self._persist_assistant_message(user_id, group_id, response)
         if not group_id:
             await self.store.prune_old_messages(user_id, group_id, self.config.max_messages)
@@ -266,7 +298,54 @@ class ChatSession:
         return fallback_response
 
     async def _coordinator_on_result(self, user_id: str, group_id: str, result: str) -> None:
-        """中间轮结果：通过 MessagePort 发送、持久化并扣减额度。"""
+        """中间轮结果：通过 MessagePort 发送、持久化、扣减配额。
+
+        计费原则：按 coordinator 轮次算，每轮 1 次配额扣减。
+
+        - coordinator 外层循环每跑 1 轮 = 1 次扣费
+          （无论非分段/分段输出，也不论该轮内部因工具循环/分段/round callback
+           调了多少次 LLM API；内层 LLM API 调用次数与配额扣减无关）
+        - max_iterations 是外层循环上限（防刷屏），正常使用不会触及
+        - 分段路径下，本函数提前返回（消息已通过 send_reply_segment + dispatcher
+          实时发送，无需在此重发也无需写历史），但 charge 应在早返之前完成
+
+        场景对照（假设单次 LLM 调用从开始到完成耗时 5 秒）：
+
+        A. 单条消息 + 非分段输出
+           t=0 发 msg_1；之后无新消息
+           → coordinator 跑 1 轮 → 1 次扣费（仅最终轮 success）
+
+        B. 单条消息 + 分段输出
+           t=0 发 msg_1；之后无新消息
+           → coordinator 跑 1 轮 → 1 次扣费（仅最终轮 success）
+
+        C. 在第 1 轮期间发 1 条新消息 + 非分段输出
+           t=0 发 msg_1（开始 iter 1）；t=2 发 msg_2（iter 1 期间，进 buffer）；
+           t=5 iter 1 完成、发送 msg_1 的回复、开始 iter 2 处理 msg_2；
+           t=10 iter 2 完成、发送 msg_2 的回复，无新消息 → 退出
+           → coordinator 跑 2 轮 → 2 次扣费（iter 1 触发本函数 1 次 + 最终 success 1 次）
+
+        D. 在第 1 轮期间发 1 条新消息 + 分段输出
+           同 C 时间轴
+           → coordinator 跑 2 轮 → 2 次扣费
+
+        E. 连续在每轮期间发新消息 + 非分段输出
+           t=0 发 msg_1（开始 iter 1）；t=2 发 msg_2（iter 1 期间，进 buffer）；
+           t=5 iter 1 完成、发送 msg_1 的回复、开始 iter 2 处理 msg_2；
+           t=7 发 msg_3（iter 2 期间，进 buffer）；
+           t=10 iter 2 完成、发送 msg_2 的回复、开始 iter 3 处理 msg_3；
+           t=15 iter 3 完成、发送 msg_3 的回复，无新消息 → 退出
+           → coordinator 跑 3 轮 → 3 次扣费
+
+        F. 连续在每轮期间发新消息 + 分段输出
+           同 E 时间轴
+           → coordinator 跑 3 轮 → 3 次扣费
+        """
+        await self._billing.charge(user_id)
+
+        if isinstance(result, self._SegmentedSentinel):
+            return
+
         if self.port:
             await self.port.send_segmented(
                 user_id,
@@ -279,7 +358,6 @@ class ChatSession:
                 f"消息无法发送 (user={user_id}, group={group_id})"
             )
         await self._persist_assistant_message(user_id, group_id, result)
-        await self._billing.charge(user_id)
 
     async def _chat_via_coordinator(
         self, user_id: str, group_id: str, message: str, target_key: str
@@ -287,7 +365,7 @@ class ChatSession:
         fallback_response: Optional[str] = None
         current_message_for_exhausted = message
 
-        async def chat_call_fn(messages: List[str]) -> str:
+        async def chat_call_fn(messages: List[str]) -> Optional[str]:
             nonlocal current_message_for_exhausted
             current_message = "\n".join(messages) if messages else message
             current_message_for_exhausted = current_message
@@ -313,6 +391,8 @@ class ChatSession:
         if result.status == "success":
             # 最终轮计费：on_result 只覆盖中间轮，最终轮通过 success 路径扣费。
             await self._billing.charge(user_id)
+            # _SegmentedSentinel 是 str 子类，直接透传——
+            # 调用方用 `is None` 区分"未进入 chat"，用 `bool()` 区分"是否需要再发"
             return result.value
         return fallback_response if fallback_response is not None else None
 
@@ -324,9 +404,35 @@ class ChatSession:
         group_id: str,
         messages: List[Dict],
     ) -> str:
-        """支持工具调用的对话（通过 ToolRegistry）"""
+        """支持工具调用的对话"""
+        target_key = SegmentDispatcher.target_key(user_id, group_id)
+
+        # 5.3: 新聊天轮次开始前清空前一轮残段
+        if self.segment_dispatcher:
+            await self.segment_dispatcher.flush(target_key)
+
         tools = self.tool_registry.get_definitions_for(ToolDomain.CHAT)
-        ctx = ToolContext(user_id=user_id, group_id=group_id, store=self.store, send=self.port)
+
+        # 5.4.1: 构造 SegmentBudgetState 并注入 ToolContext
+        segment_state = None
+        if self.segment_dispatcher:
+            segment_limits = SegmentLimits(
+                max_chars=self.config.segment_max_chars,
+                soft_limit=self.config.segment_soft_limit,
+                hard_limit=self.config.segment_hard_limit,
+                count_max=self.config.segment_count_max,
+                max_delay=self.config.segment_max_delay,
+            )
+            segment_state = SegmentBudgetState(limits=segment_limits)
+
+        ctx = ToolContext(
+            user_id=user_id,
+            group_id=group_id,
+            store=self.store,
+            send=self.port,
+            segment_dispatcher=self.segment_dispatcher,
+            segment_state=segment_state,
+        )
         tool_executor = self.tool_registry.make_executor_for(ToolDomain.CHAT, ctx=ctx)
 
         content, metadata = await self.router.generate_with_tools(
@@ -337,6 +443,12 @@ class ChatSession:
             max_tool_rounds=self.config.tools_max_rounds,
             user_id=user_id,
             group_id=group_id,
+            on_round_complete=(
+                self._on_segment_round_complete if segment_state else None
+            ),
+            max_round_callbacks=(
+                self.config.segment_round_callbacks_max if segment_state else 0
+            ),
         )
 
         if metadata.get("tool_rounds", 0) > 0:
@@ -347,7 +459,106 @@ class ChatSession:
                 f"cached={metadata.get('cached_tokens', 0)}"
             )
 
+        if self.segment_dispatcher:
+            return await self._run_chat_with_tools_segmented(
+                user_id, group_id, target_key, content, metadata, segment_state
+            )
+
         return content
+
+    async def _run_chat_with_tools_segmented(
+        self,
+        user_id: str,
+        group_id: str,
+        target_key: str,
+        content: str,
+        metadata: Dict[str, Any],
+        segment_state: SegmentBudgetState,
+    ) -> str:
+        """分段路径：拼接回复、兜底处理、历史写入"""
+        full_reply = "".join(segment_state.buffer)
+
+        # 5.4.4 / 5.4.5: 兜底 — callback 用尽且 LLM 仍未分段
+        if metadata.get("callback_count", 0) >= self.config.segment_round_callbacks_max:
+            if content:
+                fallback_content = content[:self.config.segment_hard_limit]
+                logger.warning(
+                    f"LLM 忽略分段工具，使用兜底: user={user_id}, "
+                    f"fallback_len={len(fallback_content)}"
+                )
+                # fallback 语义为"完整替代"：清空此前尝试，丢弃 queue 中待发送 segment，
+                # 用最终 content 替代。已发送的 segment 无法召回。
+                # 历史仅记录 fallback_content，已发送的 segment 不计入历史，属已知设计妥协。
+                if segment_state.buffer:
+                    segment_state.buffer.clear()
+                    segment_state.total_chars = 0
+                    segment_state.segment_count = 0
+                if self.segment_dispatcher:
+                    await self.segment_dispatcher.flush(target_key)
+                segment_state.buffer.append(fallback_content)
+                segment_state.total_chars += len(fallback_content)
+                segment_state.segment_count += 1
+                self.segment_dispatcher.notify(
+                    target_key,
+                    SegmentItem(
+                        content=fallback_content,
+                        delay_before=0.0,
+                        user_id=user_id,
+                        group_id=group_id,
+                    ),
+                )
+                full_reply = "".join(segment_state.buffer)
+            else:
+                logger.error(f"LLM 耗尽 callback 且返回空 content: user={user_id}")
+
+        # 5.4.6: 写入历史（不依赖发送结果）
+        if not group_id:
+            await self.store.add_message(user_id, group_id, "assistant", full_reply)
+            await self.store.prune_old_messages(user_id, group_id, self.config.max_messages)
+        else:
+            await self.store.add_group_conversation(
+                group_id=group_id,
+                user_id="assistant",
+                role="assistant",
+                content=full_reply,
+                display_name="我",
+            )
+
+        return self._SegmentedSentinel(full_reply)
+
+    async def _on_segment_round_complete(
+        self,
+        completed_tool_rounds: int,
+        result: "RoundResult",
+        current_messages: List[Dict],
+    ) -> Optional[Dict]:
+        """5.5: LLM 不调用 send_reply_segment 时的纠正注入"""
+        has_send_reply_segment = any(
+            tc.get("name") == "send_reply_segment" for tc in (result.tool_calls or [])
+        )
+
+        # 5.5.1: 含 send_reply_segment → 正常流程
+        if has_send_reply_segment:
+            # 5.5.3: content + tool_call 同时存在 → warning log，丢弃 content
+            if result.content:
+                logger.warning(
+                    "LLM returned content alongside send_reply_segment; content ignored"
+                )
+            return None
+
+        # 5.5.2: 无工具调用且 content 非空 → 注入纠正
+        # 使用 user 角色而非 system，兼容 MiniMax 等不支持 mid-conversation system 角色的厂商
+        if result.content:
+            logger.warning(
+                f"send_reply_segment 未被调用，注入纠正指令: "
+                f"round={completed_tool_rounds}, content_preview={result.content[:30]!r}"
+            )
+            return {
+                "role": "user",
+                "content": "[内部指令: 请使用 send_reply_segment 工具发送回复，不要直接输出文本]",
+            }
+
+        return None
 
     # ── 关系与评分 ────────────────────────────────────────────
 

--- a/src/plugins/DicePP/module/persona/command.py
+++ b/src/plugins/DicePP/module/persona/command.py
@@ -368,8 +368,11 @@ class PersonaCommand(UserCommandBase):
         else:
             response = self._get_introduction()
 
-        # 发送回复（去重命中时 response 为 None，静默不发送）
-        if not response:
+        # 发送回复
+        # - response is None：去重命中或未进入 chat 路径，静默早退
+        # - response 是 falsy 但非 None（_SegmentedSentinel("")）：分段路径已通过
+        #   调度器实时发送，仍需更新群活跃度，但跳过再次 _send
+        if response is None:
             return []
 
         # 更新群活跃度（群聊且是@触发或AI命令）
@@ -385,7 +388,9 @@ class PersonaCommand(UserCommandBase):
             except Exception as e:
                 dice_log(f"[Persona] 群活跃度更新失败（已忽略）: {e}")
 
-        await self._send(user_id, group_id, response)
+        # 分段路径下 response 是 falsy sentinel，已通过 dispatcher 发出，不再次 _send
+        if response:
+            await self._send(user_id, group_id, response)
         return []
 
     async def _send(self, user_id: str, group_id: str, content: str) -> None:
@@ -621,6 +626,11 @@ class PersonaCommand(UserCommandBase):
     async def _handle_debug(self, user_id: str, group_id: str, msg: str) -> str:
         """.pa 命令已废弃，请使用 .ai admin 子命令"""
         return ".pa 命令已废弃，请使用 .ai admin 子命令"
+
+    async def shutdown(self) -> None:
+        """Bot 关闭时清理分段调度器"""
+        if self.app and self.app.segment_dispatcher:
+            await self.app.segment_dispatcher.shutdown()
 
     def get_description(self) -> str:
         """获取命令描述"""

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -35,6 +35,8 @@ from .tools.registry import ToolRegistry, ToolDomain
 from .tools.search_memory import SEARCH_MEMORY_TOOL, search_memory_executor
 from .tools.search_history import SEARCH_HISTORY_TOOL, make_search_history_executor
 from .tools.roll_dice import ROLL_DICE_TOOL, roll_dice_executor
+from .tools.send_reply_segment import make_tool_def, send_reply_segment_executor
+from .chat.segment_dispatcher import SegmentDispatcher
 
 
 @dataclass
@@ -45,6 +47,7 @@ class PersonaApp:
     life: LifeSimulator
     store: PersonaDataStore
     port: MessagePort
+    segment_dispatcher: Optional[SegmentDispatcher] = None
 
     # ── 角色卡 ────────────────────────────────────────────────
 
@@ -73,7 +76,7 @@ class PersonaApp:
 
     async def chat_with_user(
         self, user_id: str, group_id: str, message: str, nickname: str
-    ) -> str:
+    ) -> Optional[str]:
         return await self.chat.chat(user_id, group_id, message, nickname)
 
     # ── 消息发送 ──────────────────────────────────────────────
@@ -212,14 +215,28 @@ def _build_chat(
     config,
     decay_calculator: DecayCalculator,
     port: MessagePort,
+    segment_dispatcher: Optional[SegmentDispatcher] = None,
 ) -> ChatSession:
     """组装 ChatSession"""
     scoring_agent = ScoringAgent(router)
+    from .chat.context import SegmentGuide
+
+    segment_guide = None
+    if config.segment_enabled:
+        segment_guide = SegmentGuide(
+            enabled=True,
+            target_chars=config.segment_target_chars,
+            max_chars=config.segment_max_chars,
+            soft_limit=config.segment_soft_limit,
+            hard_limit=config.segment_hard_limit,
+        )
+
     context_builder = ContextBuilder(
         character,
         max_short_term_chars=config.max_short_term_chars,
         timezone=config.timezone,
         lore_token_budget=config.lore_token_budget,
+        segment_guide=segment_guide,
     )
     chat_config = ChatConfig.from_persona(config)
     return ChatSession(
@@ -233,6 +250,7 @@ def _build_chat(
         context_builder=context_builder,
         decay_calculator=decay_calculator,
         port=port,
+        segment_dispatcher=segment_dispatcher,
     )
 
 
@@ -336,6 +354,14 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
     store = await _build_store(bot, config)
     router = _build_router(config, store)
 
+    port = _build_port(bot, store)
+
+    segment_dispatcher = None
+    if config.segment_enabled:
+        segment_dispatcher = SegmentDispatcher(
+            message_port=port,
+        )
+
     tool_registry = ToolRegistry()
     tool_registry.register(ToolDomain.CHAT, SEARCH_MEMORY_TOOL, search_memory_executor)
     tool_registry.register(
@@ -344,7 +370,17 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
         make_search_history_executor(config.search_chat_history_max_chars),
     )
     tool_registry.register(ToolDomain.CHAT, ROLL_DICE_TOOL, roll_dice_executor)
-    logger.info("工具注册表已初始化")
+    if config.segment_enabled:
+        tool_registry.register(
+            ToolDomain.CHAT,
+            make_tool_def(
+                target_chars=config.segment_target_chars,
+                max_chars=config.segment_max_chars,
+                max_delay=config.segment_max_delay,
+            ),
+            send_reply_segment_executor,
+        )
+    logger.info("工具注册表与分段调度器已初始化")
 
     coordinator = LLMCallCoordinator(
         max_failures=config.proactive_coordinator_max_failures,
@@ -358,9 +394,12 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
     )
     logger.info("衰减计算器已初始化")
 
-    port = _build_port(bot, store)
-    chat = _build_chat(store, router, tool_registry, coordinator, character, config, decay_calculator, port)
+    chat = _build_chat(
+        store, router, tool_registry, coordinator, character, config, decay_calculator, port, segment_dispatcher
+    )
     life = await _build_life(store, character, config, coordinator, port, decay_calculator, router)
 
     logger.info("Persona 模块初始化完成")
-    return PersonaApp(chat=chat, life=life, store=store, port=port)
+    return PersonaApp(
+        chat=chat, life=life, store=store, port=port, segment_dispatcher=segment_dispatcher
+    )

--- a/src/plugins/DicePP/module/persona/gateway/port.py
+++ b/src/plugins/DicePP/module/persona/gateway/port.py
@@ -33,6 +33,12 @@ class MessagePort(EventSharePort):
     async def send_segmented(
         self, user_id: str, group_id: str, segments: List[Dict]
     ) -> bool:
+        """批量发送分段消息，默认记录历史。
+
+        与 send_now 的差异：send_segmented 走 pipeline + 后台任务，
+        send_now 为即时单条发送。skip_history_record 默认均为 False，
+        分段域如需跳过应在调用侧显式指定。
+        """
         actions = [
             SendAction(
                 user_id=user_id,
@@ -46,6 +52,47 @@ class MessagePort(EventSharePort):
         processed = await self._pipeline.process(actions)
         self._spawn_background(processed)
         return True  # fire-and-forget
+
+    async def send_now(
+        self,
+        user_id: str,
+        group_id: str,
+        content: str,
+        *,
+        skip_history_record: bool = False,
+    ) -> bool:
+        """即时单条发送，默认记录历史。
+
+        分段调度器应显式传 skip_history_record=True，
+        把"分段消息不记历史"的决策留在分段域。
+        """
+        action = SendAction(
+            user_id=user_id,
+            group_id=group_id,
+            content=content,
+            delay_seconds=0,
+            skip_history_record=skip_history_record,
+        )
+        processed = await self._pipeline.process([action])
+        a = processed[0]
+        try:
+            await self._send(
+                a.user_id,
+                a.group_id,
+                a.content,
+                skip_history_record=a.skip_history_record,
+            )
+            return True
+        except Exception as e:
+            logger.exception("send_now 失败")
+            if self._on_delivery_failed:
+                await self._on_delivery_failed(
+                    user_id=a.user_id,
+                    group_id=a.group_id,
+                    content=a.content,
+                    error=str(e),
+                )
+            return False
 
     def _spawn_background(self, actions: List[SendAction]) -> None:
         task = asyncio.create_task(self._run_actions(actions))

--- a/src/plugins/DicePP/module/persona/llm/client.py
+++ b/src/plugins/DicePP/module/persona/llm/client.py
@@ -4,12 +4,22 @@ LLM 客户端封装
 基于 AsyncOpenAI 的异步客户端，支持超时和错误处理
 """
 import asyncio
+from dataclasses import dataclass
 from nonebot.log import logger
-from typing import List, Dict, Optional, Any, Callable, Awaitable
+from typing import List, Dict, Optional, Any, Callable, Awaitable, TypedDict
 import time
 
+
+class ToolCallInfo(TypedDict):
+    """工具调用结构，供 RoundResult 与 ToolExecutor 使用"""
+
+    id: str
+    name: str
+    arguments: str
+
+
 # 工具执行器类型别名
-ToolExecutor = Callable[[List[Dict]], Awaitable[List[Dict]]]
+ToolExecutor = Callable[[List[ToolCallInfo]], Awaitable[List[Dict]]]
 
 
 _RETRYABLE_KEYWORDS = (
@@ -24,6 +34,14 @@ class ForcedToolError(Exception):
     def __init__(self, message: str, raw_content: str = ""):
         super().__init__(message)
         self.raw_content = raw_content
+
+
+@dataclass
+class RoundResult:
+    """单轮 LLM 响应结果，供 on_round_complete 回调使用"""
+
+    content: Optional[str]
+    tool_calls: List[ToolCallInfo]
 
 
 class LLMClient:
@@ -239,6 +257,10 @@ class LLMClient:
         max_tool_rounds: int = 5,
         timeout: int = 60,
         temperature: Optional[float] = None,
+        on_round_complete: Optional[
+            Callable[[int, RoundResult, List[Dict]], Awaitable[Optional[Dict]]]
+        ] = None,
+        max_round_callbacks: int = 3,
     ) -> tuple[str, dict]:
         """
         支持多轮工具调用的对话（完整循环实现）
@@ -259,6 +281,9 @@ class LLMClient:
             max_tool_rounds: 最多多少轮工具调用
             timeout: 单次调用超时时间
             temperature: 采样温度
+            on_round_complete: 每轮 LLM 响应后的回调；返回 dict 则注入消息并继续，
+                返回 None 则走原流程（处理 tool_calls 或返回 content）。
+            max_round_callbacks: 回调注入最大次数。
 
         Returns:
             (最终回复文本, 元数据字典)
@@ -268,8 +293,12 @@ class LLMClient:
         total_tool_calls = 0
         all_tool_names: List[str] = []
         retry_count = 0  # 独立重试计数器，避免轮次过多时退避时间过长
+        callback_count = 0
+        tool_round_num = 0
+        total_rounds = 0
+        max_total_rounds = max_tool_rounds + max_round_callbacks
 
-        for round_num in range(max_tool_rounds):
+        while total_rounds < max_total_rounds:
             try:
                 create_kwargs: Dict[str, Any] = {
                     "model": self.model,
@@ -285,6 +314,7 @@ class LLMClient:
                     timeout=timeout
                 )
 
+                total_rounds += 1
                 message = response.choices[0].message
 
                 # 检查单轮工具调用数量上限
@@ -295,6 +325,26 @@ class LLMClient:
                     # 截断到上限
                     message.tool_calls = message.tool_calls[:self.MAX_TOOLS_PER_ROUND]
 
+                result = RoundResult(
+                    content=message.content or "",
+                    tool_calls=[
+                        {
+                            "id": tc.id,
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        }
+                        for tc in (message.tool_calls or [])
+                    ],
+                )
+
+                # ── Round callback (injection) ──
+                if on_round_complete is not None and callback_count < max_round_callbacks:
+                    injected = await on_round_complete(tool_round_num, result, current_messages)
+                    if injected is not None:
+                        current_messages.append(injected)
+                        callback_count += 1
+                        continue  # 跳过原流程，直接进入下一轮 LLM
+
                 # 如果没有工具调用，直接返回内容
                 if not message.tool_calls:
                     content = message.content or ""
@@ -303,13 +353,14 @@ class LLMClient:
                     # 收集元数据
                     metadata = {
                         "model": self.model,
-                        "tool_rounds": round_num,
+                        "tool_rounds": tool_round_num,
                         "total_tool_calls": total_tool_calls,
                         "tool_names": all_tool_names,
                         "tokens_input": response.usage.prompt_tokens if response.usage else 0,
                         "tokens_output": response.usage.completion_tokens if response.usage else 0,
                         # Phase 3: 缓存数据收集
                         "cached_tokens": self._get_cached_tokens(response),
+                        "callback_count": callback_count,
                     }
 
                     return content, metadata
@@ -347,6 +398,7 @@ class LLMClient:
                             "tool_call_id": tc.id,
                             "content": "[System note: Tool execution is temporarily unavailable, please respond without using this information]"
                         })
+                    tool_round_num += 1
                     continue  # 继续循环，让 LLM 基于错误信息生成合适的回复
 
                 # 执行工具调用
@@ -366,7 +418,7 @@ class LLMClient:
                     # 工具执行失败，返回错误信息
                     return f"（工具执行失败: {e}）", {
                         "model": self.model,
-                        "tool_rounds": round_num,
+                        "tool_rounds": tool_round_num,
                         "error": str(e),
                     }
 
@@ -378,32 +430,36 @@ class LLMClient:
                         "content": result["content"],
                     })
 
+                tool_round_num += 1
                 # 继续下一轮循环，让 LLM 基于工具结果生成回复
                 continue
 
-            except asyncio.TimeoutError:
-                raise
             except Exception as e:
                 error_msg = str(e).lower()
-                # 检查是否需要重试的错误
-                retryable = any(keyword in error_msg for keyword in _RETRYABLE_KEYWORDS)
+                # 检查是否需要重试的错误（包含 timeout）
+                retryable = (
+                    any(keyword in error_msg for keyword in _RETRYABLE_KEYWORDS)
+                    or isinstance(e, asyncio.TimeoutError)
+                )
 
                 if not retryable or retry_count >= 3:  # 最多重试 3 次
                     raise
 
-                # 使用指数退避（基于独立重试计数器，避免轮次过多时延迟过大）
-                retry_delay = 2 * (2 ** retry_count)
+                # timeout 与其他可重试异常共享总轮次预算
+                total_rounds += 1
                 retry_count += 1
-                logger.warning(f"工具调用第 {round_num + 1} 轮失败，{retry_delay}秒后重试: {e}")
+                retry_delay = 2 * (2 ** retry_count)
+                logger.warning(f"工具调用第 {tool_round_num + 1} 轮失败，{retry_delay}秒后重试: {e}")
                 await asyncio.sleep(retry_delay)
                 continue
 
         # 达到最大轮次仍未完成
         return "（工具调用次数超过限制）", {
             "model": self.model,
-            "tool_rounds": max_tool_rounds,
+            "tool_rounds": tool_round_num,
             "total_tool_calls": total_tool_calls,
             "tool_names": all_tool_names,
+            "callback_count": callback_count,
         }
 
     def _get_cached_tokens(self, response) -> int:

--- a/src/plugins/DicePP/module/persona/llm/router.py
+++ b/src/plugins/DicePP/module/persona/llm/router.py
@@ -12,7 +12,7 @@ from typing import List, Dict, Any, Optional, Callable, Awaitable, TYPE_CHECKING
 import time
 import uuid
 from nonebot.log import logger
-from .client import LLMClient
+from .client import LLMClient, RoundResult
 from ..data.models import ModelTier, UserLLMConfig
 
 if TYPE_CHECKING:
@@ -459,6 +459,10 @@ class LLMRouter:
         max_tool_rounds: int = 5,
         user_id: Optional[str] = None,
         group_id: Optional[str] = None,
+        on_round_complete: Optional[
+            Callable[[int, RoundResult, List[Dict]], Awaitable[Optional[Dict]]]
+        ] = None,
+        max_round_callbacks: int = 3,
     ) -> tuple[str, dict]:
         """
         生成回复，支持工具调用（完整循环）
@@ -498,6 +502,8 @@ class LLMRouter:
                     max_tool_rounds=max_tool_rounds,
                     timeout=actual_timeout,
                     temperature=temperature,
+                    on_round_complete=on_round_complete,
+                    max_round_callbacks=max_round_callbacks,
                 ),
                 session_id=session_id,
                 user_id=user_id,

--- a/src/plugins/DicePP/module/persona/tools/context.py
+++ b/src/plugins/DicePP/module/persona/tools/context.py
@@ -19,3 +19,5 @@ class ToolContext:
     group_id: str
     store: Any = None
     send: Optional[SendPort] = None
+    segment_dispatcher: Optional[Any] = None
+    segment_state: Optional[Any] = None

--- a/src/plugins/DicePP/module/persona/tools/send_reply_segment.py
+++ b/src/plugins/DicePP/module/persona/tools/send_reply_segment.py
@@ -1,0 +1,147 @@
+"""send_reply_segment 工具 — 让 LLM 按段输出回复内容
+
+Executor 读取 / 更新 chat-local 状态，不持有全局状态。
+"""
+
+from typing import Dict, Any, Optional
+
+from nonebot.log import logger
+
+from ..chat.segment_dispatcher import SegmentDispatcher, SegmentItem
+from ..chat.segment_state import SegmentBudgetState
+from ..chat.context import DEFAULT_DELAY_BEFORE
+from .context import ToolContext
+from .registry import ToolDef
+
+
+def make_tool_def(
+    target_chars: int,
+    max_chars: int,
+    max_delay: float,
+) -> ToolDef:
+    """构造 send_reply_segment 工具定义"""
+    return ToolDef(
+        name="send_reply_segment",
+        description=(
+            f"发送回复的一段内容。建议每段 {target_chars} 字，"
+            f"单段上限 {max_chars} 字。"
+            f"若有多段，可多次调用本工具。"
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "该段回复的文本内容",
+                },
+                "delay_before": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": max_delay,
+                    "default": DEFAULT_DELAY_BEFORE,
+                    "description": f"发送前等待秒数（0–{max_delay}）",
+                },
+            },
+            "required": ["content"],
+        },
+    )
+
+
+async def send_reply_segment_executor(args: Dict[str, Any], ctx: ToolContext) -> str:
+    """执行 send_reply_segment 工具
+
+    校验链（按顺序，失败即返回 error，不修改状态）：
+    1. content.strip() != ""
+    2. 0 <= delay_before <= max_delay
+    3. len(content) <= max_chars
+    4. segment_count + 1 <= count_max
+    5. total_chars + len(content) <= hard_limit（soft_limit 发 warning）
+
+    通过校验后：
+    - buffer.append(content)
+    - total_chars += len(content)
+    - segment_count += 1
+    - dispatcher.notify(target_key, SegmentItem(...))
+    """
+    content: str = args.get("content", "")
+    delay_before: float = args.get("delay_before", DEFAULT_DELAY_BEFORE)
+
+    state: Optional[SegmentBudgetState] = ctx.segment_state
+    dispatcher: Optional[SegmentDispatcher] = ctx.segment_dispatcher
+
+    if state is None or dispatcher is None:
+        return _json_result(status="error", error="分段状态未初始化")
+
+    # 1. empty / whitespace-only
+    if content.strip() == "":
+        return _json_result(status="error", error="内容不能为空")
+
+    # 2. delay_before bounds
+    if not (0 <= delay_before <= state.limits.max_delay):
+        return _json_result(
+            status="error",
+            error=f"delay_before 必须在 0–{state.limits.max_delay} 秒之间",
+        )
+
+    # 3. per-segment char limit
+    if len(content) > state.limits.max_chars:
+        remaining = max(0, state.limits.soft_limit - state.total_chars)
+        return _json_result(
+            status="error",
+            error=f"单段不超过 {state.limits.max_chars} 字符，当前剩余预算约 {remaining} 字符，请拆分后重试",
+            remaining_chars=remaining,
+        )
+
+    # 4. segment count limit
+    if state.segment_count + 1 > state.limits.count_max:
+        return _json_result(
+            status="error",
+            error=f"已超过单次回复最大段数（{state.limits.count_max}），请结束回复",
+            remaining_chars=max(0, state.limits.soft_limit - state.total_chars),
+        )
+
+    # 5. total char limit (soft / hard)
+    new_total = state.total_chars + len(content)
+    if new_total > state.limits.hard_limit:
+        return _json_result(
+            status="error",
+            error=f"超过单次回复上限 {state.limits.hard_limit} 字符，请精简或结束回复",
+            remaining_chars=max(0, state.limits.soft_limit - state.total_chars),
+        )
+
+    # ── 通过校验，更新状态并入队 ──
+    state.buffer.append(content)
+    state.total_chars = new_total
+    state.segment_count += 1
+
+    target_key = SegmentDispatcher.target_key(ctx.user_id, ctx.group_id)
+    dispatcher.notify(
+        target_key,
+        SegmentItem(
+            content=content,
+            delay_before=delay_before,
+            user_id=ctx.user_id,
+            group_id=ctx.group_id,
+        ),
+    )
+
+    if new_total <= state.limits.soft_limit:
+        return _json_result(
+            status="success",
+            remaining_chars=state.limits.soft_limit - new_total,
+        )
+    else:
+        return _json_result(
+            status="warning",
+            warning="已超过推荐字数上限，请尽快收尾",
+            remaining_chars=max(0, state.limits.soft_limit - new_total),
+        )
+
+
+def _json_result(status: str, remaining_chars: int = 0, **kwargs) -> str:
+    import json
+
+    result: Dict[str, Any] = {"status": status, "remaining_chars": remaining_chars}
+    result.update(kwargs)
+    return json.dumps(result, ensure_ascii=False)

--- a/tests/integration/persona/test_command.py
+++ b/tests/integration/persona/test_command.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from plugins.DicePP.module.persona.command import PersonaCommand
+from plugins.DicePP.module.persona.chat.session import ChatSession
 from plugins.DicePP.module.persona.data.models import (
     RelationshipState,
     UserProfile,
@@ -527,3 +528,71 @@ class TestGroupChatRecorder(IsolatedAsyncioTestCase):
             content="hello",
             display_name="小明",
         )
+
+
+@pytest.mark.integration
+class TestSegmentedPathPreservesGroupActivity(IsolatedAsyncioTestCase):
+    """R4 回归: 分段路径下 chat_with_user 返回 falsy `_SegmentedSentinel`(空字符串子类)，
+    群活跃度仍需更新, 但 _send 不应被再次调用 (消息已通过 dispatcher 实时发出)
+    """
+
+    async def asyncSetUp(self):
+        from plugins.DicePP.core.config.pydantic_models import PersonaConfig
+        # 与 _default_persona_config() 同源, 但启用 group_activity
+        persona = PersonaConfig(
+            enabled=True,
+            character_name="test_char",
+            character_path="./content/characters",
+            primary_api_key="fake_key",
+            primary_base_url="http://localhost",
+            primary_model="gpt-4o",
+            observe_group_enabled=False,
+            group_activity_enabled=True,
+            trace_enabled=False,
+            whitelist_enabled=False,
+            daily_limit=100,
+            quota_check_enabled=False,
+            relationship_refuse_enabled=False,
+            decay_enabled=False,
+            proactive_enabled=False,
+            character_life_enabled=False,
+            group_chat_enabled=False,
+        )
+        self.bot = _make_mock_bot(persona)
+        self.cmd = _make_cmd(self.bot)
+        self.store = AsyncMock()
+        self.cmd.data_store = self.store
+        self.cmd._send = AsyncMock()
+
+        self.store.is_group_whitelisted = AsyncMock(return_value=True)
+        self.store.update_group_activity = AsyncMock()
+        self.store.add_group_conversation = AsyncMock()
+
+        self.cmd.app = MagicMock()
+        self.cmd.app.chat_with_user = AsyncMock(
+            return_value=ChatSession._SegmentedSentinel("")
+        )
+
+    async def test_segmented_response_updates_activity_without_resend(self):
+        meta = _make_group_meta("hello", to_me=True)
+        await self.cmd.process_msg("hello", meta, None)
+
+        # @ 触发后 chat_with_user 走过一次
+        self.cmd.app.chat_with_user.assert_awaited_once()
+
+        # 即便分段路径让 response 是 falsy sentinel,群活跃度仍需更新一次
+        self.store.update_group_activity.assert_awaited_once()
+
+        # 分段消息已由 dispatcher 实时发出,_send 不应被再次调用
+        self.cmd._send.assert_not_awaited()
+
+    async def test_none_response_short_circuits_before_activity(self):
+        """response is None(去重命中或未进 chat 路径)应在 update_group_activity 之前早退"""
+        self.cmd.app.chat_with_user = AsyncMock(return_value=None)
+        meta = _make_group_meta("hello", to_me=True)
+        await self.cmd.process_msg("hello", meta, None)
+
+        self.cmd.app.chat_with_user.assert_awaited_once()
+        # response is None → 在群活跃度更新之前 return [],store 不被触达
+        self.store.update_group_activity.assert_not_awaited()
+        self.cmd._send.assert_not_awaited()

--- a/tests/module/persona/chat/test_segment_dispatcher.py
+++ b/tests/module/persona/chat/test_segment_dispatcher.py
@@ -1,0 +1,164 @@
+"""Tests for SegmentDispatcher.
+
+Covers: lazy creation, idle timeout, wake on new segment, delay_before=0,
+flush, shutdown logs, worker_max_per_run cap, target_key naming.
+"""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from plugins.DicePP.module.persona.chat.segment_dispatcher import (
+    SegmentDispatcher,
+    SegmentItem,
+)
+
+
+@pytest.fixture
+def mock_port():
+    return AsyncMock()
+
+
+@pytest.fixture
+def dispatcher(mock_port):
+    return SegmentDispatcher(
+        message_port=mock_port,
+        idle_seconds=1,
+        max_per_run=3,
+    )
+
+
+class TestTargetKey:
+    def test_group_key(self):
+        assert SegmentDispatcher.target_key("u1", "g123") == "group:g123"
+
+    def test_private_key(self):
+        assert SegmentDispatcher.target_key("u1", "") == "user:u1"
+
+
+class TestLazyCreation:
+    @pytest.mark.asyncio
+    async def test_first_segment_creates_worker(self, dispatcher, mock_port):
+        dispatcher.notify("group:1", SegmentItem("hello", 0, "u1", "g1"))
+        await asyncio.sleep(0.05)
+        mock_port.send_now.assert_awaited_once_with("u1", "g1", "hello", skip_history_record=True)
+
+    @pytest.mark.asyncio
+    async def test_second_segment_reuses_worker(self, dispatcher, mock_port):
+        dispatcher.notify("group:1", SegmentItem("a", 0, "u1", "g1"))
+        dispatcher.notify("group:1", SegmentItem("b", 0, "u1", "g1"))
+        await asyncio.sleep(0.05)
+        assert mock_port.send_now.await_count == 2
+
+
+class TestIdleTimeout:
+    @pytest.mark.asyncio
+    async def test_worker_exits_after_idle(self, dispatcher):
+        dispatcher.notify("group:1", SegmentItem("hi", 0, "u1", "g1"))
+        await asyncio.sleep(0.05)
+        # Worker should still exist briefly after send
+        assert "group:1" in dispatcher._workers
+        # After idle timeout it should be gone
+        await asyncio.sleep(1.2)
+        assert "group:1" not in dispatcher._workers
+        assert "group:1" not in dispatcher._queues
+
+
+class TestDelayBefore:
+    @pytest.mark.asyncio
+    async def test_zero_delay_sends_immediately(self, dispatcher, mock_port):
+        dispatcher.notify("group:1", SegmentItem("now", 0, "u1", "g1"))
+        await asyncio.sleep(0.05)
+        mock_port.send_now.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_positive_delay_waits(self, dispatcher, mock_port):
+        dispatcher.notify("group:1", SegmentItem("later", 0.3, "u1", "g1"))
+        await asyncio.sleep(0.05)
+        # Not sent yet
+        mock_port.send_now.assert_not_awaited()
+        await asyncio.sleep(0.35)
+        mock_port.send_now.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_new_segment_wakes_sleeping_worker(self, dispatcher, mock_port):
+        dispatcher.notify("group:1", SegmentItem("a", 0.5, "u1", "g1"))
+        await asyncio.sleep(0.05)
+        # Enqueue second segment while first is sleeping
+        dispatcher.notify("group:1", SegmentItem("b", 0, "u1", "g1"))
+        await asyncio.sleep(0.6)
+        # Both should be sent; order preserved
+        calls = mock_port.send_now.await_args_list
+        assert len(calls) == 2
+        assert calls[0][0][2] == "a"
+        assert calls[1][0][2] == "b"
+
+
+class TestFlush:
+    @pytest.mark.asyncio
+    async def test_flush_drops_pending(self, dispatcher):
+        # Directly populate queue to verify flush removes pending segments
+        queue = asyncio.Queue()
+        dispatcher._queues["group:1"] = queue
+        queue.put_nowait(SegmentItem("a", 0, "u1", "g1"))
+        queue.put_nowait(SegmentItem("b", 0, "u1", "g1"))
+        await dispatcher.flush("group:1")
+        assert queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_flush_on_empty_queue_is_safe(self, dispatcher):
+        await dispatcher.flush("group:1")
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_logs_pending(self, dispatcher):
+        from unittest.mock import patch
+        queue = asyncio.Queue()
+        dispatcher._queues["group:1"] = queue
+        queue.put_nowait(SegmentItem("a", 0, "u1", "g1"))
+        queue.put_nowait(SegmentItem("b", 0, "u1", "g1"))
+        with patch("plugins.DicePP.module.persona.chat.segment_dispatcher.logger") as mock_logger:
+            await dispatcher.shutdown()
+        mock_logger.warning.assert_called_once()
+        assert "segments lost on shutdown" in mock_logger.warning.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_no_warning_when_empty(self, dispatcher):
+        from unittest.mock import patch
+        dispatcher.notify("group:1", SegmentItem("a", 0, "u1", "g1"))
+        await asyncio.sleep(0.1)
+        with patch("plugins.DicePP.module.persona.chat.segment_dispatcher.logger") as mock_logger:
+            await dispatcher.shutdown()
+        assert not mock_logger.warning.called
+
+
+class TestMaxPerRun:
+    @pytest.mark.asyncio
+    async def test_worker_rotates_after_cap(self, dispatcher, mock_port):
+        # max_per_run = 3; worker 达到上限后退出，需新的 notify() 触发重建
+        for i in range(3):
+            dispatcher.notify("group:1", SegmentItem(str(i), 0, "u1", "g1"))
+        await asyncio.sleep(0.1)
+        calls = mock_port.send_now.await_args_list
+        assert len(calls) == 3
+
+        for i in range(3, 5):
+            dispatcher.notify("group:1", SegmentItem(str(i), 0, "u1", "g1"))
+        await asyncio.sleep(0.1)
+        calls = mock_port.send_now.await_args_list
+        assert len(calls) == 5
+        contents = [c[0][2] for c in calls]
+        assert contents == ["0", "1", "2", "3", "4"]
+
+
+class TestSendFailure:
+    @pytest.mark.asyncio
+    async def test_failure_does_not_kill_worker(self, dispatcher, mock_port):
+        mock_port.send_now.side_effect = [Exception("boom"), None]
+        dispatcher.notify("group:1", SegmentItem("fail", 0, "u1", "g1"))
+        dispatcher.notify("group:1", SegmentItem("ok", 0, "u1", "g1"))
+        await asyncio.sleep(0.1)
+        assert mock_port.send_now.await_count == 2

--- a/tests/module/persona/tools/test_send_reply_segment.py
+++ b/tests/module/persona/tools/test_send_reply_segment.py
@@ -1,0 +1,162 @@
+"""Tests for send_reply_segment tool executor.
+
+Covers: empty/whitespace content, max_chars limit, soft/hard limit,
+count_max limit, delay_before bounds, warning state, error isolation.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from plugins.DicePP.module.persona.chat.segment_dispatcher import SegmentDispatcher, SegmentItem
+from plugins.DicePP.module.persona.chat.segment_state import SegmentBudgetState, SegmentLimits
+from plugins.DicePP.module.persona.tools.context import ToolContext
+from plugins.DicePP.module.persona.tools.send_reply_segment import (
+    send_reply_segment_executor,
+    make_tool_def,
+)
+
+
+@pytest.fixture
+def mock_port():
+    return MagicMock()
+
+
+@pytest.fixture
+async def dispatcher(mock_port):
+    d = SegmentDispatcher(message_port=mock_port, idle_seconds=0.05, max_per_run=20)
+    yield d
+    await d.shutdown()
+
+
+@pytest.fixture
+def limits():
+    return SegmentLimits(max_chars=10, soft_limit=15, hard_limit=20, count_max=3, max_delay=5.0)
+
+
+@pytest.fixture
+def ctx(dispatcher, limits):
+    return ToolContext(
+        user_id="u1",
+        group_id="g1",
+        segment_dispatcher=dispatcher,
+        segment_state=SegmentBudgetState(limits=limits),
+    )
+
+
+def parse(result: str) -> dict:
+    return json.loads(result)
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_empty_content_rejected(self, ctx):
+        result = parse(await send_reply_segment_executor({"content": ""}, ctx))
+        assert result["status"] == "error"
+        assert "不能为空" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_content_rejected(self, ctx):
+        result = parse(await send_reply_segment_executor({"content": "   "}, ctx))
+        assert result["status"] == "error"
+        assert "不能为空" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_negative_delay_rejected(self, ctx):
+        result = parse(await send_reply_segment_executor({"content": "hi", "delay_before": -1}, ctx))
+        assert result["status"] == "error"
+        assert "delay_before" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delay_exceeds_max_rejected(self, ctx):
+        result = parse(await send_reply_segment_executor({"content": "hi", "delay_before": 10}, ctx))
+        assert result["status"] == "error"
+        assert "delay_before" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_content_exceeds_max_chars(self, ctx):
+        result = parse(await send_reply_segment_executor({"content": "a" * 11}, ctx))
+        assert result["status"] == "error"
+        assert "不超过" in result["error"]
+
+
+class TestBudget:
+    @pytest.mark.asyncio
+    async def test_success_within_soft_limit(self, ctx):
+        result = parse(await send_reply_segment_executor({"content": "hello"}, ctx))
+        assert result["status"] == "success"
+        assert result["remaining_chars"] == 10  # 15 - 5
+
+    @pytest.mark.asyncio
+    async def test_warning_between_soft_and_hard(self, ctx, limits):
+        state = SegmentBudgetState(limits=limits)
+        ctx.segment_state = state
+        # 15 soft, 20 hard; max_chars=10 so each segment must be <=10
+        await send_reply_segment_executor({"content": "a" * 8}, ctx)   # 8 chars
+        assert state.total_chars == 8
+        result = parse(await send_reply_segment_executor({"content": "b" * 5}, ctx))  # +5 = 13
+        assert result["status"] == "success"
+        assert state.total_chars == 13
+        result2 = parse(await send_reply_segment_executor({"content": "c" * 3}, ctx))  # +3 = 16 > soft
+        assert result2["status"] == "warning"
+        assert "收尾" in result2["warning"]
+
+    @pytest.mark.asyncio
+    async def test_error_exceeds_hard_limit(self, ctx):
+        result = parse(await send_reply_segment_executor({"content": "a" * 21}, ctx))
+        assert result["status"] == "error"
+        assert "不超过" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_count_max_rejected(self, ctx):
+        for i in range(3):
+            result = parse(await send_reply_segment_executor({"content": str(i)}, ctx))
+            assert result["status"] in ("success", "warning")
+        result = parse(await send_reply_segment_executor({"content": "x"}, ctx))
+        assert result["status"] == "error"
+        assert "最大段数" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_state_not_mutated_on_error(self, ctx):
+        before = ctx.segment_state.segment_count
+        await send_reply_segment_executor({"content": ""}, ctx)
+        assert ctx.segment_state.segment_count == before
+
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_segment_enqueued(self, ctx, dispatcher):
+        await send_reply_segment_executor({"content": "hi", "delay_before": 2.0}, ctx)
+        assert ctx.segment_state.buffer == ["hi"]
+        assert ctx.segment_state.total_chars == 2
+        assert ctx.segment_state.segment_count == 1
+        # queue should have the segment
+        queue = dispatcher._queues.get("group:g1")
+        assert queue is not None
+        assert not queue.empty()
+        await dispatcher.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_zero_delay_accepted(self, ctx, dispatcher):
+        result = parse(await send_reply_segment_executor({"content": "now", "delay_before": 0}, ctx))
+        assert result["status"] == "success"
+        queue = dispatcher._queues.get("group:g1")
+        assert queue is not None
+        item = queue.get_nowait()
+        assert item.delay_before == 0
+        await dispatcher.shutdown()
+
+
+class TestToolDef:
+    def test_schema_has_minlength(self):
+        schema = make_tool_def(target_chars=30, max_chars=80, max_delay=10.0)
+        params = schema.parameters["properties"]
+        assert params["content"]["minLength"] == 1
+        assert params["delay_before"]["minimum"] == 0
+        assert params["delay_before"]["maximum"] == 10.0
+
+    def test_description_contains_limits(self):
+        schema = make_tool_def(target_chars=30, max_chars=80, max_delay=10.0)
+        desc = schema.description
+        assert "30" in desc
+        assert "80" in desc

--- a/tests/unit/persona/test_chat_session_charging.py
+++ b/tests/unit/persona/test_chat_session_charging.py
@@ -85,7 +85,7 @@ async def test_single_call_charges_once():
 
 @pytest.mark.asyncio
 async def test_buffered_merge_charges_per_call():
-    """3 次 LLM 调用（2 中间 + 1 最终）→ 3 次扣费"""
+    """N 次 LLM 调用（中间轮 + 最终轮）→ N 次扣费（中间轮 on_result + 最终轮 success 各扣 1 次）"""
     coordinator = LLMCallCoordinator()
     session = _make_session(coordinator)
 
@@ -122,7 +122,7 @@ async def test_buffered_merge_charges_per_call():
 
     # call_count 至少 2（首轮 + 至少 1 次 buffered 合并）
     assert call_count >= 2
-    # 计费次数等于实际 LLM 调用次数
+    # 中间轮通过 on_result 各扣 1 次 + 最终轮 success 1 次：N 次 LLM 调用 → N 次扣费
     assert session.router.increment_usage.await_count == call_count
 
 

--- a/tests/unit/persona/test_chat_session_segmented.py
+++ b/tests/unit/persona/test_chat_session_segmented.py
@@ -1,0 +1,210 @@
+"""ChatSession 分段回复集成测试
+
+覆盖: _chat_with_tools flush、flag 生命周期、coordinator 协作、
+      兜底场景、返回值语义。
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from plugins.DicePP.module.persona.chat.session import ChatSession, ChatConfig
+from plugins.DicePP.module.persona.chat.segment_dispatcher import SegmentDispatcher, SegmentItem
+from plugins.DicePP.module.persona.chat.segment_state import SegmentBudgetState
+from plugins.DicePP.module.persona.data.store import PersonaDataStore
+from plugins.DicePP.module.persona.llm.router import LLMRouter
+from plugins.DicePP.module.persona.tools.registry import ToolRegistry, ToolDomain
+from plugins.DicePP.module.persona.llm.coordinator import LLMCallCoordinator
+from plugins.DicePP.module.persona.character.models import Character
+from plugins.DicePP.module.persona.chat.scoring import ScoringAgent
+from plugins.DicePP.module.persona.chat.context import ContextBuilder
+
+
+@pytest.fixture
+def mock_store():
+    store = MagicMock(spec=PersonaDataStore)
+    store.get_group_conversations = AsyncMock(return_value=[])
+    store.get_recent_messages = AsyncMock(return_value=[])
+    store.add_message = AsyncMock()
+    store.add_group_conversation = AsyncMock()
+    store.get_relationship = AsyncMock(return_value=None)
+    store.get_user_profile = AsyncMock(return_value=None)
+    store.get_user_llm_config = AsyncMock(return_value=None)
+    store.get_daily_usage = AsyncMock(return_value=0)
+    store.is_user_whitelisted = AsyncMock(return_value=False)
+    store.is_group_whitelisted = AsyncMock(return_value=False)
+    return store
+
+
+@pytest.fixture
+def mock_router():
+    router = MagicMock(spec=LLMRouter)
+    router.generate = AsyncMock(return_value="hello")
+    router.generate_with_tools = AsyncMock(return_value=("hello", {"tool_rounds": 0, "callback_count": 0}))
+    router.increment_usage = AsyncMock()
+    return router
+
+
+@pytest.fixture
+def mock_port():
+    return AsyncMock()
+
+
+@pytest.fixture
+def dispatcher(mock_port):
+    return SegmentDispatcher(message_port=mock_port, idle_seconds=300, max_per_run=20)
+
+
+@pytest.fixture
+def tool_registry():
+    reg = ToolRegistry()
+    return reg
+
+
+@pytest.fixture
+def coordinator():
+    return LLMCallCoordinator(max_failures=3, max_iterations=5)
+
+
+@pytest.fixture
+def character():
+    return Character(name="Test")
+
+
+@pytest.fixture
+def context_builder(character):
+    return ContextBuilder(character)
+
+
+@pytest.fixture
+def config():
+    return ChatConfig(
+        tools_enabled=True,
+        tools_max_rounds=5,
+        segment_target_chars=30,
+        segment_max_chars=80,
+        segment_soft_limit=100,
+        segment_hard_limit=120,
+        segment_count_max=10,
+        segment_max_delay=10.0,
+        segment_round_callbacks_max=3,
+    )
+
+
+@pytest.fixture
+def session(mock_store, mock_router, tool_registry, coordinator, character, config, context_builder, dispatcher, mock_port):
+    return ChatSession(
+        store=mock_store,
+        router=mock_router,
+        tool_registry=tool_registry,
+        coordinator=coordinator,
+        character=character,
+        config=config,
+        scoring_agent=MagicMock(),
+        context_builder=context_builder,
+        port=mock_port,
+        segment_dispatcher=dispatcher,
+    )
+
+
+class TestChatWithToolsFlush:
+    @pytest.mark.asyncio
+    async def test_flush_on_entry(self, session, dispatcher, mock_port):
+        # Pre-populate dispatcher with an old segment
+        dispatcher.notify("user:u1", SegmentItem("old", 0, "u1", ""))
+        await session._chat_with_tools("u1", "", [{"role": "user", "content": "hi"}])
+        # Old segment should be flushed (dropped, not sent)
+        queue = dispatcher._queues.get("user:u1")
+        if queue is not None:
+            assert queue.empty()
+        mock_port.send_now.assert_not_awaited()
+
+
+class TestFlagLifecycle:
+    @pytest.mark.asyncio
+    async def test_segmented_sentinel_returned_by_chat_with_tools(self, session):
+        result = await session._chat_with_tools("u1", "", [{"role": "user", "content": "hi"}])
+        assert isinstance(result, session._SegmentedSentinel)
+
+    @pytest.mark.asyncio
+    async def test_chat_via_coordinator_returns_falsy_sentinel_for_segmented(self, session):
+        result = await session._chat_via_coordinator("u1", "", "hi", "user:u1")
+        assert result is not None
+        assert not result
+        assert isinstance(result, ChatSession._SegmentedSentinel)
+
+    @pytest.mark.asyncio
+    async def test_exception_does_not_produce_sentinel(self, session, mock_router):
+        mock_router.generate_with_tools = AsyncMock(side_effect=RuntimeError("boom"))
+        with pytest.raises(RuntimeError):
+            await session._chat_with_tools("u1", "", [{"role": "user", "content": "hi"}])
+
+
+class TestReturnSemantics:
+    @pytest.mark.asyncio
+    async def test_chat_returns_falsy_sentinel_for_segmented(self, session):
+        # tools_enabled=True with segment_dispatcher -> falsy _SegmentedSentinel
+        result = await session.chat("u1", "", "hello")
+        assert result is not None
+        assert not result
+        assert isinstance(result, ChatSession._SegmentedSentinel)
+        assert session.router.increment_usage.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_chat_returns_str_for_tools_disabled(self, session):
+        session.config.tools_enabled = False
+        result = await session.chat("u1", "", "hello")
+        assert result == "hello"
+
+
+class TestFallback:
+    @pytest.mark.asyncio
+    async def test_fallback_when_callbacks_exhausted(self, session, mock_router):
+        mock_router.generate_with_tools = AsyncMock(return_value=("fallback content", {
+            "tool_rounds": 0,
+            "callback_count": 3,
+        }))
+        result = await session._chat_with_tools("u1", "", [{"role": "user", "content": "hi"}])
+        # Fallback content should be appended to buffer
+        assert "fallback content" in result
+
+    @pytest.mark.asyncio
+    async def test_fallback_empty_content_logged(self, session, mock_router):
+        from unittest.mock import patch
+        mock_router.generate_with_tools = AsyncMock(return_value=("", {
+            "tool_rounds": 0,
+            "callback_count": 3,
+        }))
+        with patch("plugins.DicePP.module.persona.chat.session.logger") as mock_logger:
+            result = await session._chat_with_tools("u1", "", [{"role": "user", "content": "hi"}])
+        assert result == ""
+        mock_logger.error.assert_called_once()
+        assert "耗尽 callback 且返回空 content" in mock_logger.error.call_args[0][0]
+
+
+class TestOnSegmentRoundComplete:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_tool_called(self, session):
+        from plugins.DicePP.module.persona.llm.client import RoundResult
+        result = RoundResult(content="", tool_calls=[{"name": "send_reply_segment"}])
+        injected = await session._on_segment_round_complete(0, result, [])
+        assert injected is None
+
+    @pytest.mark.asyncio
+    async def test_returns_injection_when_content_without_tools(self, session):
+        from plugins.DicePP.module.persona.llm.client import RoundResult
+        result = RoundResult(content="hello", tool_calls=[])
+        injected = await session._on_segment_round_complete(0, result, [])
+        assert injected is not None
+        assert "send_reply_segment" in injected["content"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_and_warns_when_both(self, session):
+        from unittest.mock import patch
+        from plugins.DicePP.module.persona.llm.client import RoundResult
+        result = RoundResult(content="extra", tool_calls=[{"name": "send_reply_segment"}])
+        with patch("plugins.DicePP.module.persona.chat.session.logger") as mock_logger:
+            injected = await session._on_segment_round_complete(0, result, [])
+        assert injected is None
+        mock_logger.warning.assert_called_once()
+        assert "content alongside send_reply_segment" in mock_logger.warning.call_args[0][0]

--- a/tests/unit/persona/test_chat_with_tools.py
+++ b/tests/unit/persona/test_chat_with_tools.py
@@ -9,7 +9,7 @@ import asyncio
 from typing import List, Dict, Any
 from unittest.mock import Mock, AsyncMock
 
-from plugins.DicePP.module.persona.llm.client import LLMClient, ForcedToolError
+from plugins.DicePP.module.persona.llm.client import LLMClient, ForcedToolError, RoundResult
 from plugins.DicePP.module.persona.llm.router import LLMRouter
 
 
@@ -314,8 +314,186 @@ class TestChatWithTools:
             tools=tools,
             tool_executor=mock_executor,
             max_tool_rounds=2,  # 限制为 2 轮
+            max_round_callbacks=0,  # 禁用回调以保持原测试语义
             timeout=60
         )
 
         assert "工具调用次数超过限制" in content
         assert metadata["tool_rounds"] == 2
+
+    @pytest.mark.asyncio
+    async def test_callback_injection_appends_message_and_continues(self):
+        """回调返回 dict 时注入消息并继续循环"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        # Round 0: content without tool_calls -> callback injects system note
+        mock_response1 = Mock()
+        mock_response1.choices = [Mock()]
+        mock_response1.choices[0].message = Mock()
+        mock_response1.choices[0].message.content = "hello"
+        mock_response1.choices[0].message.tool_calls = None
+        mock_response1.usage = None
+
+        # Round 1 (after injection): content again -> callback returns None
+        mock_response2 = Mock()
+        mock_response2.choices = [Mock()]
+        mock_response2.choices[0].message = Mock()
+        mock_response2.choices[0].message.content = "world"
+        mock_response2.choices[0].message.tool_calls = None
+        mock_response2.usage = None
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(
+            side_effect=[mock_response1, mock_response2]
+        )
+        client._client = mock_openai_client
+
+        async def on_round(round_num, result, messages):
+            if result.content == "hello":
+                return {"role": "system", "content": "inject"}
+            return None
+
+        content, metadata = await client.chat_with_tools(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[],
+            on_round_complete=on_round,
+            max_round_callbacks=3,
+            max_tool_rounds=5,
+        )
+
+        assert content == "world"
+        assert metadata["callback_count"] == 1
+        assert metadata["tool_rounds"] == 0
+        # Verify injected message was appended
+        second_call_messages = mock_openai_client.chat.completions.create.await_args_list[1][1]["messages"]
+        assert any(m.get("content") == "inject" for m in second_call_messages)
+
+    @pytest.mark.asyncio
+    async def test_callback_returns_none_uses_original_flow(self):
+        """回调返回 None 时走原流程（处理 tool_calls）"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.tool_calls = [
+            MockToolCall("tc_1", "search_memory", '{}')
+        ]
+        mock_response.usage = None
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        client._client = mock_openai_client
+
+        async def mock_executor(tool_calls):
+            return [{"tool_call_id": tc["id"], "content": "ok"} for tc in tool_calls]
+
+        async def on_round(round_num, result, messages):
+            return None
+
+        content, metadata = await client.chat_with_tools(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[{"type": "function", "function": {"name": "search_memory"}}],
+            tool_executor=mock_executor,
+            on_round_complete=on_round,
+            max_round_callbacks=2,
+            max_tool_rounds=1,
+        )
+
+        assert metadata["callback_count"] == 0  # on_round 返回 None，不递增
+        assert metadata["total_tool_calls"] > 0   # 确实走了 tool_calls 处理流程
+
+    @pytest.mark.asyncio
+    async def test_max_round_callbacks_stops_injection(self):
+        """callback_count 达到 max_round_callbacks 后不再注入"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                self._make_response("a"),
+                self._make_response("b"),
+                self._make_response("c"),
+            ]
+        )
+        client._client = mock_openai_client
+
+        async def on_round(round_num, result, messages):
+            return {"role": "system", "content": "inject"}
+
+        content, metadata = await client.chat_with_tools(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[],
+            on_round_complete=on_round,
+            max_round_callbacks=2,
+            max_tool_rounds=2,
+        )
+
+        assert metadata["callback_count"] == 2
+        # max_total_rounds = 2 + 2 = 4, but after 2 injections total_rounds=3
+        # then round 3 (total_rounds=4) returns "c" without injection (callback exhausted)
+
+    def _make_response(self, content: str):
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = content
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = None
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_max_total_rounds_enforced(self):
+        """total_rounds 达到 max_total_rounds 时强制退出"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                self._make_response("a"),
+                self._make_response("b"),
+            ]
+        )
+        client._client = mock_openai_client
+
+        async def on_round(round_num, result, messages):
+            return {"role": "system", "content": "inject"}
+
+        content, metadata = await client.chat_with_tools(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[],
+            on_round_complete=on_round,
+            max_round_callbacks=1,
+            max_tool_rounds=1,
+        )
+
+        # max_total_rounds = 1 + 1 = 2
+        # round 0: "a" -> inject (callback_count=1, total_rounds=1)
+        # round 1: "b" -> callback exhausted, return "b" (total_rounds=2)
+        assert content == "b"
+        assert metadata["callback_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_with_forced_tool_does_not_accept_callback(self):
+        """generate_with_forced_tool 签名不包含 callback 参数"""
+        import inspect
+        sig = inspect.signature(LLMClient.generate_with_forced_tool)
+        assert "on_round_complete" not in sig.parameters
+        assert "max_round_callbacks" not in sig.parameters

--- a/tests/unit/persona/test_context_builder.py
+++ b/tests/unit/persona/test_context_builder.py
@@ -220,5 +220,72 @@ class TestContextBuilderSpeakerPrefix:
         assert "[你]" in system_content or "[我]" in system_content
 
 
+class TestContextBuilderSegmentGuide:
+    """测试分段回复引导文本注入"""
+
+    def _make_character(self):
+        return Character(
+            name="苏晓",
+            description="一个温柔的AI伴侣",
+        )
+
+    def test_segment_guide_injected_with_defaults(self):
+        char = self._make_character()
+        from plugins.DicePP.module.persona.chat.context import SegmentGuide
+        builder = ContextBuilder(
+            char,
+            segment_guide=SegmentGuide(
+                enabled=True, target_chars=30, max_chars=80, soft_limit=100, hard_limit=120
+            ),
+        )
+        messages = builder.build(short_term_history=[], current_message="hi")
+        system = messages[0]["content"]
+        assert "send_reply_segment" in system
+        assert "30" in system  # target_chars
+        assert "80" in system  # max_chars
+        assert "100" in system  # soft_limit
+        assert "120" in system  # hard_limit
+        assert "delay_before" in system
+
+    def test_segment_guide_reflects_custom_values(self):
+        char = self._make_character()
+        from plugins.DicePP.module.persona.chat.context import SegmentGuide
+        builder = ContextBuilder(
+            char,
+            segment_guide=SegmentGuide(
+                enabled=True, target_chars=50, max_chars=100, soft_limit=200, hard_limit=250
+            ),
+        )
+        messages = builder.build(short_term_history=[], current_message="hi")
+        system = messages[0]["content"]
+        assert "50" in system
+        assert "100" in system
+        assert "200" in system
+        assert "250" in system
+
+    def test_segment_guide_placed_after_character_info(self):
+        char = self._make_character()
+        from plugins.DicePP.module.persona.chat.context import SegmentGuide
+        builder = ContextBuilder(
+            char,
+            segment_guide=SegmentGuide(
+                enabled=True, target_chars=30, max_chars=80, soft_limit=100, hard_limit=120
+            ),
+        )
+        messages = builder.build(short_term_history=[], current_message="hi")
+        system = messages[0]["content"]
+        name_idx = system.index("苏晓")
+        guide_idx = system.index("【回复规则】")
+        remind_idx = system.index("请记住用户说过的话")
+        assert name_idx < guide_idx < remind_idx
+
+    def test_segment_guide_disabled_when_segment_enabled_false(self):
+        char = self._make_character()
+        builder = ContextBuilder(char, segment_guide=None)
+        messages = builder.build(short_term_history=[], current_message="hi")
+        system = messages[0]["content"]
+        assert "【回复规则】" not in system
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/persona/test_factory_smoke.py
+++ b/tests/unit/persona/test_factory_smoke.py
@@ -137,13 +137,15 @@ async def test_create_persona_success_registers_three_tools(monkeypatch):
     assert "search_memory" in names, f"缺失 search_memory，实际注册: {names}"
     assert "search_chat_history" in names, f"缺失 search_chat_history，实际注册: {names}"
     assert "roll_dice" in names, f"缺失 roll_dice，实际注册: {names}"
-    assert len(names) == 3, f"期望恰好 3 个工具，实际: {names}"
+    assert "send_reply_segment" in names, f"缺失 send_reply_segment，实际注册: {names}"
+    assert len(names) == 4, f"期望恰好 4 个工具，实际: {names}"
 
     # R6: 跨组件引用一致性
     assert app.chat is not None
     assert app.life is not None
     assert app.store is not None
     assert app.port is not None
+    assert app.segment_dispatcher is not None
     assert app.chat.port is app.port
     assert app.life.scheduler is not None
     assert app.life.character_life is not None

--- a/tests/unit/persona/test_message_port.py
+++ b/tests/unit/persona/test_message_port.py
@@ -62,3 +62,49 @@ async def test_send_without_proxy_drops_silently():
     await port._send(user_id="u1", group_id="", content="hi")
 
     # 不应抛 AttributeError；测试通过即代表降级生效
+
+
+@pytest.mark.asyncio
+async def test_send_now_success_awaits_send():
+    bot = _make_bot()
+    port = MessagePort(bot)
+
+    result = await port.send_now("u1", "g1", "hello", skip_history_record=True)
+
+    assert result is True
+    bot.proxy.process_bot_command.assert_awaited_once()
+    cmd = bot.proxy.process_bot_command.await_args.args[0]
+    assert cmd.msg == "hello"
+    assert cmd.skip_history_record is True
+
+
+@pytest.mark.asyncio
+async def test_send_now_failure_returns_false_and_calls_on_delivery_failed():
+    bot = _make_bot()
+    bot.proxy.process_bot_command = AsyncMock(side_effect=RuntimeError("net down"))
+    on_failed = AsyncMock()
+    port = MessagePort(bot, on_delivery_failed=on_failed)
+
+    result = await port.send_now("u1", "", "oops")
+
+    assert result is False
+    on_failed.assert_awaited_once()
+    kwargs = on_failed.await_args.kwargs
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["content"] == "oops"
+
+
+@pytest.mark.asyncio
+async def test_send_now_pipeline_stages_still_applied():
+    bot = _make_bot()
+    from plugins.DicePP.module.persona.gateway.pipeline import MessagePipeline, TruncateStage
+
+    pipeline = MessagePipeline()
+    pipeline.add(TruncateStage(max_chars=5))
+    port = MessagePort(bot, pipeline=pipeline)
+
+    result = await port.send_now("u1", "", "very long content")
+
+    assert result is True
+    cmd = bot.proxy.process_bot_command.await_args.args[0]
+    assert cmd.msg == "ve..."  # truncated by TruncateStage (max_chars=5 -> 2 chars + "...")

--- a/tests/unit/persona/test_models.py
+++ b/tests/unit/persona/test_models.py
@@ -148,6 +148,40 @@ class TestPersonaConfig:
         assert ModelTier.PRIMARY == "primary"
         assert ModelTier.AUXILIARY == "auxiliary"
 
+    def test_segment_defaults(self):
+        """测试分段回复配置默认值"""
+        config = PersonaConfig()
+        assert config.segment_enabled is True
+        assert config.segment_target_chars == 30
+        assert config.segment_max_chars == 80
+        assert config.segment_soft_limit == 100
+        assert config.segment_hard_limit == 120
+        assert config.segment_count_max == 10
+        assert config.segment_max_delay == 10.0
+        assert config.segment_round_callbacks_max == 3
+
+    def test_segment_soft_limit_must_not_exceed_hard(self):
+        """soft_limit > hard_limit 时构造应抛 ValidationError"""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            PersonaConfig(
+                segment_soft_limit=150,
+                segment_hard_limit=120,
+            )
+        assert "segment_soft_limit" in str(exc_info.value)
+
+    def test_segment_positive_constraints(self):
+        """正数字段边界校验"""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PersonaConfig(segment_max_chars=0)
+        with pytest.raises(ValidationError):
+            PersonaConfig(segment_count_max=0)
+        with pytest.raises(ValidationError):
+            PersonaConfig(segment_max_delay=0)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/persona/test_persona_app.py
+++ b/tests/unit/persona/test_persona_app.py
@@ -5,9 +5,11 @@ PersonaApp 是工厂 create_persona 的返回值，持有 chat/life/store/port �
 """
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 
 from plugins.DicePP.module.persona.factory import PersonaApp
+from plugins.DicePP.module.persona.command import PersonaCommand
+from plugins.DicePP.module.persona.chat.session import ChatSession
 
 
 def _make_app() -> PersonaApp:
@@ -58,3 +60,65 @@ async def test_update_character_handles_missing_scheduler():
 
     app.chat.update_character.assert_called_once_with(new_char)
     app.life.update_character.assert_called_once_with(new_char)
+
+
+@pytest.mark.asyncio
+async def test_chat_with_user_returns_falsy_when_segmented():
+    """分段模式下 ChatSession.chat 返回 falsy `_SegmentedSentinel`，PersonaApp 应透传"""
+    app = _make_app()
+    sentinel = ChatSession._SegmentedSentinel("")
+    app.chat.chat = AsyncMock(return_value=sentinel)
+
+    result = await app.chat_with_user("u1", "g1", "hello", "nick")
+
+    assert result is not None
+    assert not result
+    assert isinstance(result, ChatSession._SegmentedSentinel)
+    app.chat.chat.assert_awaited_once_with("u1", "g1", "hello", "nick")
+
+
+@pytest.mark.asyncio
+async def test_chat_with_user_returns_str_when_not_segmented():
+    """非分段模式下 ChatSession.chat 返回字符串，PersonaApp 应透传字符串"""
+    app = _make_app()
+    app.chat.chat = AsyncMock(return_value="hello world")
+
+    result = await app.chat_with_user("u1", "g1", "hello", "nick")
+
+    assert result == "hello world"
+    app.chat.chat.assert_awaited_once_with("u1", "g1", "hello", "nick")
+
+
+@pytest.mark.asyncio
+async def test_shutdown_calls_segment_dispatcher_shutdown():
+    """PersonaCommand.shutdown 应调用 app.segment_dispatcher.shutdown()"""
+    bot = MagicMock()
+    bot.config.persona_ai = MagicMock()
+    bot.config.persona_ai.enabled = True
+
+    app = _make_app()
+    app.segment_dispatcher = AsyncMock()
+
+    cmd = PersonaCommand(bot)
+    cmd.app = app
+
+    await cmd.shutdown()
+
+    app.segment_dispatcher.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_handles_none_dispatcher():
+    """PersonaCommand.shutdown 在 segment_dispatcher 为 None 时不应抛异常"""
+    bot = MagicMock()
+    bot.config.persona_ai = MagicMock()
+    bot.config.persona_ai.enabled = True
+
+    app = _make_app()
+    app.segment_dispatcher = None
+
+    cmd = PersonaCommand(bot)
+    cmd.app = app
+
+    # 不应抛异常
+    await cmd.shutdown()


### PR DESCRIPTION
## Summary

- 实现 persona 分段回复 v4：通过 `SegmentDispatcher` + `send_reply_segment` 工具，让 LLM 按段实时输出回复
- 修复 review4 反馈三项（R1 计费契约、R2 注入分支可观测性、R4 sentinel 透传）

## 主体改动（分段回复 v4）

- **SegmentDispatcher**：按 `target_key` 维护独立 asyncio worker，实现按段实时发送、节流与去重
- **send_reply_segment 工具**：LLM 通过工具调用按段输出，绕过整段 buffer 等待
- **ChatSession 分段路径**：`_chat_with_tools` 整合 SegmentDispatcher 与 `LLMCallCoordinator`，支持 buffered merge + 分段输出共存
- **`_SegmentedSentinel`**：继承 `str` 的哨兵类型，falsy 但携带类型信息，避免 `None` 与「分段已完成」语义冲突
- **配置新增**：`segment_target_chars` / `segment_max_chars` / `segment_soft_limit` / `segment_hard_limit` / `segment_count_max` / `segment_max_delay` / `segment_round_callbacks_max`

## Review 反馈修复

| Rn | 问题 | 修复 |
|----|------|------|
| **R1** | 原计费仅在 `status=success` 扣 1 次，buffered merge 触发的中间轮全部白嫖；`max_iterations` 失败时 0 扣费 | 计费迁移到 `_coordinator_on_result`（中间轮）+ success 路径（最终轮），契约改为「N 轮 → N 次扣费」。`_coordinator_on_result` 添加完整 docstring 含 6 个场景时间轴 |
| **R2** | `_on_segment_round_complete` 注入分支静默，「LLM 未调用 send_reply_segment」次优路径无法诊断 | 注入分支前加 `logger.warning`，带 round 编号 + content_preview |
| **R4** | `_chat_via_coordinator` 把 sentinel 转 `None` 返回，导致分段路径下群活跃度漏更新 | 删除 sentinel→None 转换，调用方三段式判定：`is None` 早退 → 群活跃度更新（无条件） → `if response` 才 `_send` |

R3（参数合理性归档）已共识·延后，归档至 backlog `B-260508-1f1b9e`，本 PR 不含。

## Test plan

- [x] `tests/unit/persona`、`tests/integration/persona`：474 passed
- [x] 全套件 `uv run pytest`：1622 passed
- [x] R4 回归 `TestSegmentedPathPreservesGroupActivity`：分段路径走活跃度但不重发 / `None` 路径完全短路
- [x] R1 计费回归：`test_chat_session_charging.py` 验证 N 次调用 → N 次扣费
- [ ] dicepp-shell 交互式验收（可在 review 阶段补）

## 备注

- 远端 master 3 个新 commit（`ba920e7` / `4956e17` / `e74d9b1`）已 rebase，冲突点在 `pydantic_models.py`（`e74d9b1` 删除了 `ProactiveGreetingEntry` 死代码，本 commit 保留删除并对齐 import）