### PR TITLE
feat(persona): 统一 LLM timeout 配置为 chat/background 双字段

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -9,6 +9,19 @@
 
 ---
 
+## ci
+
+### [B-260508-93fe70] CI 没覆盖 integration 测试，回归保护层裸奔
+- 创建: 2026-05-08
+- 问题表现:
+  - .github/workflows/ci.yml:41 仅执行 pytest -m unit，整个 tests/integration/** 不会被 CI 触发
+  - 本次 timeout 收敛改动验证时发现 tests/integration/persona/test_command.py::TestAdminCommands::test_admin_events 在 origin/master 41d8973 之前就已 break，未被任何 CI/PR 拦截
+  - 用户面命令链路（IsolatedAsyncioTestCase 走 .ai admin events 等）恰好是 integration 标签，CI 长期裸奔
+- 工作计划:
+  - 在 ci.yml 增加 integration 测试 step：可改为 pytest -m "unit or integration" 单 job，或拆分为独立 job 便于失败定位
+  - 本机跑 tests/unit/persona + tests/integration/persona 共 494 用例约 58s，加进 CI 总时长可控
+  - 如担心 integration 偶发依赖（外部进程/真实 IO），先 grep tests/integration 确认无 real_llm/external_service 类需要单独 marker 隔离
+
 ## persona
 
 ### [B-260507-f9ea98] 厂商适配层根据模型类型选择 prompt 注入角色（system/user/developer）
@@ -34,12 +47,13 @@
     - 影响面：persona 模块所有出口消息（chat 非分段、`PersonaApp.send_message`、life 主动消息）
     - 风险点：需保证 life 主动消息行为不退化（delay/失败回调语义一致性）；何时拉起：分段回复主线合入并稳定运行后单独立项推进
 
-### [B-260508-d32c36] timeout 配置碎片化统一收敛
+### [B-260508-da7e68] admin events 命令打印好感度等级时数组越界
 - 创建: 2026-05-08
 - 问题表现:
-    - EventGenerationAgent 内部 4 个 LLM 方法使用 3 种 timeout 来源（self.timeout / self.config.proactive_share_timeout_seconds / router 默认 30）
-    - PersonaConfig 中 timeout 分裂为 4 条独立路径（timeout:30 / proactive_share_timeout_seconds:60 / event_generation_timeout:90 / diary 未传）
+  - .ai admin events 命令在打印 [好感度等级] 时 admin.py:314 抛 IndexError: list index out of range
+  - 根因：char.get_warmth_labels() 返回的 labels 数量超过 STAGE_FLOORS = [0,20,40,60,80] 的 5 档，循环到 i=4 时访问 STAGE_FLOORS[i+1] 越界
+  - 集成测试 tests/integration/persona/test_command.py::TestAdminCommands::test_admin_events 因此长期失败
 - 工作计划:
-    - 立项统一后台 proactive 任务 timeout 配置项，覆盖 event、share、diary、observation 等后台路径
-    - 评估 diary/observation 是否也应共享同一 timeout，避免"三等公民"
+  - 让 admin.py:312-316 的循环和 STAGE_FLOORS 长度对齐：要么把多余 labels 折叠进最后一档，要么扩展 STAGE_FLOORS 与 labels 同长度
+  - 顺手核对 get_warmth_labels() 是否本就该和 STAGE_FLOORS 严格 1:1（决定是修循环还是修数据契约）
 

--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -5,9 +5,12 @@ All bot configuration is represented as typed fields here.
 Config is loaded hierarchically by ConfigLoader:
   global defaults < global secrets < persona < account overrides < env vars
 """
+import logging
 from typing import List
 
 from pydantic import AliasChoices, BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 class PersonaConfig(BaseModel):
@@ -26,11 +29,15 @@ class PersonaConfig(BaseModel):
     auxiliary_model: str = "gpt-4o-mini"
     
     max_concurrent_requests: int = 2
-    timeout: int = 30
-    event_generation_timeout: int = Field(
+    chat_llm_timeout_seconds: int = Field(
+        default=30,
+        ge=5,
+        description="用户对话触发的 LLM 调用超时（秒）",
+    )
+    background_llm_timeout_seconds: int = Field(
         default=90,
         ge=5,
-        description="事件生成 LLM 调用超时（秒）",
+        description="后台角色模拟（事件/反应/日记/分享/观察）LLM 调用超时（秒）",
     )
     timezone: str = "Asia/Shanghai"
 
@@ -105,6 +112,50 @@ class PersonaConfig(BaseModel):
             )
         return self
 
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_timeout_fields(cls, data):
+        if not isinstance(data, dict):
+            return data
+
+        # 一对一迁移: timeout -> chat_llm_timeout_seconds
+        if "timeout" in data:
+            if "chat_llm_timeout_seconds" not in data:
+                data["chat_llm_timeout_seconds"] = data.pop("timeout")
+                logger.warning(
+                    "配置项 'timeout' 已被重命名为 'chat_llm_timeout_seconds'，"
+                    "旧值已自动迁移，请更新配置文件。"
+                )
+            else:
+                data.pop("timeout", None)
+                logger.warning(
+                    "配置项 'timeout' 已被重命名为 'chat_llm_timeout_seconds'，"
+                    "当前 'timeout' 的值将被忽略（新字段已存在）。"
+                )
+
+        # 多对一迁移: event_generation_timeout / proactive_share_timeout_seconds -> background_llm_timeout_seconds
+        bg_old_fields = ["event_generation_timeout", "proactive_share_timeout_seconds"]
+        has_old_bg = any(f in data for f in bg_old_fields)
+        if has_old_bg:
+            if "background_llm_timeout_seconds" not in data:
+                values = [data.pop(f) for f in bg_old_fields if f in data]
+                data["background_llm_timeout_seconds"] = max(values)
+                logger.warning(
+                    "配置项 'event_generation_timeout' / 'proactive_share_timeout_seconds' "
+                    "已被重命名为 'background_llm_timeout_seconds'，旧值已自动迁移（取较大值），"
+                    "请更新配置文件。"
+                )
+            else:
+                for f in bg_old_fields:
+                    data.pop(f, None)
+                logger.warning(
+                    "配置项 'event_generation_timeout' / 'proactive_share_timeout_seconds' "
+                    "已被重命名为 'background_llm_timeout_seconds'，当前旧字段的值将被忽略"
+                    "（新字段已存在）。"
+                )
+
+        return data
+
     # ── Phase 4+: 群活跃度（影响主动消息频率，暂未启用）
     # group_activity_decay_days: List[int] = [1, 3, 7]
     # group_activity_decay_values: List[int] = [10, 30, 50]
@@ -172,9 +223,6 @@ class PersonaConfig(BaseModel):
     )
     proactive_share_max_retries: int = Field(
         default=2, ge=0, description="分享消息生成失败后的最大重试次数"
-    )
-    proactive_share_timeout_seconds: int = Field(
-        default=60, ge=5, description="单次分享消息 LLM 调用超时（秒）"
     )
     proactive_share_backoff_base_seconds: int = Field(
         default=2, ge=1, description="分享消息重试的指数退避基数（秒）"

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -185,7 +185,7 @@ def _build_router(config, store: PersonaDataStore) -> LLMRouter:
         auxiliary_base_url=config.auxiliary_base_url,
         auxiliary_model=config.auxiliary_model,
         max_concurrent=config.max_concurrent_requests,
-        timeout=config.timeout,
+        timeout=config.chat_llm_timeout_seconds,
         daily_limit=config.daily_limit,
         quota_check_enabled=config.quota_check_enabled,
         data_store=store,

--- a/src/plugins/DicePP/module/persona/life/event_agent.py
+++ b/src/plugins/DicePP/module/persona/life/event_agent.py
@@ -15,6 +15,9 @@ from ..llm.router import LLMRouter
 from ..data.models import ModelTier
 from typing import TYPE_CHECKING
 
+# keep in sync with PersonaConfig.background_llm_timeout_seconds default
+_DEFAULT_BG_TIMEOUT = 90
+
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
 
@@ -123,6 +126,11 @@ class EventGenerationAgent:
     ):
         self.llm_router = llm_router
         self.config = config
+        self._bg_timeout = (
+            getattr(config, "background_llm_timeout_seconds", _DEFAULT_BG_TIMEOUT)
+            if config
+            else _DEFAULT_BG_TIMEOUT
+        )
 
     @staticmethod
     def _format_state_prompt(energy: Optional[int], mood: Optional[int],
@@ -270,7 +278,7 @@ class EventGenerationAgent:
                 tool_name="record_event",
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.9,
-                timeout=self.config.event_generation_timeout if self.config else 90,
+                timeout=self._bg_timeout,
             )
 
             # tool-call 输出（generate_with_forced_tool）：args 已是合法 JSON，
@@ -436,7 +444,7 @@ class EventGenerationAgent:
                 tool_name="record_reaction",
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.9,
-                timeout=self.config.event_generation_timeout if self.config else 90,
+                timeout=self._bg_timeout,
             )
 
             # tool-call 输出（generate_with_forced_tool）：args 已是合法 JSON，
@@ -571,6 +579,7 @@ class EventGenerationAgent:
                 ],
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.85,
+                timeout=self._bg_timeout,
             )
 
             diary = response.strip()
@@ -589,9 +598,8 @@ class EventGenerationAgent:
         为指定目标生成个性化分享消息。
 
         使用 AUXILIARY tier 模型，通过 generate_with_forced_tool 强制输出。
-        默认单次 10 秒超时、最多 2 次重试，实际值受配置项
-        proactive_share_timeout_seconds / proactive_share_max_retries /
-        proactive_share_backoff_base_seconds 控制。
+        超时与重试由配置项 background_llm_timeout_seconds /
+        proactive_share_max_retries / proactive_share_backoff_base_seconds 控制。
         彻底失败返回 None（调用方应静默丢弃）。
 
         Args:
@@ -718,7 +726,7 @@ class EventGenerationAgent:
         ]
 
         max_retries = getattr(self.config, "proactive_share_max_retries", 3) if self.config else 3
-        timeout_seconds = getattr(self.config, "proactive_share_timeout_seconds", 60) if self.config else 60
+        timeout_seconds = self._bg_timeout
         backoff_base = getattr(self.config, "proactive_share_backoff_base_seconds", 2) if self.config else 2
         max_chars = getattr(self.config, "proactive_share_max_chars", 200) if self.config else 200
 

--- a/src/plugins/DicePP/module/persona/life/observation.py
+++ b/src/plugins/DicePP/module/persona/life/observation.py
@@ -313,6 +313,11 @@ class ObservationExtractor:
         self.event_agent = event_agent
         self.data_store = data_store
         self.config = config
+        self._bg_timeout = (
+            getattr(config, "background_llm_timeout_seconds", 90)
+            if config
+            else 90
+        )
         self._prune_observations_keep = prune_observations_keep
 
     async def extract_observations(
@@ -419,6 +424,7 @@ class ObservationExtractor:
                 ],
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.7,
+                timeout=self._bg_timeout,
             )
 
             # 解析 JSON 响应：自由文本可能含 markdown 围栏，走统一容错

--- a/tests/unit/persona/test_event_agent.py
+++ b/tests/unit/persona/test_event_agent.py
@@ -37,7 +37,7 @@ class TestEventGenerationAgent:
     def agent(self, mock_llm_router):
         """创建 EventGenerationAgent 实例"""
         config = MagicMock()
-        config.event_generation_timeout = 90
+        config.background_llm_timeout_seconds = 90
         return EventGenerationAgent(mock_llm_router, config=config)
 
     @pytest.fixture
@@ -77,6 +77,7 @@ class TestEventGenerationAgent:
             mock_llm_router.generate.assert_called_once()
             call_kwargs = mock_llm_router.generate.call_args.kwargs
             assert call_kwargs["temperature"] == 0.85
+            assert call_kwargs["timeout"] == 90
             assert call_kwargs["model_tier"] == ModelTier.AUXILIARY
 
         async def test_generate_diary_truncate_long(self, agent, mock_llm_router):
@@ -169,7 +170,7 @@ class TestGenerateEventResult:
     @pytest.fixture
     def agent_forced(self, mock_llm_router_forced):
         config = MagicMock()
-        config.event_generation_timeout = 90
+        config.background_llm_timeout_seconds = 90
         return EventGenerationAgent(mock_llm_router_forced, config=config)
 
     @pytest.mark.asyncio
@@ -355,7 +356,7 @@ class TestGenerateEventReaction:
     @pytest.fixture
     def agent_forced(self, mock_llm_router_forced):
         config = MagicMock()
-        config.event_generation_timeout = 90
+        config.background_llm_timeout_seconds = 90
         return EventGenerationAgent(mock_llm_router_forced, config=config)
 
     @pytest.mark.asyncio

--- a/tests/unit/persona/test_factory_smoke.py
+++ b/tests/unit/persona/test_factory_smoke.py
@@ -26,7 +26,7 @@ def _make_bot() -> MagicMock:
     cfg.auxiliary_base_url = ""
     cfg.auxiliary_model = ""
     cfg.max_concurrent_requests = 2
-    cfg.timeout = 30
+    cfg.chat_llm_timeout_seconds = 30
     cfg.daily_limit = 20
     cfg.quota_check_enabled = False
     cfg.trace_enabled = False

--- a/tests/unit/persona/test_generate_share_message.py
+++ b/tests/unit/persona/test_generate_share_message.py
@@ -19,7 +19,7 @@ from plugins.DicePP.module.persona.llm import ForcedToolError
 class MockConfig:
     proactive_share_max_chars = 200
     proactive_share_max_retries = 2
-    proactive_share_timeout_seconds = 10
+    background_llm_timeout_seconds = 10
     proactive_share_backoff_base_seconds = 2
 
 
@@ -107,6 +107,7 @@ async def test_generate_share_message_timeout_raises(agent, mock_llm_router, bas
         await agent.generate_share_message(base_context)
 
     assert mock_llm_router.generate_with_forced_tool.call_count == 1
+    assert mock_llm_router.generate_with_forced_tool.call_args.kwargs["timeout"] == 10
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- 将 PersonaConfig 中分散的 timeout/event_generation_timeout/
  proactive_share_timeout_seconds 收敛为 chat_llm_timeout_seconds
  (前台对话) 与 background_llm_timeout_seconds (后台模拟)
- 新增 model_validator 自动迁移旧字段值并 warning 提示用户更新配置
- EventGenerationAgent 提取 _DEFAULT_BG_TIMEOUT 常量并通过 __init__
  缓存 _bg_timeout, 消除 6 处硬编码 fallback 的隐式耦合
- diary 与 observation 的 LLM 调用显式传入后台超时
  (修复此前共享 router 默认 30s 的问题)
- 同步更新相关测试的 mock 字段名与 timeout 透传断言