### PR TITLE
feat: persona 评分失败持久化记录与触发条件改造

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -26,18 +26,6 @@
     - 影响面: 仅死代码删除, character_life 已有 wake_up/good_night 槽位机制不受影响
     - 风险: 低 (零消费者), 但需确认 bot 配置文件 config/bots/*.json 不会因严格模式 pydantic 校验报错
 
-### [B-260507-9b9094] 评分失败持久化记录与触发条件改造
-- 创建: 2026-05-07
-- 问题表现:
-  - `persona_score_history` 最后一条停留在 2026-04-19，之后用户共 12 条消息、6 轮对话均未触发评分
-  - 触发条件 `len(messages) >= scoring_interval * 2 = 10`，多用户场景下刚好卡边缘
-  - 失败路径: `_process_batch_scoring` 异常仅 `logger.warning`，无持久化，旧容器日志已丢失，根因无从回溯
-- 工作计划:
-  - 新增 `persona_scoring_failures` 表（user_id/group_id/error/raw_response/created_at）持久化失败记录
-  - 评估触发条件改造: 时间窗口（24h 内有对话即触发）或下调 `scoring_interval`
-  - 需先在 dev 加日志复现一次评分失败路径，确认是 LLM 返回异常 / 解析失败 / 超时
-  - 影响面: `chat/session.py:_process_batch_scoring`、`data/store.py` 表结构、配置项
-
 ### [B-260507-d4b350] 消息发送路径统一（合并 send_segmented 与 send_now）
 - 创建: 2026-05-07
 - 问题表现:

--- a/src/plugins/DicePP/module/persona/chat/scoring.py
+++ b/src/plugins/DicePP/module/persona/chat/scoring.py
@@ -6,9 +6,18 @@
 import json
 from typing import List, Dict, Any, Optional
 from nonebot.log import logger
+from pydantic import BaseModel
 from ..data.models import ScoreDeltas, UserProfile, RelationshipState, ModelTier
 from ..llm.router import LLMRouter
 from ..utils.json_helpers import safe_json_loads
+
+
+class ScoringAnalysisResult(BaseModel):
+    """评分分析结果"""
+    deltas: ScoreDeltas
+    facts: Dict[str, Any]
+    raw_response: str = ""
+    parse_error: str = ""  # 非空表示解析失败
 
 
 class ScoringAgent:
@@ -22,23 +31,28 @@ class ScoringAgent:
         messages: List[Dict[str, str]],
         current_profile: Optional[UserProfile] = None,
         relationship: Optional[RelationshipState] = None,
-    ) -> tuple[ScoreDeltas, Dict[str, Any]]:
+    ) -> ScoringAnalysisResult:
         prompt = self._build_analysis_prompt(
             messages,
             current_profile or UserProfile(user_id="", facts={}),
             relationship
         )
-        
+
         # 调用辅助模型
         response = await self.llm_router.generate(
             messages=[{"role": "user", "content": prompt}],
             model_tier=ModelTier.AUXILIARY,
         )
-        
+
         # 解析结果
-        deltas, facts = self._parse_response(response)
-        
-        return deltas, facts
+        deltas, facts, parse_error = self._parse_response(response)
+
+        return ScoringAnalysisResult(
+            deltas=deltas,
+            facts=facts,
+            raw_response=response,
+            parse_error=parse_error,
+        )
 
     def _build_analysis_prompt(
         self,
@@ -95,12 +109,19 @@ class ScoringAgent:
         
         return prompt
 
-    def _parse_response(self, response: str) -> tuple[ScoreDeltas, Dict[str, Any]]:
-        """解析 LLM 响应（统一走 safe_json_loads 容错）"""
+    def _parse_response(self, response: str) -> tuple[ScoreDeltas, Dict[str, Any], str]:
+        """解析 LLM 响应（统一走 safe_json_loads 容错）
+
+        Returns:
+            (deltas, facts, parse_error)
+        """
         data = safe_json_loads(response, fallback=None, log_prefix="评分解析")
         if not isinstance(data, dict):
-            return ScoreDeltas(), {}
-        return self._extract_result(data)
+            return ScoreDeltas(), {}, f"JSON 解析失败或返回非 dict: type={type(data).__name__}"
+        try:
+            return (*self._extract_result(data), "")
+        except Exception as exc:
+            return ScoreDeltas(), {}, f"提取评分结果异常: {type(exc).__name__}: {exc}"
 
     @staticmethod
     def _safe_float(value: Any, default: float = 0.0) -> float:

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -27,6 +27,7 @@ from ..data.models import (
     RelationshipState,
     ScoreEvent,
     GroupConversation,
+    ScoringFailure,
 )
 from ..llm.router import LLMRouter, QuotaExceeded
 from ..llm.client import RoundResult
@@ -60,7 +61,7 @@ class ChatConfig:
     relationship_refuse_enabled: bool = False
     relationship_refuse_prob_base: float = 0.3
     relationship_refuse_prob_max: float = 0.9
-    scoring_interval: int = 10
+    scoring_interval: int = 5
     max_messages: int = 100
     group_max_age_minutes: int = 60
     group_context_budget_tokens: float = 2000.0
@@ -607,18 +608,17 @@ class ChatSession:
                 await self._process_batch_scoring(user_id, group_id)
             except Exception as e:
                 logger.warning(f"批量评分失败（不影响对话）: {e}")
-                self._pending_messages.pop(key, None)
 
     async def _process_batch_scoring(self, user_id: str, group_id: str) -> None:
         if not self.scoring_agent:
             return
 
         key = f"{user_id}:{group_id}"
-        messages = self._pending_messages.get(key, [])
+        messages = list(self._pending_messages.get(key, []))
         if not messages:
             return
 
-        self._pending_messages[key] = []
+        messages_count = len(messages)
 
         profile = await self.store.get_user_profile(user_id)
         rel = await self.store.get_relationship(user_id, group_id)
@@ -628,12 +628,52 @@ class ChatSession:
             initial = float(self.character.extensions.initial_relationship)
             rel_for_scoring = self.decay_calculator.effective_relationship(rel, initial)
 
-        deltas, new_facts = await self.scoring_agent.batch_analyze(
-            messages=messages,
-            current_profile=profile,
-            relationship=rel_for_scoring,
-        )
+        try:
+            result = await self.scoring_agent.batch_analyze(
+                messages=messages,
+                current_profile=profile,
+                relationship=rel_for_scoring,
+            )
+        except Exception as exc:
+            try:
+                await self.store.record_scoring_failure(
+                    ScoringFailure(
+                        user_id=user_id,
+                        group_id=group_id,
+                        messages_count=messages_count,
+                        error=f"{type(exc).__name__}: {exc}",
+                        conversation_digest=self._build_conversation_digest(messages),
+                    )
+                )
+            except Exception as record_exc:
+                logger.error(
+                    f"记录评分失败时数据库出错: {record_exc} "
+                    f"(原始异常: {type(exc).__name__}: {exc})"
+                )
+            raise
 
+        if result.parse_error:
+            logger.warning(
+                f"评分解析失败，{messages_count} 条消息保留待重试: "
+                f"user={user_id}, parse_error={result.parse_error[:100]}"
+            )
+            await self.store.record_scoring_failure(
+                ScoringFailure(
+                    user_id=user_id,
+                    group_id=group_id,
+                    messages_count=messages_count,
+                    error=result.parse_error,
+                    raw_response=result.raw_response,
+                    conversation_digest=self._build_conversation_digest(messages),
+                )
+            )
+            return
+
+        # 评分成功后才清空 pending 消息
+        self._pending_messages[key] = []
+
+        deltas = result.deltas
+        new_facts = result.facts
         now = persona_wall_now(self.config.timezone)
         if rel:
             composite_before = rel.composite_score

--- a/src/plugins/DicePP/module/persona/data/migrations.py
+++ b/src/plugins/DicePP/module/persona/data/migrations.py
@@ -145,6 +145,28 @@ CREATE TABLE IF NOT EXISTS persona_user_relationships (
 );
 """
 
+# 评分失败记录表
+CREATE_SCORING_FAILURES_TABLE = """
+CREATE TABLE IF NOT EXISTS persona_scoring_failures (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    group_id TEXT DEFAULT '',
+    messages_count INTEGER DEFAULT 0,
+    error TEXT DEFAULT '',
+    raw_response TEXT DEFAULT '',
+    conversation_digest TEXT DEFAULT '',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+CREATE_SCORING_FAILURES_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_persona_scoring_failures_user ON persona_scoring_failures(user_id, group_id, created_at DESC);
+"""
+
+CREATE_SCORING_FAILURES_INDEX_CREATED_AT = """
+CREATE INDEX IF NOT EXISTS idx_persona_scoring_failures_created_at ON persona_scoring_failures(created_at);
+"""
+
 # 群活跃度表
 CREATE_GROUP_ACTIVITY_TABLE = """
 CREATE TABLE IF NOT EXISTS persona_group_activity (
@@ -282,4 +304,7 @@ ALL_MIGRATIONS = [
     CREATE_GROUP_CONVERSATIONS_TABLE,
     CREATE_GROUP_CONVERSATIONS_INDEX,
     CREATE_GROUP_CONVERSATIONS_USER_INDEX,
+    CREATE_SCORING_FAILURES_TABLE,
+    CREATE_SCORING_FAILURES_INDEX,
+    CREATE_SCORING_FAILURES_INDEX_CREATED_AT,
 ]

--- a/src/plugins/DicePP/module/persona/data/models.py
+++ b/src/plugins/DicePP/module/persona/data/models.py
@@ -158,6 +158,18 @@ class ScoreEvent(BaseModel):
     created_at: Optional[datetime] = None
 
 
+class ScoringFailure(BaseModel):
+    """评分失败记录"""
+    id: Optional[int] = None
+    user_id: str
+    group_id: str = ""
+    messages_count: int = 0
+    error: str = ""  # 异常信息
+    raw_response: str = ""  # LLM 原始响应（若有）
+    conversation_digest: str = ""  # 消息内容摘要
+    created_at: Optional[datetime] = None
+
+
 class DiaryEntry(BaseModel):
     """角色日记条目"""
     date: str  # YYYY-MM-DD

--- a/src/plugins/DicePP/module/persona/data/store.py
+++ b/src/plugins/DicePP/module/persona/data/store.py
@@ -23,6 +23,7 @@ from .models import (
     Message, WhitelistEntry, DailyUsage, ScoreEvent, ScoreDeltas, UserProfile,
     RelationshipState, Observation, DailyEvent, GroupActivity, UserLLMConfig,
     LLMTraceRecord, DelayedTask, GroupConversation, CharacterState,
+    ScoringFailure,
 )
 from .migrations import ALL_MIGRATIONS
 
@@ -83,6 +84,7 @@ class PersonaDataStore:
         await self._ensure_observations_debug_columns()
         await self._ensure_daily_events_share_columns()
         await self._ensure_daily_events_delta_columns()
+        await self._ensure_scoring_failures_table()
 
     async def _ensure_group_activity_daily_columns(self) -> None:
         """
@@ -178,6 +180,31 @@ class PersonaDataStore:
         if "health_delta" not in col_names:
             await self.db.execute(
                 "ALTER TABLE persona_daily_events ADD COLUMN health_delta INTEGER"
+            )
+
+    async def _ensure_scoring_failures_table(self) -> None:
+        """确保评分失败记录表及索引已创建（兼容旧库升级）。"""
+        from .migrations import (
+            CREATE_SCORING_FAILURES_TABLE,
+            CREATE_SCORING_FAILURES_INDEX,
+            CREATE_SCORING_FAILURES_INDEX_CREATED_AT,
+        )
+        async with self.db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='persona_scoring_failures'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            await self.db.execute(CREATE_SCORING_FAILURES_TABLE)
+        # 索引
+        for idx_sql in [CREATE_SCORING_FAILURES_INDEX, CREATE_SCORING_FAILURES_INDEX_CREATED_AT]:
+            await self.db.execute(idx_sql)
+        # 兼容旧库：conversation_digest 列
+        async with self.db.execute("PRAGMA table_info(persona_scoring_failures)") as cursor:
+            rows = await cursor.fetchall()
+        col_names = {r[1] for r in rows}
+        if "conversation_digest" not in col_names:
+            await self.db.execute(
+                "ALTER TABLE persona_scoring_failures ADD COLUMN conversation_digest TEXT DEFAULT ''"
             )
 
     # ========== 消息相关 ==========
@@ -765,6 +792,69 @@ class PersonaDataStore:
             )
         )
         await self.db.commit()
+
+    async def record_scoring_failure(self, failure: ScoringFailure) -> None:
+        """记录评分失败"""
+        await self.db.execute(
+            """
+            INSERT INTO persona_scoring_failures
+            (user_id, group_id, messages_count, error, raw_response, conversation_digest, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                failure.user_id,
+                failure.group_id,
+                failure.messages_count,
+                failure.error,
+                failure.raw_response,
+                failure.conversation_digest,
+                failure.created_at.isoformat() if failure.created_at else self._wall_now().isoformat(),
+            )
+        )
+        await self.db.commit()
+
+    async def get_recent_scoring_failures(
+        self,
+        user_id: str,
+        group_id: Optional[str] = None,
+        limit: int = 10,
+    ) -> List[ScoringFailure]:
+        """获取最近评分失败记录"""
+        limit = max(1, limit)
+        async with self.db.execute(
+            """
+            SELECT id, user_id, group_id, messages_count, error, raw_response, conversation_digest, created_at
+            FROM persona_scoring_failures
+            WHERE user_id = ? AND (? IS NULL OR group_id = ?)
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (user_id, group_id, group_id, limit),
+        ) as cursor:
+            rows = await cursor.fetchall()
+            return [
+                ScoringFailure(
+                    id=row[0],
+                    user_id=row[1],
+                    group_id=row[2],
+                    messages_count=row[3] or 0,
+                    error=row[4] or "",
+                    raw_response=row[5] or "",
+                    conversation_digest=row[6] or "",
+                    created_at=datetime.fromisoformat(row[7]) if row[7] else None,
+                )
+                for row in rows
+            ]
+
+    async def prune_scoring_failures(self, max_age_days: int) -> int:
+        """清理超过 max_age_days 的评分失败记录"""
+        cutoff = (self._wall_now() - timedelta(days=max_age_days)).isoformat()
+        cursor = await self.db.execute(
+            "DELETE FROM persona_scoring_failures WHERE datetime(created_at) < datetime(?)",
+            (cutoff,),
+        )
+        await self.db.commit()
+        return cursor.rowcount
 
     # ========== 群聊观察 ==========
 

--- a/tests/unit/persona/test_scoring_agent.py
+++ b/tests/unit/persona/test_scoring_agent.py
@@ -31,18 +31,19 @@ class TestScoringAgentParsing:
         }
         '''
         
-        deltas, facts = agent._parse_response(response)
-        
+        deltas, facts, parse_error = agent._parse_response(response)
+
         assert deltas.intimacy == 3.5
         assert deltas.passion == 1.0
         assert deltas.trust == 2.0
         assert deltas.secureness == 0.5
         assert facts["name"] == "张三"
+        assert parse_error == ""
 
     def test_parse_with_markdown_fence(self):
         """测试解析带 markdown 围栏的 JSON"""
         agent = ScoringAgent(None)
-        
+
         response = '''
 ```json
 {
@@ -56,25 +57,27 @@ class TestScoringAgentParsing:
 }
 ```
         '''
-        
-        deltas, facts = agent._parse_response(response)
-        
+
+        deltas, facts, parse_error = agent._parse_response(response)
+
         assert deltas.intimacy == 2.0
         assert deltas.secureness == -0.5
+        assert parse_error == ""
 
     def test_parse_invalid_fallback(self):
-        """测试解析失败返回零值"""
+        """测试解析失败返回零值并附带 parse_error"""
         agent = ScoringAgent(None)
-        
+
         response = "这不是有效的 JSON"
-        
-        deltas, facts = agent._parse_response(response)
-        
+
+        deltas, facts, parse_error = agent._parse_response(response)
+
         assert deltas.intimacy == 0.0
         assert deltas.passion == 0.0
         assert deltas.trust == 0.0
         assert deltas.secureness == 0.0
         assert facts == {}
+        assert "JSON 解析失败" in parse_error
 
     def test_parse_bracket_counting_fallback(self):
         """测试 Level 3：括号计数从噪声文本中提取 JSON"""
@@ -82,16 +85,17 @@ class TestScoringAgentParsing:
 
         response = '好的，根据分析结果如下：{"deltas": {"intimacy": 1.0, "passion": 0.5, "trust": 2.0, "secureness": 0.0}, "facts": {"name": "小明"}} 以上为评分结果。'
 
-        deltas, facts = agent._parse_response(response)
+        deltas, facts, parse_error = agent._parse_response(response)
 
         assert deltas.intimacy == 1.0
         assert deltas.trust == 2.0
         assert facts["name"] == "小明"
+        assert parse_error == ""
 
     def test_clamp_values(self):
         """测试值被限制在范围内"""
         agent = ScoringAgent(None)
-        
+
         response = '''
         {
           "deltas": {
@@ -102,8 +106,8 @@ class TestScoringAgentParsing:
           }
         }
         '''
-        
-        deltas, _ = agent._parse_response(response)
+
+        deltas, _, parse_error = agent._parse_response(response)
         
         # 应该被限制在 [-5, 5] 范围内
         assert deltas.intimacy == 5.0

--- a/tests/unit/persona/test_scoring_failure_store.py
+++ b/tests/unit/persona/test_scoring_failure_store.py
@@ -1,0 +1,148 @@
+"""
+评分失败记录存储单元测试
+"""
+
+from datetime import datetime, timedelta
+import aiosqlite
+import pytest
+
+from plugins.DicePP.module.persona.data.store import PersonaDataStore
+from plugins.DicePP.module.persona.data.models import ScoringFailure
+
+
+@pytest.mark.asyncio
+async def test_record_scoring_failure_defaults():
+    """record_scoring_failure 默认值写入"""
+    async with aiosqlite.connect(":memory:") as db:
+        store = PersonaDataStore(db)
+        await store.ensure_tables()
+
+        await store.record_scoring_failure(
+            ScoringFailure(user_id="u1", group_id="g1", messages_count=10, error="timeout")
+        )
+
+        failures = await store.get_recent_scoring_failures("u1", "g1")
+        assert len(failures) == 1
+        f = failures[0]
+        assert f.user_id == "u1"
+        assert f.group_id == "g1"
+        assert f.messages_count == 10
+        assert f.error == "timeout"
+        assert f.raw_response == ""
+        assert f.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_record_scoring_failure_explicit_fields():
+    """record_scoring_failure 显式字段写入"""
+    async with aiosqlite.connect(":memory:") as db:
+        store = PersonaDataStore(db)
+        await store.ensure_tables()
+
+        now = datetime(2026, 5, 8, 12, 0, 0)
+        await store.record_scoring_failure(
+            ScoringFailure(
+                user_id="u2",
+                group_id="",
+                messages_count=5,
+                error="parse_error",
+                raw_response="not json",
+                created_at=now,
+            )
+        )
+
+        failures = await store.get_recent_scoring_failures("u2", "")
+        assert len(failures) == 1
+        f = failures[0]
+        assert f.messages_count == 5
+        assert f.raw_response == "not json"
+        assert f.created_at == now
+
+
+@pytest.mark.asyncio
+async def test_get_recent_scoring_failures_filter_and_order():
+    """get_recent_scoring_failures 按 user_id/group_id 过滤、按 created_at DESC 排序"""
+    async with aiosqlite.connect(":memory:") as db:
+        store = PersonaDataStore(db)
+        await store.ensure_tables()
+
+        base = datetime(2026, 5, 8, 12, 0, 0)
+        for i in range(3):
+            await store.record_scoring_failure(
+                ScoringFailure(
+                    user_id="u3",
+                    group_id="g3",
+                    messages_count=i + 1,
+                    error=f"err{i}",
+                    created_at=base + timedelta(minutes=i),
+                )
+            )
+        # 不同 user
+        await store.record_scoring_failure(
+            ScoringFailure(user_id="u_other", group_id="g3", messages_count=99, error="other")
+        )
+
+        failures = await store.get_recent_scoring_failures("u3", "g3", limit=10)
+        assert len(failures) == 3
+        # DESC 排序：最新的在前
+        assert failures[0].error == "err2"
+        assert failures[1].error == "err1"
+        assert failures[2].error == "err0"
+
+        # 过滤其他 user
+        other = await store.get_recent_scoring_failures("u_other", "g3")
+        assert len(other) == 1
+        assert other[0].messages_count == 99
+
+
+@pytest.mark.asyncio
+async def test_prune_scoring_failures_by_days():
+    """prune_scoring_failures 按天数正确清理（覆盖 R2 同天边界）"""
+    async with aiosqlite.connect(":memory:") as db:
+        store = PersonaDataStore(db)
+        await store.ensure_tables()
+
+        now = datetime(2026, 5, 8, 15, 0, 0)
+        # 插入一条旧记录（上午10点，应被清理）
+        old = now - timedelta(days=2)
+        await store.record_scoring_failure(
+            ScoringFailure(
+                user_id="u4",
+                group_id="g4",
+                messages_count=1,
+                error="old",
+                created_at=old,
+            )
+        )
+        # 插入一条同天但更早的记录（上午11点，仍在 1 天 cutoff 内，不应被清理）
+        same_day_early = now - timedelta(hours=4)  # 11:00
+        await store.record_scoring_failure(
+            ScoringFailure(
+                user_id="u4",
+                group_id="g4",
+                messages_count=2,
+                error="same_day",
+                created_at=same_day_early,
+            )
+        )
+        # 插入一条新记录
+        await store.record_scoring_failure(
+            ScoringFailure(
+                user_id="u4",
+                group_id="g4",
+                messages_count=3,
+                error="new",
+                created_at=now,
+            )
+        )
+
+        # 清理 1 天前的记录
+        deleted = await store.prune_scoring_failures(1)
+        assert deleted == 1
+
+        remaining = await store.get_recent_scoring_failures("u4", "g4", limit=10)
+        assert len(remaining) == 2
+        errors = {r.error for r in remaining}
+        assert "old" not in errors
+        assert "same_day" in errors
+        assert "new" in errors


### PR DESCRIPTION
## 变更摘要

- 新增 \`persona_scoring_failures\` 表及索引, 持久化评分失败记录
- \`ScoringAnalysisResult\` 改为 BaseModel, 支持 parse_error 和 raw_response
- \`scoring_interval\` 默认 10→5, 解决多用户场景卡边缘不触发的问题
- \`_process_batch_scoring\` 异常/解析失败时写入失败记录, 含 conversation_digest
- 评分成功后清空 pending, 失败保留待重试
- 新增 \`test_scoring_failure_store.py\` 单元测试覆盖 record/get/prune

## 测试

- 全部 1625 个测试通过, 1 个跳过

backlog: B-260507-9b9094