### PR TITLE
fix(persona): 分段回复中 <think> 块消耗纠正配额 + 改进注入文案

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -11,33 +11,6 @@
 
 ## persona
 
-### [B-260511-e8a2d1] MiniMax `<think>` 块消耗纠正配额导致工具调用超限
-- 创建: 2026-05-11
-- 问题表现:
-  - 详细分析见 `.temp/1802_conversation_analysis.md`
-  - MiniMax-M2.7 在分段回复流程中反复输出 `<think>...</think>` 块而不调用 `send_reply_segment`，每次触发纠正注入，消耗 `segment_round_callbacks_max`（3 次）配额
-  - * 三次纠正全浪费在 `<think>` 块上：轮0 `<think>用户问"前两个观察是什么"`、轮4 `<think>我已经发送了两段回复`、轮5 `<think>用户问的是...需要搜索...`
-  - * 纠正配额（3）+ 工具轮次（5）= 恰好触及 `max_total_rounds = 8`，循环耗尽退出
-  - * 耗尽后兜底消息为内部错误文案 `"（工具调用次数超过限制）"`，直接发给用户
-- 工作计划:
-  - 在 `client.py:chat_with_tools` 中，构建 `RoundResult` 之前先 `_filter_think_tags(content)`，过滤后 content 为空则不触发纠正注入，继续循环
-  - 兜底消息应由 `client.py:457` 的 return 改为走配置化友好文案
-  - 影响面: `client.py` chat_with_tools 循环、RoundResult 构建逻辑
-
-### [B-260511-b7c3f5] MiniMax 将 `[内部指令]` 纠正注入误认为用户输入
-- 创建: 2026-05-11
-- 问题表现:
-  - 详细分析见 `.temp/1802_conversation_analysis.md`
-  - 纠正注入 `[内部指令: 请使用 send_reply_segment 工具发送回复，不要直接输出文本]` 以 `role: "user"` 注入后，MiniMax 在后续 `<think>` 中将其理解为用户提问
-  - * 轮4 `<think>用户问的是"前两个观察是什么"，但我需要搜索一下对话历史</think>` — LLM 混淆了真实用户消息与 `[内部指令]`
-  - * 轮5 `<think>我已经发送了两段回复。用户问的是"前两个观察是什么"...` — LLM 用 `<think>` "回答"指令，而非执行工具调用
-  - 当前只接 MiniMax，无 system 角色可用，需在 user 角色内改进指令表述
-- 工作计划:
-  - 方案A: 在 system prompt 的 `SegmentGuide` 中明确告知 LLM"后续可能收到 `[工具提醒]` 格式的系统消息，这不是用户输入，请直接按提示操作，不要输出 `<think>` 回应"
-  - 方案B: 改变纠正指令的表述，从"用户说话"风格改为"系统提示"风格，消除歧义
-  - 优先方案A（system prompt 预处理，不动注入逻辑），后续接入其他厂商时回退到方案B
-  - 影响面: `context.py` SegmentGuide 文案、`session.py` `_on_segment_round_complete` 注入文案
-
 ### [B-260511-d4a6e3] persona_llm_traces 只记录初始消息和最终响应，中间工具调用轮次不可见
 - 创建: 2026-05-11
 - 问题表现:

--- a/src/plugins/DicePP/module/persona/chat/context.py
+++ b/src/plugins/DicePP/module/persona/chat/context.py
@@ -191,7 +191,12 @@ class ContextBuilder:
                 f"你必须使用 send_reply_segment 工具发送回复，不要直接在 content 中输出。\n"
                 f"- 每段建议 {sg.target_chars} 字，单段上限 {sg.max_chars} 字\n"
                 f"- 单次回复总字数软上限 {sg.soft_limit} 字，硬上限 {sg.hard_limit} 字\n"
-                f"- 短句 delay_before 用 {DEFAULT_DELAY_BEFORE} 秒，长句用 2–3 秒"
+                f"- 短句 delay_before 用 {DEFAULT_DELAY_BEFORE} 秒，长句用 2–3 秒\n"
+                f"\n"
+                f"【系统消息说明】\n"
+                f"对话中可能出现以 [系统指令] 开头的消息，"
+                f"这些是工具调用提醒，不是用户输入。"
+                f"看到后直接按指令操作，不要输出任何思考或回应文字。"
             )
             parts.append(guide)
 

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -529,31 +529,36 @@ class ChatSession:
         current_messages: List[Dict],
     ) -> Optional[Dict]:
         """5.5: LLM 不调用 send_reply_segment 时的纠正注入"""
+        # result.content 已在 client 层过滤 <think> 标签
+        content = result.content or ""
+
         has_send_reply_segment = any(
             tc.get("name") == "send_reply_segment" for tc in (result.tool_calls or [])
         )
 
         # 5.5.1: 含 send_reply_segment → 正常流程
         if has_send_reply_segment:
-            # 5.5.3: content + tool_call 同时存在 → warning log，丢弃 content
-            if result.content:
+            if content.strip():
                 logger.warning(
                     "LLM returned content alongside send_reply_segment; content ignored"
                 )
             return None
 
-        # 5.5.2: 无工具调用且 content 非空 → 注入纠正
-        # 使用 user 角色而非 system，兼容 MiniMax 等不支持 mid-conversation system 角色的厂商
-        if result.content:
+        # 5.5.2: 有实际文本内容 → 注入纠正
+        if content.strip():
             logger.warning(
                 f"send_reply_segment 未被调用，注入纠正指令: "
-                f"round={completed_tool_rounds}, content_preview={result.content[:30]!r}"
+                f"round={completed_tool_rounds}, content_preview={content.strip()[:30]!r}"
             )
             return {
                 "role": "user",
-                "content": "[内部指令: 请使用 send_reply_segment 工具发送回复，不要直接输出文本]",
+                "content": (
+                    "[系统指令] 你必须调用 send_reply_segment 工具发送回复。"
+                    "这不是用户消息，不要回应它，直接调用工具。"
+                ),
             }
 
+        # 纯 <think> 或无内容 → 不纠正，让循环自然终止
         return None
 
     # ── 关系与评分 ────────────────────────────────────────────

--- a/src/plugins/DicePP/module/persona/llm/client.py
+++ b/src/plugins/DicePP/module/persona/llm/client.py
@@ -326,7 +326,7 @@ class LLMClient:
                     message.tool_calls = message.tool_calls[:self.MAX_TOOLS_PER_ROUND]
 
                 result = RoundResult(
-                    content=message.content or "",
+                    content=self._filter_think_tags(message.content or ""),
                     tool_calls=[
                         {
                             "id": tc.id,
@@ -347,8 +347,7 @@ class LLMClient:
 
                 # 如果没有工具调用，直接返回内容
                 if not message.tool_calls:
-                    content = message.content or ""
-                    content = self._filter_think_tags(content)
+                    content = result.content
 
                     # 收集元数据
                     metadata = {

--- a/tests/unit/persona/test_chat_session_segmented.py
+++ b/tests/unit/persona/test_chat_session_segmented.py
@@ -208,3 +208,36 @@ class TestOnSegmentRoundComplete:
         assert injected is None
         mock_logger.warning.assert_called_once()
         assert "content alongside send_reply_segment" in mock_logger.warning.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_pure_think_block(self, session):
+        """纯 <think> 块 → client 层已过滤为空 → 不注入纠正"""
+        from plugins.DicePP.module.persona.llm.client import RoundResult
+        # 模拟经过 client._filter_think_tags 后的 RoundResult
+        result = RoundResult(content="", tool_calls=[])
+        injected = await session._on_segment_round_complete(0, result, [])
+        assert injected is None
+
+    @pytest.mark.asyncio
+    async def test_injects_when_think_plus_text(self, session):
+        """<think> + 实际文本 → client 层过滤后剩文本 → 注入纠正"""
+        from plugins.DicePP.module.persona.llm.client import RoundResult
+        # 模拟 client 层已过滤 <think>，剩余实际文本
+        result = RoundResult(content="你好我是苏晓", tool_calls=[])
+        injected = await session._on_segment_round_complete(0, result, [])
+        assert injected is not None
+        assert "send_reply_segment" in injected["content"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_none_think_and_segment_tool(self, session):
+        """纯 <think> + send_reply_segment → client 层过滤后 content 为空 → 正常流程，无 warning"""
+        from unittest.mock import patch
+        from plugins.DicePP.module.persona.llm.client import RoundResult
+        result = RoundResult(
+            content="",
+            tool_calls=[{"name": "send_reply_segment"}],
+        )
+        with patch("plugins.DicePP.module.persona.chat.session.logger") as mock_logger:
+            injected = await session._on_segment_round_complete(0, result, [])
+        assert injected is None
+        mock_logger.warning.assert_not_called()

--- a/tests/unit/persona/test_chat_with_tools.py
+++ b/tests/unit/persona/test_chat_with_tools.py
@@ -497,3 +497,55 @@ class TestChatWithTools:
         sig = inspect.signature(LLMClient.generate_with_forced_tool)
         assert "on_round_complete" not in sig.parameters
         assert "max_round_callbacks" not in sig.parameters
+
+
+class TestFilterThinkTags:
+    """<think> 标签过滤（client 层模型输出归一化）"""
+
+    def test_filters_single_think_block(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags("<think>用户问的是前两个观察</think>")
+        assert result == ""
+
+    def test_filters_multiple_think_blocks(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags(
+            "<think>分析1</think>\n<think>分析2</think>"
+        )
+        assert result == ""
+
+    def test_preserves_text_after_think(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags(
+            "<think>需要回答</think>你好我是苏晓"
+        )
+        assert result == "你好我是苏晓"
+
+    def test_preserves_text_before_think(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags(
+            "你好<think>这里是思考</think>再见"
+        )
+        assert result == "你好再见"
+
+    def test_handles_multiline_think(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags(
+            "<think>\n分析中...\n需要搜索对话历史\n</think>\n"
+        )
+        assert result == ""
+
+    def test_no_think_tags_unchanged(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags("这是普通文本")
+        assert result == "这是普通文本"
+
+    def test_empty_string_unchanged(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags("")
+        assert result == ""
+
+    def test_whitespace_only_stripped(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        result = client._filter_think_tags("  \t\n  ")
+        assert result == ""

--- a/tests/unit/persona/test_context_builder.py
+++ b/tests/unit/persona/test_context_builder.py
@@ -246,6 +246,9 @@ class TestContextBuilderSegmentGuide:
         assert "100" in system  # soft_limit
         assert "120" in system  # hard_limit
         assert "delay_before" in system
+        assert "【系统消息说明】" in system
+        assert "[系统指令]" in system
+        assert "不是用户输入" in system
 
     def test_segment_guide_reflects_custom_values(self):
         char = self._make_character()


### PR DESCRIPTION
## Summary
- 修复 MiniMax 反复输出 `<think>` 块不调用 `send_reply_segment` 导致纠正配额耗尽的问题
- 修复纠正注入 `[内部指令]` 被 LLM 误认为用户输入的问题
- 关闭 backlog B-260511-e8a2d1, B-260511-b7c3f5

## 改动
- **client.py**: `<think>` 过滤统一在 RoundResult 构建时处理，模型输出归一化集中在 client 层
- **session.py**: 移除重复过滤逻辑，注入文案改为命令式 `[系统指令]`
- **context.py**: SegmentGuide 追加「系统消息说明」预声明，告知 LLM `[系统指令]` 不是用户输入
- **tests**: 新增 `TestFilterThinkTags`(8) + 回调过滤用例(3) + 预声明断言(3)

## Test plan
- [x] `uv run pytest tests/unit/persona/` — 50 passed