### PR TITLE
feat(persona): 事件描述与上下文摘要解耦，消除入库前硬截断

### DIFF
--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -813,12 +813,20 @@ class ChatSession:
 
         events = await self.store.get_daily_events(today)
         if events:
-            valid_events = [e for e in events if e.description and e.description.strip()]
+            valid_events = [
+                e for e in events
+                if (e.context_summary and e.context_summary.strip())
+                or (e.description and e.description.strip())
+            ]
             valid_events.sort(key=lambda e: e.created_at or PERSONA_EPOCH, reverse=True)
 
             if valid_events:
-                descriptions = [e.description for e in valid_events]
-                diary_context = "今天发生的事：" + "；".join(descriptions)
+                # 优先用 context_summary，空则回退到 description
+                summaries = [
+                    e.context_summary if e.context_summary else e.description
+                    for e in valid_events
+                ]
+                diary_context = "今天发生的事：" + "；".join(summaries)
                 if len(diary_context) > max_diary_len:
                     diary_context = diary_context[:max_diary_len].rsplit('；', 1)[0] + "..."
                 return diary_context

--- a/src/plugins/DicePP/module/persona/data/models.py
+++ b/src/plugins/DicePP/module/persona/data/models.py
@@ -205,6 +205,7 @@ class DailyEvent(BaseModel):
     date: str  # YYYY-MM-DD
     event_type: str  # "system" | "scheduled"
     description: str  # 事件描述
+    context_summary: str = ""  # 聊天上下文注入用的简短摘要
     reaction: str = ""  # 角色反应
     share_desire: float = 0.0  # 分享欲望值 0~1
     duration_minutes: int = 0  # 持续时间（分钟），0 表示瞬时

--- a/src/plugins/DicePP/module/persona/data/store.py
+++ b/src/plugins/DicePP/module/persona/data/store.py
@@ -85,6 +85,7 @@ class PersonaDataStore:
         await self._ensure_observations_debug_columns()
         await self._ensure_daily_events_share_columns()
         await self._ensure_daily_events_delta_columns()
+        await self._ensure_daily_events_context_summary()
         await self._ensure_scoring_failures_table()
 
     async def _ensure_group_activity_daily_columns(self) -> None:
@@ -213,6 +214,16 @@ class PersonaDataStore:
         if "health_delta" not in col_names:
             await self.db.execute(
                 "ALTER TABLE persona_daily_events ADD COLUMN health_delta INTEGER"
+            )
+
+    async def _ensure_daily_events_context_summary(self) -> None:
+        """为每日事件表增加 context_summary 列，存储聊天上下文注入用的简短摘要。"""
+        async with self.db.execute("PRAGMA table_info(persona_daily_events)") as cursor:
+            rows = await cursor.fetchall()
+        col_names = {row[1] for row in rows}
+        if "context_summary" not in col_names:
+            await self.db.execute(
+                "ALTER TABLE persona_daily_events ADD COLUMN context_summary TEXT DEFAULT ''"
             )
 
     async def _ensure_scoring_failures_table(self) -> None:
@@ -1006,6 +1017,7 @@ class PersonaDataStore:
         energy_delta: Optional[int] = None,
         mood_delta: Optional[int] = None,
         health_delta: Optional[int] = None,
+        context_summary: str = "",
     ) -> None:
         """添加每日事件"""
         await self.db.execute(
@@ -1014,8 +1026,9 @@ class PersonaDataStore:
                 date, event_type, description, reaction,
                 share_desire, duration_minutes,
                 system_prompt_digest, raw_response,
-                energy_delta, mood_delta, health_delta, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                energy_delta, mood_delta, health_delta, created_at,
+                context_summary
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 date,
@@ -1030,6 +1043,7 @@ class PersonaDataStore:
                 mood_delta,
                 health_delta,
                 self._wall_now().isoformat(),
+                context_summary,
             )
         )
         await self.db.commit()
@@ -1041,7 +1055,8 @@ class PersonaDataStore:
             SELECT event_type, description, reaction, share_desire,
                    duration_minutes, created_at,
                    system_prompt_digest, raw_response,
-                   energy_delta, mood_delta, health_delta
+                   energy_delta, mood_delta, health_delta,
+                   context_summary
             FROM persona_daily_events
             WHERE date = ?
             ORDER BY created_at
@@ -1063,6 +1078,7 @@ class PersonaDataStore:
                     energy_delta=row[8],
                     mood_delta=row[9],
                     health_delta=row[10],
+                    context_summary=row[11] or "",
                 )
                 for row in rows
             ]

--- a/src/plugins/DicePP/module/persona/life/character_life.py
+++ b/src/plugins/DicePP/module/persona/life/character_life.py
@@ -548,6 +548,7 @@ class CharacterLife:
                     energy_delta=event_result.energy_delta,
                     mood_delta=event_result.mood_delta,
                     health_delta=event_result.health_delta,
+                    context_summary=event_result.context_summary,
                 )
 
                 if event_result.duration_minutes > 0:

--- a/src/plugins/DicePP/module/persona/life/event_agent.py
+++ b/src/plugins/DicePP/module/persona/life/event_agent.py
@@ -21,12 +21,10 @@ _DEFAULT_BG_TIMEOUT = 90
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
 
-_EVENT_DESCRIPTION_MAX_LEN = 60
-
-
 @dataclass
 class EventGenerationResult:
     description: str = ""
+    context_summary: str = ""  # 用于聊天上下文注入的简短摘要
     duration_minutes: int = 0
     energy_delta: Optional[int] = None
     mood_delta: Optional[int] = None
@@ -195,10 +193,11 @@ class EventGenerationAgent:
 2. 只记录可观察的行为和状态（动作、位置、物品、身体状态）
 3. 不包含心理活动、情绪评价、内心独白
 4. 不使用"觉得""认为""感到"等主观动词
-5. 20-60字，简洁具体
-6. 符合世界观和场景设定，但场景中的具体动作是参考而非约束
-7. 避免与今天已发生事件在具体内容上高度重复，优先描述不同的事
-8. 同时给出该事件对角色体力/心情/健康的影响（delta，可选整数，范围-20~+20）
+5. description 自然叙事，不强制字数上限，但保持简洁
+6. context_summary 为事件摘要，30-60字，仅包含关键事实（谁、在哪、做了什么、结果）
+7. 符合世界观和场景设定，但场景中的具体动作是参考而非约束
+8. 避免与今天已发生事件在具体内容上高度重复，优先描述不同的事
+9. 同时给出该事件对角色体力/心情/健康的影响（delta，可选整数，范围-20~+20）
 
 你必须通过调用 record_event 工具来输出结果。"""
 
@@ -240,7 +239,12 @@ class EventGenerationAgent:
                         "properties": {
                             "description": {
                                 "type": "string",
-                                "description": "20-60字的生活事件描述",
+                                "description": "事件描述，自然叙事，不强制字数上限但保持简洁",
+                            },
+                            "context_summary": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "事件摘要，30-60字，仅包含关键事实（谁、在哪、做了什么、结果），用于聊天上下文注入",
                             },
                             "duration_minutes": {
                                 "type": "integer",
@@ -261,7 +265,7 @@ class EventGenerationAgent:
                                 "description": "事件对健康的影响（可选，范围-20~+20）",
                             },
                         },
-                        "required": ["description", "duration_minutes"],
+                        "required": ["description", "context_summary", "duration_minutes"],
                     },
                 },
             }
@@ -289,6 +293,11 @@ class EventGenerationAgent:
                 description = "我正在房间里休息。"
             duration_minutes = max(0, min(2880, int(args.get("duration_minutes", 0))))
 
+            context_summary = str(args.get("context_summary", "")).strip().strip('"').strip("'")
+            if not context_summary:
+                # fallback: 用 description 前 60 字
+                context_summary = description[:60]
+
             # 解析可选的 delta 值
             def _parse_delta(val) -> Optional[int]:
                 if val is None:
@@ -302,15 +311,13 @@ class EventGenerationAgent:
             mood_delta = _parse_delta(args.get("mood_delta"))
             health_delta = _parse_delta(args.get("health_delta"))
 
-            if len(description) > _EVENT_DESCRIPTION_MAX_LEN:
-                description = description[:_EVENT_DESCRIPTION_MAX_LEN - 3] + "..."
-
             logger.debug(
-                f"生成事件: {description}, duration={duration_minutes}, "
-                f"deltas=({energy_delta}, {mood_delta}, {health_delta})"
+                f"生成事件: {description[:50]}..., summary={context_summary[:50]}..., "
+                f"duration={duration_minutes}, deltas=({energy_delta}, {mood_delta}, {health_delta})"
             )
             return EventGenerationResult(
                 description=description,
+                context_summary=context_summary,
                 duration_minutes=duration_minutes,
                 energy_delta=energy_delta,
                 mood_delta=mood_delta,
@@ -323,6 +330,7 @@ class EventGenerationAgent:
             logger.error(f"事件生成失败: {e}")
             fallback_args = {
                 "description": "我正在房间里休息。",
+                "context_summary": "在房间里休息",
                 "duration_minutes": 0,
                 "energy_delta": 0,
                 "mood_delta": None,

--- a/tests/unit/persona/test_chat_session.py
+++ b/tests/unit/persona/test_chat_session.py
@@ -14,7 +14,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from plugins.DicePP.module.persona.chat.session import ChatSession, ChatConfig
-from plugins.DicePP.module.persona.data.models import RelationshipState
+from plugins.DicePP.module.persona.data.models import DailyEvent, RelationshipState
 from plugins.DicePP.module.persona.llm.coordinator import LLMCallCoordinator
 
 
@@ -327,3 +327,77 @@ class TestDecayInChatSession:
         # 验证写入的 score_event 包含 decay 原因
         event = session.store.add_score_event.call_args[0][0]
         assert "time_decay" in event.reason
+
+
+class TestBuildDiaryContext:
+    """测试 _build_diary_context 的 context_summary 选择逻辑"""
+
+    @pytest.mark.asyncio
+    async def test_uses_context_summary_when_present(self):
+        """context_summary 非空时优先使用"""
+        session = _make_session()
+        session.store.get_daily_events = AsyncMock(return_value=[
+            DailyEvent(date="2024-01-01", event_type="system",
+                       description="长描述内容在这里很长很长很长",
+                       context_summary="短摘要"),
+        ])
+        session.store.get_diary = AsyncMock(return_value=None)
+        result = await session._build_diary_context()
+        assert "短摘要" in result
+        assert "长描述" not in result
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_description_when_context_summary_empty(self):
+        """context_summary 为空时回退到 description"""
+        session = _make_session()
+        session.store.get_daily_events = AsyncMock(return_value=[
+            DailyEvent(date="2024-01-01", event_type="system",
+                       description="窗外下雨了",
+                       context_summary=""),
+        ])
+        session.store.get_diary = AsyncMock(return_value=None)
+        result = await session._build_diary_context()
+        assert "窗外下雨了" in result
+
+    @pytest.mark.asyncio
+    async def test_filters_out_events_with_both_fields_empty(self):
+        """context_summary 和 description 都为空时事件被过滤"""
+        session = _make_session()
+        session.store.get_daily_events = AsyncMock(return_value=[
+            DailyEvent(date="2024-01-01", event_type="system",
+                       description="   ", context_summary=""),
+        ])
+        session.store.get_diary = AsyncMock(return_value=None)
+        result = await session._build_diary_context()
+        assert result == ""  # 无有效事件，无日记
+
+    @pytest.mark.asyncio
+    async def test_mixed_scenario(self):
+        """混合场景：摘要/回退/过滤同时存在"""
+        session = _make_session()
+        session.store.get_daily_events = AsyncMock(return_value=[
+            DailyEvent(date="2024-01-01", event_type="system",
+                       description="长描述A", context_summary="摘要A"),
+            DailyEvent(date="2024-01-01", event_type="system",
+                       description="长描述B", context_summary=""),
+            DailyEvent(date="2024-01-01", event_type="system",
+                       description="   ", context_summary=""),
+        ])
+        session.store.get_diary = AsyncMock(return_value=None)
+        result = await session._build_diary_context()
+        assert "摘要A" in result        # 使用 context_summary
+        assert "长描述B" in result      # 回退到 description
+        assert "长描述A" not in result  # context_summary 替代了 description
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_yesterday_diary_when_no_events(self):
+        """无有效事件时回退到昨日日记"""
+        session = _make_session()
+        session.store.get_daily_events = AsyncMock(return_value=[
+            DailyEvent(date="2024-01-01", event_type="system",
+                       description="   ", context_summary=""),
+        ])
+        session.store.get_diary = AsyncMock(return_value="昨天去了公园")
+        result = await session._build_diary_context()
+        assert "昨天" in result
+        assert "公园" in result

--- a/tests/unit/persona/test_data_store_daily_event.py
+++ b/tests/unit/persona/test_data_store_daily_event.py
@@ -22,10 +22,17 @@ async def test_add_and_get_daily_event_with_new_fields(tmp_path):
         energy_delta=3,
         mood_delta=-2,
         health_delta=1,
+        context_summary="在酒馆喝酒",
+    )
+    # 不传 context_summary
+    await store.add_daily_event(
+        date="2024-01-01",
+        event_type="system",
+        description="另一件事",
     )
 
     events = await store.get_daily_events("2024-01-01")
-    assert len(events) == 1
+    assert len(events) == 2
     ev = events[0]
     assert ev.share_desire == 0.75
     assert ev.duration_minutes == 30
@@ -35,5 +42,9 @@ async def test_add_and_get_daily_event_with_new_fields(tmp_path):
     assert ev.energy_delta == 3
     assert ev.mood_delta == -2
     assert ev.health_delta == 1
+    assert ev.context_summary == "在酒馆喝酒"
+    # 不传时回读为空字符串
+    ev2 = events[1]
+    assert ev2.context_summary == ""
 
     await db.close()

--- a/tests/unit/persona/test_event_agent.py
+++ b/tests/unit/persona/test_event_agent.py
@@ -176,7 +176,7 @@ class TestGenerateEventResult:
     @pytest.mark.asyncio
     async def test_generate_event_result_success(self, agent_forced, mock_llm_router_forced):
         mock_llm_router_forced.generate_with_forced_tool.return_value = (
-            '{"description": "窗外下雨了", "duration_minutes": 30}',
+            '{"description": "窗外下雨了", "context_summary": "窗外下雨", "duration_minutes": 30}',
             {}
         )
 
@@ -193,11 +193,13 @@ class TestGenerateEventResult:
         )
 
         assert result.description == "窗外下雨了"
+        assert result.context_summary == "窗外下雨"
         assert result.duration_minutes == 30
         # raw_response 和 system_prompt_digest 必须保存原始 LLM 输出
         assert result.raw_response != ""
         raw = json.loads(result.raw_response)
         assert raw["description"] == "窗外下雨了"
+        assert raw["context_summary"] == "窗外下雨"
         assert raw["duration_minutes"] == 30
         assert result.system_prompt_digest != ""
         assert "世界观设定专家" in result.system_prompt_digest
@@ -297,9 +299,9 @@ class TestGenerateEventResult:
         assert result.duration_minutes == 0
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_truncate_long_description(self, agent_forced, mock_llm_router_forced):
-        """超长描述被截断到 _EVENT_DESCRIPTION_MAX_LEN 并加省略号"""
-        long_desc = "窗外" * 50  # 100 字，超过 60
+    async def test_generate_event_result_no_truncate_long_description(self, agent_forced, mock_llm_router_forced):
+        """description 不再硬截断，完整保留；context_summary 为空时 fallback 到 description 前 60 字"""
+        long_desc = "窗外" * 50  # 100 字
         mock_llm_router_forced.generate_with_forced_tool.return_value = (
             f'{{"description": "{long_desc}", "duration_minutes": 0}}',
             {}
@@ -317,8 +319,28 @@ class TestGenerateEventResult:
             )
         )
 
-        assert len(result.description) <= 60
-        assert result.description.endswith("...")
+        assert result.description == long_desc  # 完整保留，不截断
+        assert len(result.context_summary) == 60
+        assert result.context_summary == long_desc[:60]
+
+        # description < 60 字时 fallback 保留完整文本
+        short_desc = "窗外下雨了"
+        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+            f'{{"description": "{short_desc}", "duration_minutes": 0}}',
+            {}
+        )
+        result2 = await agent_forced.generate_event_result(
+            EventContext(
+                character_name="小雨",
+                character_description="温柔的少女",
+                world="",
+                scenario="",
+                recent_diaries=[],
+                today_events=[],
+                current_time=datetime(2024, 1, 1, 10, 0),
+            )
+        )
+        assert result2.context_summary == short_desc
 
     @pytest.mark.asyncio
     async def test_generate_event_result_empty_context(self, agent_forced, mock_llm_router_forced):

--- a/tests/unit/persona/test_scoring_failure_store.py
+++ b/tests/unit/persona/test_scoring_failure_store.py
@@ -5,6 +5,7 @@
 from datetime import datetime, timedelta
 import aiosqlite
 import pytest
+from unittest.mock import patch
 
 from plugins.DicePP.module.persona.data.store import PersonaDataStore
 from plugins.DicePP.module.persona.data.models import ScoringFailure
@@ -136,8 +137,9 @@ async def test_prune_scoring_failures_by_days():
             )
         )
 
-        # 清理 1 天前的记录
-        deleted = await store.prune_scoring_failures(1)
+        # 锁定 _wall_now 为测试时间，避免真实时间流逝影响 cutoff 计算
+        with patch.object(store, '_wall_now', return_value=now):
+            deleted = await store.prune_scoring_failures(1)
         assert deleted == 1
 
         remaining = await store.get_recent_scoring_failures("u4", "g4", limit=10)

--- a/tests/unit/persona/test_store_migration.py
+++ b/tests/unit/persona/test_store_migration.py
@@ -99,3 +99,87 @@ class TestPeakStageBackfill:
         # peak_stage 应保持为 3（不被 backfill 覆盖）
         rel2 = await store.get_relationship("u_cold", "")
         assert rel2.peak_stage == 3
+
+
+@pytest.fixture
+async def old_schema_daily_events_db():
+    """创建模拟旧 schema 的 daily_events 表（无 context_summary 列）。"""
+    import aiosqlite
+
+    async with aiosqlite.connect(":memory:") as db:
+        await db.execute(
+            """
+            CREATE TABLE persona_daily_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                date TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                description TEXT NOT NULL,
+                reaction TEXT DEFAULT '',
+                share_desire REAL DEFAULT 0.0,
+                duration_minutes INTEGER DEFAULT 0,
+                system_prompt_digest TEXT DEFAULT '',
+                raw_response TEXT DEFAULT '',
+                energy_delta INTEGER,
+                mood_delta INTEGER,
+                health_delta INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        # 插入一条旧数据
+        await db.execute(
+            """
+            INSERT INTO persona_daily_events
+            (date, event_type, description)
+            VALUES (?, ?, ?)
+            """,
+            ("2024-01-01", "system", "旧事件"),
+        )
+        await db.commit()
+
+        store = PersonaDataStore(db)
+        await store.ensure_tables()
+        yield store
+
+
+class TestContextSummaryMigration:
+    """测试 context_summary 列迁移：旧 schema → 新列添加 + 幂等。"""
+
+    @pytest.mark.asyncio
+    async def test_migration_adds_context_summary_column(self, old_schema_daily_events_db):
+        """旧 schema 表经 ensure_tables 后应增加 context_summary 列且旧行值为 ''。"""
+        store = old_schema_daily_events_db
+
+        # 验证 PRAGMA 中列已存在
+        async with store.db.execute("PRAGMA table_info(persona_daily_events)") as cursor:
+            rows = await cursor.fetchall()
+        col_names = {row[1] for row in rows}
+        assert "context_summary" in col_names
+
+        # 旧行回读 context_summary 为空字符串
+        events = await store.get_daily_events("2024-01-01")
+        assert len(events) == 1
+        assert events[0].context_summary == ""
+
+    @pytest.mark.asyncio
+    async def test_migration_idempotent(self, old_schema_daily_events_db):
+        """重复调用 ensure_tables 不报错且列不变。"""
+        store = old_schema_daily_events_db
+        await store.ensure_tables()  # 第二次调用
+
+        async with store.db.execute("PRAGMA table_info(persona_daily_events)") as cursor:
+            rows = await cursor.fetchall()
+        col_names = {row[1] for row in rows}
+        assert "context_summary" in col_names
+
+        # 写入新数据验证列可正常使用
+        await store.add_daily_event(
+            date="2024-01-01",
+            event_type="system",
+            description="新事件",
+            context_summary="新摘要",
+        )
+        events = await store.get_daily_events("2024-01-01")
+        assert len(events) == 2
+        new_ev = [e for e in events if e.context_summary == "新摘要"][0]
+        assert new_ev.description == "新事件"


### PR DESCRIPTION
## Summary

- 移除 `_EVENT_DESCRIPTION_MAX_LEN` 硬截断（57 字符 + "..."），事件描述不再入库前被破坏
- `record_event` tool schema 新增 `context_summary` 字段，LLM 一次调用产出两份：description（完整叙事）+ context_summary（30-60 字关键事实）
- `_build_diary_context` 优先用 `context_summary`，空则回退 `description`
- 链生成/日记/分享消息继续使用完整 `description`
- 新增 schema migration 补丁 `_ensure_daily_events_context_summary` 兼容旧数据库

## Test plan

- [x] `uv run pytest` 全量通过（1651 passed）
- [ ] 交互式验收：dicepp-shell 启动机器人，观察事件生成和聊天回复是否正常