### PR TITLE
feat(persona): LLM 上下文新增时间戳，使模型可感知消息时序

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -37,18 +37,6 @@
   - 或者 `_EVENT_DESCRIPTION_MAX_LEN` 上调到合理值（如 300），但既然 `_build_diary_context` 已有整体预算控制，直接移除硬截断更干净
   - 影响面: `event_agent.py` 事件生成、`session.py` `_build_diary_context` 截断逻辑
 
-### [B-260511-c9d0e4] 短期记忆和事件注入未附带时间戳，LLM 无法感知时间顺序
-- 创建: 2026-05-11
-- 问题表现:
-  - `context.py:215-221` `_format_short_term()` 仅输出 `[称呼] content`，丢弃了 `msg.get("created_at")`
-  - `session.py:807-824` `_build_diary_context()` 虽然按 `created_at` 排序事件，但最终只拼接纯文本描述 `描述；描述；描述...`，时间信息全部丢弃
-  - 两个位置的数据模型（`UserMessage`、`GroupConversation`、`DailyEvent`）均有 `created_at` 字段但未被使用
-- 工作计划:
-  - `_format_short_term()`: 每条消息前加上相对时间或绝对时间（如 `[12:34] [你] xxx` 或 `[5分钟前] [你] xxx`）
-  - `_build_diary_context()`: 事件描述前加上时间前缀（如 `08:15 七七醒来...；12:30 七七在绝云间...`）
-  - 时间格式用相对时间（距当前时间）还是绝对时间（HH:MM），取决于角色设定倾向；建议默认绝对时间，保持信息密度
-  - 影响面: `context.py` `_format_short_term`、`session.py` `_build_diary_context`、数据模型 dict 转换通知 created_at
-
 ### [B-260511-e2f3c7] 主动分享 prompt 中 recent_history 引发跨时段"补答"
 - 创建: 2026-05-11
 - 问题表现:

--- a/src/plugins/DicePP/module/persona/chat/context.py
+++ b/src/plugins/DicePP/module/persona/chat/context.py
@@ -11,7 +11,7 @@ from utils.string import estimate_tokens
 
 from ..character.models import Character
 from ..data.models import UserProfile
-from ..wall_clock import persona_wall_now
+from ..wall_clock import persona_wall_now, format_timestamp
 
 DEFAULT_DELAY_BEFORE = 1.0
 
@@ -218,11 +218,16 @@ class ContextBuilder:
         return "\n\n".join(parts)
 
     def _format_short_term(self, history: List[Dict[str, str]]) -> str:
-        """格式化短期记忆，根据 speaker_name 生成称呼前缀"""
+        """格式化短期记忆，根据 speaker_name 生成称呼前缀，附带时间戳"""
         lines = []
+        now = persona_wall_now(self.timezone)
         for msg in history:
             speaker_name = msg.get("speaker_name") or ("你" if msg["role"] == "user" else "我")
-            lines.append(f"[{speaker_name}] {msg['content']}")
+            prefix = format_timestamp(msg.get("created_at"), now)
+            if prefix:
+                lines.append(f"[{prefix}] [{speaker_name}] {msg['content']}")
+            else:
+                lines.append(f"[{speaker_name}] {msg['content']}")
         return "\n".join(lines)
 
     def truncate_by_turns(self, history: List[Dict[str, str]], max_chars: int) -> List[Dict[str, str]]:

--- a/src/plugins/DicePP/module/persona/chat/scoring.py
+++ b/src/plugins/DicePP/module/persona/chat/scoring.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from ..data.models import ScoreDeltas, UserProfile, RelationshipState, ModelTier
 from ..llm.router import LLMRouter
 from ..utils.json_helpers import safe_json_loads
+from ..wall_clock import persona_wall_now, format_timestamp
 
 
 class ScoringAnalysisResult(BaseModel):
@@ -23,8 +24,9 @@ class ScoringAnalysisResult(BaseModel):
 class ScoringAgent:
     """评分 Agent - 批量分析对话提取用户档案和好感度变化"""
 
-    def __init__(self, llm_router: LLMRouter):
+    def __init__(self, llm_router: LLMRouter, timezone: str = "Asia/Shanghai"):
         self.llm_router = llm_router
+        self.timezone = timezone
 
     async def batch_analyze(
         self,
@@ -61,9 +63,14 @@ class ScoringAgent:
         relationship: Optional[RelationshipState] = None,
     ) -> str:
         dialogue_lines = []
+        now = persona_wall_now(self.timezone)
         for msg in messages:
             role = "用户" if msg["role"] == "user" else "AI"
-            dialogue_lines.append(f"{role}: {msg['content']}")
+            prefix = format_timestamp(msg.get("created_at"), now)
+            if prefix:
+                dialogue_lines.append(f"[{prefix}] {role}: {msg['content']}")
+            else:
+                dialogue_lines.append(f"{role}: {msg['content']}")
         dialogue = "\n".join(dialogue_lines)
 
         existing_facts = json.dumps(profile.facts, ensure_ascii=False) if profile and profile.facts else "无"

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -35,7 +35,7 @@ from ..character.models import Character
 from ..chat.scoring import ScoringAgent
 from ..chat.context import ContextBuilder
 from ..game.decay import DecayCalculator
-from ..wall_clock import persona_wall_now, PERSONA_EPOCH
+from ..wall_clock import persona_wall_now, PERSONA_EPOCH, format_timestamp
 from ..tools.registry import ToolRegistry, ToolDomain
 from ..tools.context import ToolContext
 from ..llm.coordinator import LLMCallCoordinator
@@ -601,8 +601,8 @@ class ChatSession:
         key = f"{user_id}:{group_id}"
         if key not in self._pending_messages:
             self._pending_messages[key] = deque(maxlen=100)
-        self._pending_messages[key].append({"role": "user", "content": user_msg})
-        self._pending_messages[key].append({"role": "assistant", "content": assistant_msg})
+        self._pending_messages[key].append({"role": "user", "content": user_msg, "created_at": now})
+        self._pending_messages[key].append({"role": "assistant", "content": assistant_msg, "created_at": now})
 
         if len(self._pending_messages[key]) >= self.config.scoring_interval * 2:
             try:
@@ -725,7 +725,7 @@ class ChatSession:
         if not group_id:
             history = await self.store.get_recent_messages(user_id, group_id, limit=limit)
             history_dicts = [
-                {"role": msg.role, "content": msg.content, "speaker_name": "你" if msg.role == "user" else "我"}
+                {"role": msg.role, "content": msg.content, "speaker_name": "你" if msg.role == "user" else "我", "created_at": msg.created_at}
                 for msg in history
             ]
             truncated = self.context_builder.truncate_by_turns(
@@ -785,6 +785,7 @@ class ChatSession:
                 "role": msg.role,
                 "content": content,
                 "speaker_name": speaker_name,
+                "created_at": msg.created_at,
             })
             total_tokens += msg_cost
 
@@ -823,14 +824,16 @@ class ChatSession:
                 if (e.context_summary and e.context_summary.strip())
                 or (e.description and e.description.strip())
             ]
-            valid_events.sort(key=lambda e: e.created_at or PERSONA_EPOCH, reverse=True)
+            # 按时间升序排列（旧→新），使日记以自然时序呈现
+            valid_events.sort(key=lambda e: e.created_at or PERSONA_EPOCH, reverse=False)
 
             if valid_events:
                 # 优先用 context_summary，空则回退到 description
-                summaries = [
-                    e.context_summary if e.context_summary else e.description
-                    for e in valid_events
-                ]
+                summaries = []
+                for e in valid_events:
+                    prefix = format_timestamp(e.created_at, wall)
+                    text = e.context_summary if e.context_summary else e.description
+                    summaries.append(f"{prefix} {text}" if prefix else text)
                 diary_context = "今天发生的事：" + "；".join(summaries)
                 if len(diary_context) > max_diary_len:
                     diary_context = diary_context[:max_diary_len].rsplit('；', 1)[0] + "..."

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -216,7 +216,7 @@ def _build_chat(
     segment_dispatcher: Optional[SegmentDispatcher] = None,
 ) -> ChatSession:
     """组装 ChatSession"""
-    scoring_agent = ScoringAgent(router)
+    scoring_agent = ScoringAgent(router, timezone=config.timezone)
     from .chat.context import SegmentGuide
 
     segment_guide = None

--- a/src/plugins/DicePP/module/persona/life/observation.py
+++ b/src/plugins/DicePP/module/persona/life/observation.py
@@ -18,6 +18,7 @@ from nonebot.log import logger
 from .event_agent import EventGenerationAgent
 from ..data.store import PersonaDataStore
 from ..utils.json_helpers import safe_json_loads
+from ..wall_clock import persona_wall_now, format_timestamp
 
 
 @dataclass
@@ -340,8 +341,9 @@ class ObservationExtractor:
 
         try:
             # 构建消息文本
+            now = persona_wall_now(self.config.timezone)
             messages_text = "\n".join(
-                f"{msg.nickname}: {msg.content}"
+                f"[{format_timestamp(msg.timestamp, now)}] {msg.nickname}: {msg.content}"
                 for msg in messages[-20:]  # 最多取最近20条
             )
 

--- a/src/plugins/DicePP/module/persona/life/proactive_scheduler.py
+++ b/src/plugins/DicePP/module/persona/life/proactive_scheduler.py
@@ -15,7 +15,7 @@ from ..data.persist_keys import PERSONA_SK_SCHEDULER
 from ..data.models import RelationshipState, DEFAULT_WARMTH_LABELS
 from ..character.models import Character
 from ..game.decay import DecayCalculator
-from ..wall_clock import persona_wall_now
+from ..wall_clock import persona_wall_now, format_timestamp
 from .event_agent import EventGenerationAgent, ShareMessageContext
 from .protocols import BoundaryReceiver
 from .models import ShareTarget
@@ -385,19 +385,24 @@ class ProactiveScheduler(BoundaryReceiver):
         text = "\n".join(lines) if lines else "（无）"
         return ProactiveScheduler._sanitize_prompt_text(text)
 
-    @staticmethod
-    def _format_recent_history(messages, limit: int = 5) -> str:
-        """将 Message 列表格式化为精简对话摘要。"""
+    # 改为实例方法以通过 self._now() 获取时区时间
+    def _format_recent_history(self, messages, limit: int = 5) -> str:
+        """将 Message 列表格式化为精简对话摘要，附带时间戳。"""
         if not messages:
             return "（无）"
         lines = []
+        now = self._now()
         role_map = {"user": "用户", "assistant": "我", "system": "系统", "tool": "工具"}
         for msg in messages[-limit:]:
             role_label = role_map.get(msg.role, "用户")
             content = msg.content
             if len(content) > 50:
                 content = content[:47] + "..."
-            lines.append(f"- {role_label}: {content}")
+            prefix = format_timestamp(getattr(msg, "created_at", None), now)
+            if prefix:
+                lines.append(f"- [{prefix}] {role_label}: {content}")
+            else:
+                lines.append(f"- {role_label}: {content}")
         text = "\n".join(lines)
         return ProactiveScheduler._sanitize_prompt_text(text)
 

--- a/src/plugins/DicePP/module/persona/wall_clock.py
+++ b/src/plugins/DicePP/module/persona/wall_clock.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from typing import Optional, Union
 from nonebot.log import logger
 from datetime import datetime
 
@@ -34,3 +35,27 @@ def persona_wall_now(timezone_name: str) -> datetime:
             e,
         )
         return datetime.now()
+
+
+def format_timestamp(
+    ts: Optional[Union[datetime, str]],
+    now: datetime,
+    fmt_today: str = "%H:%M",
+    fmt_other: str = "%m-%d %H:%M",
+) -> str:
+    """格式化时间戳为可读字符串。
+
+    - ts: datetime / ISO str / None
+    - now: 参考时间（用于判断是否同日）
+    - 返回值: 当日返回 HH:MM，隔日返回 MM-DD HH:MM，ts 为 None 返回空字符串
+    """
+    if ts is None:
+        return ""
+    if isinstance(ts, str):
+        try:
+            ts = datetime.fromisoformat(ts)
+        except ValueError:
+            return ""
+    if not isinstance(ts, datetime):
+        return ""
+    return ts.strftime(fmt_today) if ts.date() == now.date() else ts.strftime(fmt_other)

--- a/tests/unit/persona/test_scheduler_context.py
+++ b/tests/unit/persona/test_scheduler_context.py
@@ -4,6 +4,8 @@
 覆盖 _build_share_context 默认值、_format_user_profile_facts、_format_recent_history。
 """
 
+from datetime import datetime
+
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
@@ -231,8 +233,14 @@ class TestFormatUserProfileFacts:
 class TestFormatRecentHistory:
     """测试 _format_recent_history"""
 
+    @staticmethod
+    def _mock_scheduler():
+        s = MagicMock()
+        s._now.return_value = datetime.now()
+        return s
+
     def test_empty_messages(self):
-        assert ProactiveScheduler._format_recent_history([]) == "（无）"
+        assert ProactiveScheduler._format_recent_history(self._mock_scheduler(), []) == "（无）"
 
     def test_user_and_assistant(self):
         msg1 = MagicMock()
@@ -241,7 +249,7 @@ class TestFormatRecentHistory:
         msg2 = MagicMock()
         msg2.role = "assistant"
         msg2.content = "你好呀"
-        result = ProactiveScheduler._format_recent_history([msg1, msg2])
+        result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), [msg1, msg2])
         assert "- 用户: 你好" in result
         assert "- 我: 你好呀" in result
 
@@ -249,28 +257,28 @@ class TestFormatRecentHistory:
         msg = MagicMock()
         msg.role = "system"
         msg.content = "系统提示"
-        result = ProactiveScheduler._format_recent_history([msg])
+        result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), [msg])
         assert "- 系统: 系统提示" in result
 
     def test_tool_role(self):
         msg = MagicMock()
         msg.role = "tool"
         msg.content = "工具结果"
-        result = ProactiveScheduler._format_recent_history([msg])
+        result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), [msg])
         assert "- 工具: 工具结果" in result
 
     def test_unknown_role(self):
         msg = MagicMock()
         msg.role = "unknown"
         msg.content = "未知内容"
-        result = ProactiveScheduler._format_recent_history([msg])
+        result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), [msg])
         assert "- 用户: 未知内容" in result  # 兜底为"用户"
 
     def test_long_content_truncation(self):
         msg = MagicMock()
         msg.role = "user"
         msg.content = "哈" * 100
-        result = ProactiveScheduler._format_recent_history([msg])
+        result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), [msg])
         assert result.endswith("...")
         assert len(result) < 100
 
@@ -281,11 +289,20 @@ class TestFormatRecentHistory:
             m.role = "user"
             m.content = f"消息{i}"
             msgs.append(m)
-        result = ProactiveScheduler._format_recent_history(msgs, limit=3)
+        result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), msgs, limit=3)
         lines = result.split("\n")
         assert len(lines) == 3
         assert "消息7" in result
         assert "消息0" not in result
+
+    def test_with_timestamps(self):
+        now = datetime.now()
+        msg = MagicMock()
+        msg.role = "user"
+        msg.content = "你好"
+        msg.created_at = datetime(2026, 5, 11, 9, 15)
+        result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), [msg])
+        assert "[09:15] 用户: 你好" in result
 
 
 if __name__ == "__main__":

--- a/tests/unit/persona/test_wall_clock.py
+++ b/tests/unit/persona/test_wall_clock.py
@@ -1,0 +1,31 @@
+"""format_timestamp 单元测试"""
+from datetime import datetime
+
+from plugins.DicePP.module.persona.wall_clock import format_timestamp
+
+
+class TestFormatTimestamp:
+    """覆盖 format_timestamp 的 4 条分支路径"""
+
+    def test_none_returns_empty(self):
+        assert format_timestamp(None, datetime.now()) == ""
+
+    def test_str_iso_today(self):
+        now = datetime(2026, 5, 11, 14, 30)
+        assert format_timestamp("2026-05-11T08:30:00", now) == "08:30"
+
+    def test_str_iso_other_day(self):
+        now = datetime(2026, 5, 11, 14, 30)
+        assert format_timestamp("2026-05-09T14:00:00", now) == "05-09 14:00"
+
+    def test_datetime_today(self):
+        now = datetime(2026, 5, 11, 14, 30)
+        assert format_timestamp(datetime(2026, 5, 11, 9, 15), now) == "09:15"
+
+    def test_datetime_other_day(self):
+        now = datetime(2026, 5, 11, 14, 30)
+        assert format_timestamp(datetime(2026, 5, 9, 14, 0), now) == "05-09 14:00"
+
+    def test_non_datetime_type_returns_empty(self):
+        now = datetime(2026, 5, 11, 14, 30)
+        assert format_timestamp("not a datetime", now) == ""


### PR DESCRIPTION
## Summary

- 短期记忆 (`_format_short_term`)、日记事件 (`_build_diary_context`)、评分对话 (`_build_analysis_prompt`)、群聊观察提取、主动分享摘要中均注入消息/事件的时间前缀 `[HH:MM]`
- 提取 `format_timestamp` 工具函数到 `wall_clock.py`，统一 5 处调用点的格式化逻辑
- 修正 `scoring.py` 和 `proactive_scheduler.py` 中两处 `datetime.now()` 为 `persona_wall_now`，确保时区一致
- 日记事件排序从降序改为升序（旧→新），以自然时序呈现

## Files changed

- `wall_clock.py`: 新增 `format_timestamp()` 工具函数
- `chat/context.py`: `_format_short_term` 每条消息加时间前缀
- `chat/session.py`: 数据流透传 `created_at`，日记上下文加时间前缀+升序排列
- `chat/scoring.py`: 评分 prompt 对话行加时间前缀，使用 `persona_wall_now`
- `life/observation.py`: 群聊观察消息加时间前缀
- `life/proactive_scheduler.py`: 主动分享历史摘要加时间前缀，`@staticmethod`→实例方法
- `factory.py`: ScoringAgent 传入 timezone
- `tests/`: 新增 `test_wall_clock.py`，补充时间戳测试用例

## Test plan

- [x] `uv run pytest` 1669 passed
- [x] 手动验证各位置 `[HH:MM]` 格式输出正确