### PR TITLE
fix(persona): add_group_conversation 去掉显式 BEGIN 避免事务嵌套报错

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -26,21 +26,6 @@
     - 影响面: 仅死代码删除, character_life 已有 wake_up/good_night 槽位机制不受影响
     - 风险: 低 (零消费者), 但需确认 bot 配置文件 config/bots/*.json 不会因严格模式 pydantic 校验报错
 
-### [B-260507-7127d2] add_group_conversation 在 post_send_hook 回调中事务嵌套报错
-- 创建: 2026-05-07
-- 问题表现:
-  - 日志原文: "旁听群消息写入失败: cannot start a transaction within a transaction"
-  - 触发路径: `_group_chat_recorder` (command.py:115) → `add_group_conversation` (store.py:271) → `BEGIN` 失败
-  - `store.py:284` 显式 `BEGIN`/`commit` 用于保证 INSERT + 裁剪 DELETE 在同一事务
-  - aiosqlite 异步共享连接，若外层已有事务，再次 `BEGIN` 失败
-  - 后果: 该次群聊消息漏写，无法回放
-- 工作计划:
-  - 加 stack trace 日志定位调用栈，在 dev 复现一次（需制造并发写入）
-  - 方案 A: `add_group_conversation` 改用 SAVEPOINT 兼容嵌套
-  - 方案 B: 拆掉显式事务，依赖 aiosqlite 隐式 autocommit（需评估裁剪与 INSERT 不在同事务的一致性影响）
-  - 方案 C: 裁剪改为异步任务，与 INSERT 解耦
-  - 影响面: `data/store.py:add_group_conversation`、所有显式调用路径（command.py、chat/session.py 多处）
-
 ### [B-260507-9b9094] 评分失败持久化记录与触发条件改造
 - 创建: 2026-05-07
 - 问题表现:

--- a/src/plugins/DicePP/module/persona/data/store.py
+++ b/src/plugins/DicePP/module/persona/data/store.py
@@ -276,39 +276,44 @@ class PersonaDataStore:
         content: str,
         display_name: str = "",
     ) -> None:
-        """添加群聊消息并在同一事务中执行群级裁剪
+        """添加群聊消息并执行群级裁剪
 
         群聊历史按 group_id 共享，私聊历史继续使用 persona_messages 按 user_id+group_id 隔离。
+        INSERT 与裁剪 DELETE 走 sqlite3 隐式事务，由末尾一次 commit 一并提交。
+
+        本类所有写方法均依赖 aiosqlite 默认 ``isolation_level=""`` 的隐式事务
+        （首条 DML 自动 BEGIN，commit 一次性提交累积写）。aiosqlite 共享单连接、
+        多协程交错时，任何前置未 commit 的 DML 都会让显式 ``await db.execute("BEGIN")``
+        触发 ``cannot start a transaction within a transaction``
+        （历史踩坑入口为 ``_group_chat_recorder`` post_send hook，但触发面不限于此）。
+
+        原子性依赖于"调用期间无其它协程在共享连接上 commit"——store.py
+        所有写方法均共享此隐式约定。极端竞态下可能出现裁剪滞后一次的瞬态，
+        不影响最终一致性。
         """
         now_iso = self._wall_now().isoformat()
-        await self.db.execute("BEGIN")
-        try:
-            await self.db.execute(
-                """
-                INSERT INTO persona_group_conversations
-                (group_id, user_id, role, content, display_name, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (group_id, user_id, role, content, display_name, now_iso),
-            )
-            # 同一事务内执行裁剪
-            await self.db.execute(
-                """
-                DELETE FROM persona_group_conversations
+        await self.db.execute(
+            """
+            INSERT INTO persona_group_conversations
+            (group_id, user_id, role, content, display_name, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (group_id, user_id, role, content, display_name, now_iso),
+        )
+        await self.db.execute(
+            """
+            DELETE FROM persona_group_conversations
+            WHERE group_id = ?
+              AND id NOT IN (
+                SELECT id FROM persona_group_conversations
                 WHERE group_id = ?
-                  AND id NOT IN (
-                    SELECT id FROM persona_group_conversations
-                    WHERE group_id = ?
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT ?
-                )
-                """,
-                (group_id, group_id, self._group_max_messages),
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
             )
-            await self.db.commit()
-        except Exception:
-            await self.db.rollback()
-            raise
+            """,
+            (group_id, group_id, self._group_max_messages),
+        )
+        await self.db.commit()
 
     async def get_group_conversations(
         self,

--- a/tests/unit/persona/test_data_store.py
+++ b/tests/unit/persona/test_data_store.py
@@ -638,7 +638,8 @@ class TestGroupConversationCRUD:
 
     @pytest.mark.asyncio
     async def test_add_group_conversation_auto_prune(self, temp_db):
-        """1.7: write+prune happens in a single transaction via add_group_conversation"""
+        """1.7: write + prune 在同一次调用内完成（依赖 sqlite3 隐式事务 + end-of-call commit），
+        裁剪结果按 _group_max_messages 生效"""
         store = temp_db
         store._group_max_messages = 3
         for i in range(5):
@@ -649,6 +650,29 @@ class TestGroupConversationCRUD:
         assert msgs[0].content == "msg2"
         assert msgs[1].content == "msg3"
         assert msgs[2].content == "msg4"
+
+    @pytest.mark.asyncio
+    async def test_add_group_conversation_no_explicit_begin_regression(self, temp_db):
+        """# B-260507-7127d2 regression: 断言 add_group_conversation 不再 issue 显式 BEGIN。
+
+        仅模拟"前置 DML 已开启隐式事务"作为最小复现场景；真实触发路径是
+        aiosqlite 共享单连接 + 多协程并发写（如 ``_persist_assistant_message``、
+        observation_buffer 旁听同时进行）。本用例不背书"嵌套事务"为支持语义，
+        目标是断言本方法不再 issue 显式 BEGIN。
+        """
+        store = temp_db
+        # 制造未 commit 的隐式事务: 直接 DML 但不 commit
+        await store.db.execute(
+            "INSERT INTO persona_messages (user_id, group_id, role, content, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("u_pre", "g_pre", "user", "pre-flight", "2024-01-01T00:00:00"),
+        )
+        # 这一行在旧实现下会抛 sqlite3.OperationalError
+        await store.add_group_conversation("g1", "u1", "user", "hello", "Alice")
+        msgs = await store.get_group_conversations("g1")
+        assert len(msgs) == 1
+        assert msgs[0].content == "hello"
+        assert msgs[0].display_name == "Alice"
 
     @pytest.mark.asyncio
     async def test_search_group_conversations_keyword(self, temp_db):


### PR DESCRIPTION
## Summary
- 移除 `store.py` 显式 `BEGIN`/`commit`/`rollback`，让 INSERT + 裁剪 DELETE 走 sqlite3 隐式事务，与 store.py 其它写方法风格一致
- 新增回归测试 `test_add_group_conversation_no_explicit_begin_regression`，旧代码下精准复现 `cannot start a transaction within a transaction`
- 同步改进 docstring，说明根因为 aiosqlite 单连接多协程并发，不限于 post_send_hook 单一路径
- 关闭 backlog B-260507-7127d2

## Commits
- 294252c fix(persona): add_group_conversation 去掉显式 BEGIN 避免事务嵌套报错