### PR TITLE
feat(persona): 统一消息发送路径为单一 send

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -36,17 +36,6 @@
   - 需先观察现有 LLM 是否真的频繁误识 `[内部指令]`，决定是否提前优先级
   - 影响面: ContextBuilder、厂商 adapter、segment dispatcher
 
-### [B-260508-1f1b9e] 消息发送路径统一（合并 send_segmented / send_now / dispatcher）
-- 创建: 2026-05-08
-- 问题表现:
-    - `send_segmented` 三处调用方（`ChatSession._coordinator_on_result`、`PersonaApp.send_message`、`LifeSimulator._send_msg`）当前都是 `[make_segment(content, group_id)]` 单段形态，行为与 `send_now` 重叠
-    - 分段路径走 `dispatcher → send_now`，非分段路径走 `send_segmented`，形成两套并存的发送路径，调度/失败回调/可观测点分裂
-    - 同一"发送"语义有两套实现，未来扩展失败重试、限流、监控时需要双写
-- 工作计划:
-    - 修复方向：评估三处调用方是否都能迁移到 dispatcher（含 life 主动消息的 delay 与失败回调语义）；设计统一发送接口（扩展 dispatcher 支持非分段单条 / 合并到 send_now / 让 send_segmented 内部走 dispatcher）；删除 `send_segmented`，迁移所有调用方，更新测试
-    - 影响面：persona 模块所有出口消息（chat 非分段、`PersonaApp.send_message`、life 主动消息）
-    - 风险点：需保证 life 主动消息行为不退化（delay/失败回调语义一致性）；何时拉起：分段回复主线合入并稳定运行后单独立项推进
-
 ### [B-260508-da7e68] admin events 命令打印好感度等级时数组越界
 - 创建: 2026-05-08
 - 问题表现:

--- a/src/plugins/DicePP/module/persona/chat/segment_dispatcher.py
+++ b/src/plugins/DicePP/module/persona/chat/segment_dispatcher.py
@@ -1,7 +1,10 @@
 """SegmentDispatcher: 内存分段调度器，按 target_key 维护独立 asyncio worker。
 
 每个 target_key（群聊 group:{id} / 私聊 user:{id}）拥有独立的 Queue + Event + worker task，
-worker 按 FIFO 顺序同步发送 segment，支持 delay_before  pacing、flush、shutdown。
+worker 按 FIFO 顺序同步发送 segment，支持 delay_before pacing、flush、shutdown。
+
+注意：分段发送 worker loop 中的异常仅记录日志，不触发 MessagePort 的
+on_delivery_failed 回调。如需失败通知，请在调用方自行处理。
 """
 
 import asyncio
@@ -16,6 +19,12 @@ _DEFAULT_MAX_PER_RUN = 20
 
 @dataclass
 class SegmentItem:
+    """分段消息项。
+
+    delay_before 为"调用 send 前等待"的秒数；send 本身的阻塞耗时会顺延
+    下一条的计时，因此实际发送间隔 ≥ delay_before。
+    """
+
     content: str
     delay_before: float
     user_id: str
@@ -151,7 +160,7 @@ class SegmentDispatcher:
 
                     try:
                         # R11: 显式传 skip_history_record=True，把决策留在分段域
-                        await self._port.send_now(
+                        await self._port.send(
                             segment.user_id,
                             segment.group_id,
                             segment.content,

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -40,7 +40,6 @@ from ..tools.registry import ToolRegistry, ToolDomain
 from ..tools.context import ToolContext
 from ..llm.coordinator import LLMCallCoordinator
 from ..gateway.port import MessagePort
-from ..gateway.pipeline import make_segment
 from .billing import BillingPolicy
 from .segment_dispatcher import SegmentDispatcher, SegmentItem
 from .segment_state import SegmentBudgetState, SegmentLimits
@@ -348,11 +347,7 @@ class ChatSession:
             return
 
         if self.port:
-            await self.port.send_segmented(
-                user_id,
-                group_id,
-                [make_segment(result, group_id)],
-            )
+            await self.port.send(user_id, group_id, result)
         else:
             logger.warning(
                 f"_coordinator_on_result: MessagePort 未注入，"

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -19,7 +19,7 @@ from .exceptions import (
     PersonaStorageError,
 )
 from .game.decay import DecayCalculator, DecayConfig
-from .gateway.pipeline import MessagePipeline, TruncateStage, make_segment
+from .gateway.pipeline import MessagePipeline, TruncateStage
 from .gateway.port import MessagePort
 from .life.character_life import CharacterLife, CharacterLifeConfig
 from .life.diary import DiaryGenerator, DiaryConfig
@@ -81,10 +81,8 @@ class PersonaApp:
 
     # ── 消息发送 ──────────────────────────────────────────────
 
-    async def send_message(self, user_id: str, group_id: str, content: str) -> None:
-        await self.port.send_segmented(
-            user_id, group_id, [make_segment(content, group_id)]
-        )
+    async def send_message(self, user_id: str, group_id: str, content: str) -> bool:
+        return await self.port.send(user_id, group_id, content)
 
     # ── LLM 路由器 ────────────────────────────────────────────
 

--- a/src/plugins/DicePP/module/persona/gateway/pipeline.py
+++ b/src/plugins/DicePP/module/persona/gateway/pipeline.py
@@ -1,5 +1,5 @@
 """消息处理管道 — 链式转换 SendAction 元数据，不做 I/O"""
-from typing import List, Dict, Any
+from typing import List
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 
@@ -11,7 +11,6 @@ class SendAction:
     user_id: str
     group_id: str
     content: str
-    delay_seconds: float = 0.0  # Pipeline 可设置, Port._execute_background 读取并执行
     skip_history_record: bool = False  # 是否跳过 adapter 层历史记录
 
 
@@ -33,8 +32,8 @@ class MessageStage(ABC):
     阶段约束：
       - 不做 I/O（不发消息、不读数据库），只修改 ``SendAction`` 字段
       - 必须就地或返回新列表，不抛异常打断流水线
-      - 阶段之间无显式协议依赖，但写入 ``content`` / ``delay_seconds``
-        / ``skip_history_record`` 时应能容忍前序阶段已修改
+      - 阶段之间无显式协议依赖，但写入 ``content`` / ``skip_history_record``
+        时应能容忍前序阶段已修改
     """
 
     @abstractmethod
@@ -70,8 +69,3 @@ class TruncateStage(MessageStage):
             if len(action.content) > self.max_chars:
                 action.content = action.content[: self.max_chars - 3] + "..."
         return actions
-
-
-def make_segment(content: str, group_id: str = "") -> Dict[str, Any]:
-    """构造 send_segmented 兼容的消息段"""
-    return {"content": content, "skip_history_record": bool(group_id)}

--- a/src/plugins/DicePP/module/persona/gateway/port.py
+++ b/src/plugins/DicePP/module/persona/gateway/port.py
@@ -1,7 +1,6 @@
 """唯一消息发送出口"""
-import asyncio
 from nonebot.log import logger
-from typing import Optional, Callable, List, Dict
+from typing import Optional, Callable
 
 from core.bot import Bot
 from core.command.bot_cmd import BotSendMsgCommand
@@ -15,7 +14,8 @@ from ..life.protocols import EventSharePort
 class MessagePort(EventSharePort):
     """唯一消息发送出口 — 同时满足 SendPort (tools) 和 EventSharePort (life)
 
-    EventSharePort 已继承 SendPort，确保工具域与生活域的 send_segmented
+    = SendPort 契约 + pipeline（截断等元数据转换）+ 失败回调 + proxy 兜底。
+    EventSharePort 已继承 SendPort，确保工具域与生活域的 send
     签名始终一致，消除 MRO 风险。
     """
 
@@ -28,49 +28,32 @@ class MessagePort(EventSharePort):
         self._bot = bot
         self._pipeline = pipeline or MessagePipeline()
         self._on_delivery_failed = on_delivery_failed
-        self._bg_tasks: set[asyncio.Task] = set()
 
-    async def send_segmented(
-        self, user_id: str, group_id: str, segments: List[Dict]
-    ) -> bool:
-        """批量发送分段消息，默认记录历史。
-
-        与 send_now 的差异：send_segmented 走 pipeline + 后台任务，
-        send_now 为即时单条发送。skip_history_record 默认均为 False，
-        分段域如需跳过应在调用侧显式指定。
-        """
-        actions = [
-            SendAction(
-                user_id=user_id,
-                group_id=group_id,
-                content=s["content"],
-                delay_seconds=s.get("delay", 0),
-                skip_history_record=s.get("skip_history_record", False),
-            )
-            for s in segments
-        ]
-        processed = await self._pipeline.process(actions)
-        self._spawn_background(processed)
-        return True  # fire-and-forget
-
-    async def send_now(
+    async def send(
         self,
         user_id: str,
         group_id: str,
         content: str,
         *,
-        skip_history_record: bool = False,
+        skip_history_record: Optional[bool] = None,
     ) -> bool:
-        """即时单条发送，默认记录历史。
+        """单条消息发送，默认记录历史。
+
+        本方法同步等待 proxy 投递返回，调用方应避免在事件循环关键路径
+        （如 1s tick / LLM 流式响应）上叠加多次裸 await；
+        如需 fire-and-forget 请自行 ``asyncio.create_task`` 包装。
 
         分段调度器应显式传 skip_history_record=True，
         把"分段消息不记历史"的决策留在分段域。
+
+        :param skip_history_record: None 时群聊默认 True（跳过历史），私聊默认 False。
         """
+        if skip_history_record is None:
+            skip_history_record = bool(group_id)
         action = SendAction(
             user_id=user_id,
             group_id=group_id,
             content=content,
-            delay_seconds=0,
             skip_history_record=skip_history_record,
         )
         processed = await self._pipeline.process([action])
@@ -84,41 +67,18 @@ class MessagePort(EventSharePort):
             )
             return True
         except Exception as e:
-            logger.exception("send_now 失败")
+            logger.exception("send 失败")
             if self._on_delivery_failed:
-                await self._on_delivery_failed(
-                    user_id=a.user_id,
-                    group_id=a.group_id,
-                    content=a.content,
-                    error=str(e),
-                )
-            return False
-
-    def _spawn_background(self, actions: List[SendAction]) -> None:
-        task = asyncio.create_task(self._run_actions(actions))
-        self._bg_tasks.add(task)
-        task.add_done_callback(self._bg_tasks.discard)
-
-    async def _run_actions(self, actions: List[SendAction]) -> None:
-        for action in actions:
-            if action.delay_seconds > 0:
-                await asyncio.sleep(action.delay_seconds)
-            try:
-                await self._send(
-                    action.user_id,
-                    action.group_id,
-                    action.content,
-                    skip_history_record=action.skip_history_record,
-                )
-            except Exception as e:
-                logger.exception("后台发送失败")
-                if self._on_delivery_failed:
+                try:
                     await self._on_delivery_failed(
-                        user_id=action.user_id,
-                        group_id=action.group_id,
-                        content=action.content,
+                        user_id=a.user_id,
+                        group_id=a.group_id,
+                        content=a.content,
                         error=str(e),
                     )
+                except Exception:
+                    logger.exception("on_delivery_failed 回调失败")
+            return False
 
     async def _send(
         self, user_id: str, group_id: str, content: str, skip_history_record: bool = False

--- a/src/plugins/DicePP/module/persona/life/protocols.py
+++ b/src/plugins/DicePP/module/persona/life/protocols.py
@@ -7,7 +7,7 @@ from ..tools.context import SendPort
 class EventSharePort(SendPort, Protocol):
     """生活域 — 我需要一个能发送事件分享消息的口子
 
-    继承 SendPort，确保工具域与生活域的 send_segmented 签名始终一致。
+    继承 SendPort，确保工具域与生活域的 send 签名始终一致。
     """
     pass
 

--- a/src/plugins/DicePP/module/persona/life/simulator.py
+++ b/src/plugins/DicePP/module/persona/life/simulator.py
@@ -13,7 +13,6 @@ from ..data.models import RelationshipState, ScoreEvent
 from ..character.models import Character
 from ..game.decay import DecayCalculator
 from ..wall_clock import persona_wall_now
-from ..gateway.pipeline import make_segment
 from .proactive_scheduler import ProactiveScheduler
 from .event_share_queue import EventShareTaskQueue
 from .protocols import EventSharePort
@@ -121,6 +120,7 @@ class LifeSimulator:
         if self.scheduler:
             try:
                 proactive_msgs = await self.scheduler.tick()
+                # 串行 await 保证消息顺序，请勿改为 gather
                 for msg in proactive_msgs:
                     await self._send_msg(msg)
             except Exception:
@@ -132,6 +132,7 @@ class LifeSimulator:
                 delayed_msgs = await self.event_share_queue.tick(
                     on_share=self._run_due_share
                 )
+                # 串行 await 保证消息顺序，请勿改为 gather
                 for msg in delayed_msgs:
                     await self._send_msg(msg)
             except Exception:
@@ -231,8 +232,10 @@ class LifeSimulator:
                 f"_send_msg 收件人为空，丢弃消息: content={content[:30]}..."
             )
             return
-        await self.port.send_segmented(
-            user_id,
-            group_id,
-            [make_segment(content, group_id)],
-        )
+        if not await self.port.send(user_id, group_id, content):
+            logger.warning(
+                "_send_msg 发送失败: user_id=%s group_id=%s content=%s...",
+                user_id,
+                group_id,
+                content[:30],
+            )

--- a/src/plugins/DicePP/module/persona/tools/context.py
+++ b/src/plugins/DicePP/module/persona/tools/context.py
@@ -1,13 +1,24 @@
 """工具执行上下文 — 运行时注入的依赖"""
-from typing import Any, Optional, Protocol, List, Dict
+from typing import Any, Optional, Protocol
 from dataclasses import dataclass
 
 
 class SendPort(Protocol):
-    """工具执行 — 我需要一个能发消息的口子"""
+    """工具执行 — 我需要一个能发消息的口子
 
-    async def send_segmented(
-        self, user_id: str, group_id: str, segments: List[Dict]
+    最小行为契约：
+    - 失败不抛异常，返回 bool 表示成功/失败
+    - 群/私聊路由由实现自行处理
+    - skip_history_record 控制是否记录历史（语义由实现定义）
+    """
+
+    async def send(
+        self,
+        user_id: str,
+        group_id: str,
+        content: str,
+        *,
+        skip_history_record: Optional[bool] = None,
     ) -> bool: ...
 
 

--- a/tests/module/persona/chat/test_segment_dispatcher.py
+++ b/tests/module/persona/chat/test_segment_dispatcher.py
@@ -43,14 +43,14 @@ class TestLazyCreation:
     async def test_first_segment_creates_worker(self, dispatcher, mock_port):
         dispatcher.notify("group:1", SegmentItem("hello", 0, "u1", "g1"))
         await asyncio.sleep(0.05)
-        mock_port.send_now.assert_awaited_once_with("u1", "g1", "hello", skip_history_record=True)
+        mock_port.send.assert_awaited_once_with("u1", "g1", "hello", skip_history_record=True)
 
     @pytest.mark.asyncio
     async def test_second_segment_reuses_worker(self, dispatcher, mock_port):
         dispatcher.notify("group:1", SegmentItem("a", 0, "u1", "g1"))
         dispatcher.notify("group:1", SegmentItem("b", 0, "u1", "g1"))
         await asyncio.sleep(0.05)
-        assert mock_port.send_now.await_count == 2
+        assert mock_port.send.await_count == 2
 
 
 class TestIdleTimeout:
@@ -71,16 +71,16 @@ class TestDelayBefore:
     async def test_zero_delay_sends_immediately(self, dispatcher, mock_port):
         dispatcher.notify("group:1", SegmentItem("now", 0, "u1", "g1"))
         await asyncio.sleep(0.05)
-        mock_port.send_now.assert_awaited_once()
+        mock_port.send.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_positive_delay_waits(self, dispatcher, mock_port):
         dispatcher.notify("group:1", SegmentItem("later", 0.3, "u1", "g1"))
         await asyncio.sleep(0.05)
         # Not sent yet
-        mock_port.send_now.assert_not_awaited()
+        mock_port.send.assert_not_awaited()
         await asyncio.sleep(0.35)
-        mock_port.send_now.assert_awaited_once()
+        mock_port.send.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_new_segment_wakes_sleeping_worker(self, dispatcher, mock_port):
@@ -90,7 +90,7 @@ class TestDelayBefore:
         dispatcher.notify("group:1", SegmentItem("b", 0, "u1", "g1"))
         await asyncio.sleep(0.6)
         # Both should be sent; order preserved
-        calls = mock_port.send_now.await_args_list
+        calls = mock_port.send.await_args_list
         assert len(calls) == 2
         assert calls[0][0][2] == "a"
         assert calls[1][0][2] == "b"
@@ -142,13 +142,13 @@ class TestMaxPerRun:
         for i in range(3):
             dispatcher.notify("group:1", SegmentItem(str(i), 0, "u1", "g1"))
         await asyncio.sleep(0.1)
-        calls = mock_port.send_now.await_args_list
+        calls = mock_port.send.await_args_list
         assert len(calls) == 3
 
         for i in range(3, 5):
             dispatcher.notify("group:1", SegmentItem(str(i), 0, "u1", "g1"))
         await asyncio.sleep(0.1)
-        calls = mock_port.send_now.await_args_list
+        calls = mock_port.send.await_args_list
         assert len(calls) == 5
         contents = [c[0][2] for c in calls]
         assert contents == ["0", "1", "2", "3", "4"]
@@ -157,8 +157,8 @@ class TestMaxPerRun:
 class TestSendFailure:
     @pytest.mark.asyncio
     async def test_failure_does_not_kill_worker(self, dispatcher, mock_port):
-        mock_port.send_now.side_effect = [Exception("boom"), None]
+        mock_port.send.side_effect = [Exception("boom"), None]
         dispatcher.notify("group:1", SegmentItem("fail", 0, "u1", "g1"))
         dispatcher.notify("group:1", SegmentItem("ok", 0, "u1", "g1"))
         await asyncio.sleep(0.1)
-        assert mock_port.send_now.await_count == 2
+        assert mock_port.send.await_count == 2

--- a/tests/unit/persona/test_chat_session_segmented.py
+++ b/tests/unit/persona/test_chat_session_segmented.py
@@ -117,7 +117,7 @@ class TestChatWithToolsFlush:
         queue = dispatcher._queues.get("user:u1")
         if queue is not None:
             assert queue.empty()
-        mock_port.send_now.assert_not_awaited()
+        mock_port.send.assert_not_awaited()
 
 
 class TestFlagLifecycle:

--- a/tests/unit/persona/test_life_simulator.py
+++ b/tests/unit/persona/test_life_simulator.py
@@ -53,7 +53,7 @@ def _make_simulator(
     character.extensions.initial_relationship = 50.0
 
     port = MagicMock()
-    port.send_segmented = AsyncMock()
+    port.send = AsyncMock()
 
     config = LifeConfig(
         proactive_event_share_threshold=share_threshold,
@@ -131,8 +131,8 @@ async def test_tick_sends_proactive_messages():
         ],
     )
     await sim.tick()
-    sim.port.send_segmented.assert_called_once()
-    args, kwargs = sim.port.send_segmented.call_args
+    sim.port.send.assert_called_once()
+    args, kwargs = sim.port.send.call_args
     assert args[0] == "u1"
 
 
@@ -145,8 +145,21 @@ async def test_tick_processes_delayed_share():
         ],
     )
     await sim.tick()
-    # send_segmented 至少调用一次（处理 delayed 消息）
-    assert sim.port.send_segmented.await_count >= 1
+    assert sim.port.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_send_msg_calls_port_with_correct_args():
+    """_send_msg 将 user_id / group_id / content 正确传递给 port.send"""
+    sim = _make_simulator()
+    await sim._send_msg({"user_id": "u1", "group_id": "g1", "content": "群消息"})
+    args, _ = sim.port.send.call_args
+    assert args == ("u1", "g1", "群消息")
+
+    sim.port.send.reset_mock()
+    await sim._send_msg({"user_id": "u1", "group_id": "", "content": "私聊"})
+    args, _ = sim.port.send.call_args
+    assert args == ("u1", "", "私聊")
 
 
 @pytest.mark.asyncio
@@ -196,10 +209,10 @@ async def test_tick_daily_calls_prune_traces_when_enabled():
 
 @pytest.mark.asyncio
 async def test_send_msg_drops_empty_recipient():
-    """_send_msg 收件人为空（user_id 与 group_id 都缺失）时跳过 port.send_segmented"""
+    """_send_msg 收件人为空（user_id 与 group_id 都缺失）时跳过 port.send"""
     sim = _make_simulator()
     await sim._send_msg({"user_id": "", "group_id": "", "content": "孤儿消息"})
-    sim.port.send_segmented.assert_not_called()
+    sim.port.send.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -207,7 +220,7 @@ async def test_send_msg_with_user_only_still_sends():
     """仅有 user_id 仍应正常发送，确认空收件人防御不会误伤"""
     sim = _make_simulator()
     await sim._send_msg({"user_id": "u1", "group_id": "", "content": "hi"})
-    sim.port.send_segmented.assert_called_once()
+    sim.port.send.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/persona/test_message_port.py
+++ b/tests/unit/persona/test_message_port.py
@@ -65,11 +65,11 @@ async def test_send_without_proxy_drops_silently():
 
 
 @pytest.mark.asyncio
-async def test_send_now_success_awaits_send():
+async def test_send_success_awaits_send():
     bot = _make_bot()
     port = MessagePort(bot)
 
-    result = await port.send_now("u1", "g1", "hello", skip_history_record=True)
+    result = await port.send("u1", "g1", "hello", skip_history_record=True)
 
     assert result is True
     bot.proxy.process_bot_command.assert_awaited_once()
@@ -79,13 +79,29 @@ async def test_send_now_success_awaits_send():
 
 
 @pytest.mark.asyncio
-async def test_send_now_failure_returns_false_and_calls_on_delivery_failed():
+async def test_send_defaults_skip_history_by_group_id():
+    """group_id 非空时默认 skip_history_record=True，空时默认 False"""
+    bot = _make_bot()
+    port = MessagePort(bot)
+
+    await port.send("u1", "g1", "hello")
+    cmd = bot.proxy.process_bot_command.await_args.args[0]
+    assert cmd.skip_history_record is True
+
+    bot.proxy.process_bot_command.reset_mock()
+    await port.send("u1", "", "hello")
+    cmd = bot.proxy.process_bot_command.await_args.args[0]
+    assert cmd.skip_history_record is False
+
+
+@pytest.mark.asyncio
+async def test_send_failure_returns_false_and_calls_on_delivery_failed():
     bot = _make_bot()
     bot.proxy.process_bot_command = AsyncMock(side_effect=RuntimeError("net down"))
     on_failed = AsyncMock()
     port = MessagePort(bot, on_delivery_failed=on_failed)
 
-    result = await port.send_now("u1", "", "oops")
+    result = await port.send("u1", "", "oops")
 
     assert result is False
     on_failed.assert_awaited_once()
@@ -95,7 +111,7 @@ async def test_send_now_failure_returns_false_and_calls_on_delivery_failed():
 
 
 @pytest.mark.asyncio
-async def test_send_now_pipeline_stages_still_applied():
+async def test_send_pipeline_stages_still_applied():
     bot = _make_bot()
     from plugins.DicePP.module.persona.gateway.pipeline import MessagePipeline, TruncateStage
 
@@ -103,8 +119,21 @@ async def test_send_now_pipeline_stages_still_applied():
     pipeline.add(TruncateStage(max_chars=5))
     port = MessagePort(bot, pipeline=pipeline)
 
-    result = await port.send_now("u1", "", "very long content")
+    result = await port.send("u1", "", "very long content")
 
     assert result is True
     cmd = bot.proxy.process_bot_command.await_args.args[0]
     assert cmd.msg == "ve..."  # truncated by TruncateStage (max_chars=5 -> 2 chars + "...")
+
+
+@pytest.mark.asyncio
+async def test_send_failure_callback_exception_still_returns_false():
+    """on_delivery_failed 自身抛异常时 send 仍返回 False 且不向上抛"""
+    bot = _make_bot()
+    bot.proxy.process_bot_command = AsyncMock(side_effect=RuntimeError("net down"))
+    on_failed = AsyncMock(side_effect=RuntimeError("callback boom"))
+    port = MessagePort(bot, on_delivery_failed=on_failed)
+
+    result = await port.send("u1", "", "oops")
+
+    assert result is False


### PR DESCRIPTION
将 MessagePort 的 send_segmented + send_now 合并为单一 send，
删除 fire-and-forget 后台任务与 make_segment 辅助。

- SendPort / EventSharePort 签名统一为 send(user_id, group_id, content)
- skip_history_record 默认规则内聚：群聊 True，私聊 False
- pipeline 清理 delay_seconds 和 make_segment
- 三处调用方（ChatSession、PersonaApp、LifeSimulator）直接传三元组
- on_delivery_failed 回调异常不穿透 send
- send_message 与 _send_msg 透传/检查 bool 返回值