### PR TITLE
fix: admin events 越界修复 + CI 集成测试覆盖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Run unit tests
         run: |
           uv run pytest -m unit --tb=short -q
+
+      - name: Run integration tests
+        run: |
+          uv run pytest -m integration --tb=short -q
       
       - name: Run compatibility corpus tests
         run: |

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -9,19 +9,6 @@
 
 ---
 
-## ci
-
-### [B-260508-93fe70] CI 没覆盖 integration 测试，回归保护层裸奔
-- 创建: 2026-05-08
-- 问题表现:
-  - .github/workflows/ci.yml:41 仅执行 pytest -m unit，整个 tests/integration/** 不会被 CI 触发
-  - 本次 timeout 收敛改动验证时发现 tests/integration/persona/test_command.py::TestAdminCommands::test_admin_events 在 origin/master 41d8973 之前就已 break，未被任何 CI/PR 拦截
-  - 用户面命令链路（IsolatedAsyncioTestCase 走 .ai admin events 等）恰好是 integration 标签，CI 长期裸奔
-- 工作计划:
-  - 在 ci.yml 增加 integration 测试 step：可改为 pytest -m "unit or integration" 单 job，或拆分为独立 job 便于失败定位
-  - 本机跑 tests/unit/persona + tests/integration/persona 共 494 用例约 58s，加进 CI 总时长可控
-  - 如担心 integration 偶发依赖（外部进程/真实 IO），先 grep tests/integration 确认无 real_llm/external_service 类需要单独 marker 隔离
-
 ## persona
 
 ### [B-260507-f9ea98] 厂商适配层根据模型类型选择 prompt 注入角色（system/user/developer）

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -36,13 +36,4 @@
   - 需先观察现有 LLM 是否真的频繁误识 `[内部指令]`，决定是否提前优先级
   - 影响面: ContextBuilder、厂商 adapter、segment dispatcher
 
-### [B-260508-da7e68] admin events 命令打印好感度等级时数组越界
-- 创建: 2026-05-08
-- 问题表现:
-  - .ai admin events 命令在打印 [好感度等级] 时 admin.py:314 抛 IndexError: list index out of range
-  - 根因：char.get_warmth_labels() 返回的 labels 数量超过 STAGE_FLOORS = [0,20,40,60,80] 的 5 档，循环到 i=4 时访问 STAGE_FLOORS[i+1] 越界
-  - 集成测试 tests/integration/persona/test_command.py::TestAdminCommands::test_admin_events 因此长期失败
-- 工作计划:
-  - 让 admin.py:312-316 的循环和 STAGE_FLOORS 长度对齐：要么把多余 labels 折叠进最后一档，要么扩展 STAGE_FLOORS 与 labels 同长度
-  - 顺手核对 get_warmth_labels() 是否本就该和 STAGE_FLOORS 严格 1:1（决定是修循环还是修数据契约）
 

--- a/src/plugins/DicePP/module/persona/admin.py
+++ b/src/plugins/DicePP/module/persona/admin.py
@@ -309,11 +309,9 @@ class AdminDispatcher:
             lines.append(f"  {ext.world}")
         labels = char.get_warmth_labels()
         lines.append(f"\n[好感度等级]")
-        for i, label in enumerate(labels):
-            if i < len(labels) - 1:
-                lines.append(f"  {STAGE_FLOORS[i]}-{STAGE_FLOORS[i+1]}: {label}")
-            else:
-                lines.append(f"  {STAGE_FLOORS[i]}-100: {label}")
+        floors = list(zip(STAGE_FLOORS, STAGE_FLOORS[1:] + [100.0]))
+        for (low, high), label in zip(floors, labels):
+            lines.append(f"  {low}-{high}: {label}")
         return "\n".join(lines)
 
     async def _admin_list(self, user_id: str, group_id: str, args: List[str]) -> str:

--- a/tests/integration/persona/test_character_day_simulation.py
+++ b/tests/integration/persona/test_character_day_simulation.py
@@ -153,6 +153,7 @@ def life(temp_db, mock_event_agent, character, config):
     return life
 
 
+@pytest.mark.integration
 class TestCharacterDaySimulation:
     """完整一天模拟"""
 


### PR DESCRIPTION
## Summary
- 修复 `.ai admin events` 好感度等级打印时 IndexError 越界
- CI 增加 integration 测试 step，修复集成测试长期不被 CI 覆盖的问题

## Changes
- `admin.py`: 循环改用 zip 对齐 STAGE_FLOORS 和 labels，labels 超过档位数时自动截短
- `ci.yml`: 拆分 unit/integration 两个 step
- `test_character_day_simulation.py`: 补 `@pytest.mark.integration`

## Test
- 653 unit + 40 integration passed