### PR TITLE
feat(persona): LLM trace 记录完整工具调用轮次摘要

### DIFF
--- a/src/plugins/DicePP/module/persona/data/migrations.py
+++ b/src/plugins/DicePP/module/persona/data/migrations.py
@@ -258,6 +258,7 @@ CREATE TABLE IF NOT EXISTS persona_llm_traces (
     messages TEXT NOT NULL,
     response TEXT NOT NULL,
     tool_calls TEXT DEFAULT '',
+    round_messages TEXT DEFAULT '',
     latency_ms INTEGER,
     tokens_in INTEGER DEFAULT 0,
     tokens_out INTEGER DEFAULT 0,

--- a/src/plugins/DicePP/module/persona/data/models.py
+++ b/src/plugins/DicePP/module/persona/data/models.py
@@ -274,6 +274,7 @@ class LLMTraceRecord(BaseModel):
     messages: str  # JSON
     response: str
     tool_calls: str = ""  # JSON
+    round_messages: str = ""  # JSON — 结构化轮次摘要
     latency_ms: Optional[int] = None
     tokens_in: int = 0
     tokens_out: int = 0

--- a/src/plugins/DicePP/module/persona/data/store.py
+++ b/src/plugins/DicePP/module/persona/data/store.py
@@ -87,6 +87,7 @@ class PersonaDataStore:
         await self._ensure_daily_events_delta_columns()
         await self._ensure_daily_events_context_summary()
         await self._ensure_scoring_failures_table()
+        await self._ensure_llm_traces_round_messages()
 
     async def _ensure_group_activity_daily_columns(self) -> None:
         """
@@ -249,6 +250,16 @@ class PersonaDataStore:
         if "conversation_digest" not in col_names:
             await self.db.execute(
                 "ALTER TABLE persona_scoring_failures ADD COLUMN conversation_digest TEXT DEFAULT ''"
+            )
+
+    async def _ensure_llm_traces_round_messages(self) -> None:
+        """为 LLM trace 表增加 round_messages 列（兼容旧库升级）。"""
+        async with self.db.execute("PRAGMA table_info(persona_llm_traces)") as cursor:
+            rows = await cursor.fetchall()
+        col_names = {r[1] for r in rows}
+        if "round_messages" not in col_names:
+            await self.db.execute(
+                "ALTER TABLE persona_llm_traces ADD COLUMN round_messages TEXT DEFAULT ''"
             )
 
     # ========== 消息相关 ==========
@@ -516,9 +527,9 @@ class PersonaDataStore:
             """
             INSERT INTO persona_llm_traces (
                 session_id, user_id, group_id, model, tier,
-                messages, response, tool_calls, latency_ms,
+                messages, response, tool_calls, round_messages, latency_ms,
                 tokens_in, tokens_out, temperature, status, error, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 trace.session_id,
@@ -529,6 +540,7 @@ class PersonaDataStore:
                 trace.messages,
                 trace.response,
                 trace.tool_calls,
+                trace.round_messages,
                 trace.latency_ms,
                 trace.tokens_in,
                 trace.tokens_out,
@@ -548,7 +560,7 @@ class PersonaDataStore:
         async with self.db.execute(
             """
             SELECT id, session_id, user_id, group_id, model, tier,
-                   messages, response, tool_calls, latency_ms,
+                   messages, response, tool_calls, round_messages, latency_ms,
                    tokens_in, tokens_out, temperature, status, error, created_at
             FROM persona_llm_traces
             WHERE user_id = ?
@@ -570,13 +582,14 @@ class PersonaDataStore:
                     messages=row[6],
                     response=row[7],
                     tool_calls=row[8] or "",
-                    latency_ms=row[9],
-                    tokens_in=row[10] or 0,
-                    tokens_out=row[11] or 0,
-                    temperature=row[12],
-                    status=row[13],
-                    error=row[14] or "",
-                    created_at=datetime.fromisoformat(row[15]) if row[15] else None,
+                    round_messages=row[9] or "",
+                    latency_ms=row[10],
+                    tokens_in=row[11] or 0,
+                    tokens_out=row[12] or 0,
+                    temperature=row[13],
+                    status=row[14],
+                    error=row[15] or "",
+                    created_at=datetime.fromisoformat(row[16]) if row[16] else None,
                 ))
             return traces
 

--- a/src/plugins/DicePP/module/persona/llm/client.py
+++ b/src/plugins/DicePP/module/persona/llm/client.py
@@ -4,10 +4,12 @@ LLM 客户端封装
 基于 AsyncOpenAI 的异步客户端，支持超时和错误处理
 """
 import asyncio
-from dataclasses import dataclass
-from nonebot.log import logger
-from typing import List, Dict, Optional, Any, Callable, Awaitable, TypedDict
+import re
 import time
+from dataclasses import dataclass
+from typing import List, Dict, Optional, Any, Callable, Awaitable, TypedDict
+
+from nonebot.log import logger
 
 
 class ToolCallInfo(TypedDict):
@@ -74,12 +76,19 @@ class LLMClient:
                 raise ImportError("openai package is required. Install with: pip install openai")
         return self._client
 
+    _THINK_RE = r'<think>.*?</think>'
+
+    @staticmethod
+    def _extract_think(content: Optional[str]) -> Optional[str]:
+        """提取全部 <think>...</think> 块内容（含标签），无则返回 None"""
+        if not content:
+            return None
+        blocks = re.findall(LLMClient._THINK_RE, content, flags=re.DOTALL)
+        return "".join(blocks) if blocks else None
+
     def _filter_think_tags(self, content: str) -> str:
         """过滤 <think>...</think> 思考过程标签"""
-        import re
-        # 移除 <think>...</think> 及其内容
-        content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
-        # 清理多余的空白
+        content = re.sub(self._THINK_RE, '', content, flags=re.DOTALL)
         content = content.strip()
         return content
 
@@ -286,10 +295,12 @@ class LLMClient:
             max_round_callbacks: 回调注入最大次数。
 
         Returns:
-            (最终回复文本, 元数据字典)
+            (最终回复文本, 元数据字典)。metadata 含 round_records 列表，
+            每轮记录 think/tool_calls/tool_results/callback。
         """
         client = self._get_client()
         current_messages = list(messages)  # 复制一份，避免修改原列表
+        round_records: List[Dict[str, Any]] = []
         total_tool_calls = 0
         all_tool_names: List[str] = []
         retry_count = 0  # 独立重试计数器，避免轮次过多时退避时间过长
@@ -337,12 +348,25 @@ class LLMClient:
                     ],
                 )
 
+                round_record: Dict[str, Any] = {
+                    "round": tool_round_num,
+                    "think": self._extract_think(message.content or ""),
+                    "tool_calls": [
+                        {"id": tc.id, "name": tc.function.name, "arguments": tc.function.arguments}
+                        for tc in (message.tool_calls or [])
+                    ],
+                    "tool_results": [],
+                    "callback": None,
+                }
+                round_records.append(round_record)
+
                 # ── Round callback (injection) ──
                 if on_round_complete is not None and callback_count < max_round_callbacks:
                     injected = await on_round_complete(tool_round_num, result, current_messages)
                     if injected is not None:
                         current_messages.append(injected)
                         callback_count += 1
+                        round_record["callback"] = injected
                         continue  # 跳过原流程，直接进入下一轮 LLM
 
                 # 如果没有工具调用，直接返回内容
@@ -360,6 +384,7 @@ class LLMClient:
                         # Phase 3: 缓存数据收集
                         "cached_tokens": self._get_cached_tokens(response),
                         "callback_count": callback_count,
+                        "round_records": round_records,
                     }
 
                     return content, metadata
@@ -397,6 +422,10 @@ class LLMClient:
                             "tool_call_id": tc.id,
                             "content": "[System note: Tool execution is temporarily unavailable, please respond without using this information]"
                         })
+                        round_record["tool_results"].append({
+                            "tool_call_id": tc.id,
+                            "content": "[System note: Tool execution is temporarily unavailable]",
+                        })
                     tool_round_num += 1
                     continue  # 继续循环，让 LLM 基于错误信息生成合适的回复
 
@@ -419,12 +448,17 @@ class LLMClient:
                         "model": self.model,
                         "tool_rounds": tool_round_num,
                         "error": str(e),
+                        "round_records": round_records,
                     }
 
                 # 将工具结果加入上下文
                 for result in tool_results:
                     current_messages.append({
                         "role": "tool",
+                        "tool_call_id": result["tool_call_id"],
+                        "content": result["content"],
+                    })
+                    round_record["tool_results"].append({
                         "tool_call_id": result["tool_call_id"],
                         "content": result["content"],
                     })
@@ -459,6 +493,7 @@ class LLMClient:
             "total_tool_calls": total_tool_calls,
             "tool_names": all_tool_names,
             "callback_count": callback_count,
+            "round_records": round_records,
         }
 
     def _get_cached_tokens(self, response) -> int:

--- a/src/plugins/DicePP/module/persona/llm/router.py
+++ b/src/plugins/DicePP/module/persona/llm/router.py
@@ -334,6 +334,7 @@ class LLMRouter:
             tool_calls_for_trace: List[Dict] = []
             if is_tools and metadata and metadata.get("tool_names"):
                 tool_calls_for_trace = [{"name": n} for n in metadata["tool_names"]]
+            round_records = metadata.get("round_records", []) if metadata else []
             self._maybe_record_trace(
                 session_id=session_id,
                 user_id=user_id,
@@ -343,6 +344,7 @@ class LLMRouter:
                 messages=messages,
                 response=response_text,
                 tool_calls=tool_calls_for_trace,
+                round_records=round_records,
                 latency_ms=latency_ms,
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
@@ -578,6 +580,7 @@ class LLMRouter:
         messages: List[Dict],
         response: str,
         tool_calls: List[Dict],
+        round_records: List[Dict],
         latency_ms: int,
         tokens_in: int,
         tokens_out: int,
@@ -591,6 +594,14 @@ class LLMRouter:
             return
         from ..data.models import LLMTraceRecord
 
+        _MAX_ROUND_MESSAGES_BYTES = 100 * 1024
+        round_json = json.dumps(round_records, ensure_ascii=False, default=str)
+        if len(round_json.encode("utf-8")) > _MAX_ROUND_MESSAGES_BYTES:
+            round_json = json.dumps(
+                {"_truncated": True, "reason": "round_messages exceeded 100KB", "rounds": len(round_records)},
+                ensure_ascii=False,
+            )
+
         trace = LLMTraceRecord(
             session_id=session_id,
             user_id=user_id or "",
@@ -600,6 +611,7 @@ class LLMRouter:
             messages=json.dumps(messages, ensure_ascii=False, default=str),
             response=response,
             tool_calls=json.dumps(tool_calls, ensure_ascii=False, default=str),
+            round_messages=round_json,
             latency_ms=latency_ms,
             tokens_in=tokens_in,
             tokens_out=tokens_out,

--- a/tests/unit/persona/test_chat_with_tools.py
+++ b/tests/unit/persona/test_chat_with_tools.py
@@ -80,6 +80,14 @@ class TestChatWithTools:
         assert metadata["tool_rounds"] == 0
         assert metadata["total_tool_calls"] == 0
 
+        rr = metadata["round_records"]
+        assert len(rr) == 1
+        assert rr[0]["round"] == 0
+        assert rr[0]["think"] is None
+        assert rr[0]["tool_calls"] == []
+        assert rr[0]["tool_results"] == []
+        assert rr[0]["callback"] is None
+
     @pytest.mark.asyncio
     async def test_single_tool_call(self):
         """测试单次工具调用"""
@@ -152,6 +160,19 @@ class TestChatWithTools:
         assert metadata["total_tool_calls"] == 1
         assert "search_memory" in metadata["tool_names"]
 
+        # round_records: 2 entries — tool call round + final round
+        rr = metadata["round_records"]
+        assert len(rr) == 2
+        assert rr[0]["round"] == 0
+        assert rr[0]["think"] is None
+        assert rr[0]["callback"] is None
+        assert rr[0]["tool_calls"] == [{"id": "tc_1", "name": "search_memory", "arguments": '{"query": "猫"}'}]
+        assert rr[0]["tool_results"] == [{"tool_call_id": "tc_1", "content": "工具 search_memory 执行结果"}]
+        assert rr[1]["round"] == 1  # tool_round_num 在上轮递增
+        assert rr[1]["think"] is None
+        assert rr[1]["tool_calls"] == []
+        assert rr[1]["tool_results"] == []
+
     @pytest.mark.asyncio
     async def test_tool_executor_none_graceful_fallback(self):
         """测试 tool_executor 为 None 时优雅降级，将错误返回给 LLM 处理"""
@@ -203,6 +224,14 @@ class TestChatWithTools:
         # 验证：元数据中包含工具调用轮次
         assert metadata["tool_rounds"] == 1
 
+        rr = metadata["round_records"]
+        assert len(rr) == 2
+        assert rr[0]["round"] == 0
+        assert rr[0]["tool_calls"][0]["name"] == "search_memory"
+        assert len(rr[0]["tool_results"]) == 1
+        assert "temporarily unavailable" in rr[0]["tool_results"][0]["content"]
+        assert rr[0]["tool_results"][0]["tool_call_id"] == "tc_1"
+
     @pytest.mark.asyncio
     async def test_tool_execution_failure(self):
         """测试工具执行失败处理"""
@@ -241,6 +270,12 @@ class TestChatWithTools:
 
         assert "工具执行失败" in content
         assert "数据库连接失败" in metadata["error"]
+
+        rr = metadata["round_records"]
+        assert len(rr) == 1
+        assert rr[0]["round"] == 0
+        assert rr[0]["tool_calls"][0]["name"] == "search_memory"
+        assert rr[0]["tool_results"] == []  # 执行失败，无结果
 
     @pytest.mark.asyncio
     async def test_generate_with_forced_tool_no_tool_calls_raises(self):
@@ -321,6 +356,15 @@ class TestChatWithTools:
         assert "工具调用次数超过限制" in content
         assert metadata["tool_rounds"] == 2
 
+        rr = metadata["round_records"]
+        assert len(rr) == 2
+        assert rr[0]["round"] == 0
+        assert rr[0]["tool_calls"][0]["name"] == "search_memory"
+        assert len(rr[0]["tool_results"]) == 1
+        assert rr[1]["round"] == 1
+        assert rr[1]["tool_calls"][0]["name"] == "search_memory"
+        assert len(rr[1]["tool_results"]) == 1
+
     @pytest.mark.asyncio
     async def test_callback_injection_appends_message_and_continues(self):
         """回调返回 dict 时注入消息并继续循环"""
@@ -368,6 +412,14 @@ class TestChatWithTools:
         assert content == "world"
         assert metadata["callback_count"] == 1
         assert metadata["tool_rounds"] == 0
+
+        rr = metadata["round_records"]
+        assert len(rr) == 2
+        assert rr[0]["callback"] == {"role": "system", "content": "inject"}
+        assert rr[0]["tool_calls"] == []
+        assert rr[0]["tool_results"] == []
+        assert rr[1]["callback"] is None
+
         # Verify injected message was appended
         second_call_messages = mock_openai_client.chat.completions.create.await_args_list[1][1]["messages"]
         assert any(m.get("content") == "inject" for m in second_call_messages)
@@ -498,6 +550,99 @@ class TestChatWithTools:
         assert "on_round_complete" not in sig.parameters
         assert "max_round_callbacks" not in sig.parameters
 
+    @pytest.mark.asyncio
+    async def test_round_records_with_think_and_multiple_tool_rounds(self):
+        """round_records 完整记录 think / tool_calls / tool_results / callback"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        # Round 0: think + tool_call
+        r0 = Mock()
+        r0.choices = [Mock()]
+        r0.choices[0].message = Mock()
+        r0.choices[0].message.content = "<think>需要查询记忆</think>"
+        r0.choices[0].message.tool_calls = [
+            MockToolCall("tc_1", "search_memory", '{"query":"猫"}')
+        ]
+        r0.usage = None
+
+        # Round 1: think + tool_call (second round, different tool)
+        r1 = Mock()
+        r1.choices = [Mock()]
+        r1.choices[0].message = Mock()
+        r1.choices[0].message.content = "<think>还需要掷骰</think>"
+        r1.choices[0].message.tool_calls = [
+            MockToolCall("tc_2", "roll_dice", '{"expr":"2d6"}')
+        ]
+        r1.usage = None
+
+        # Round 2: think + final response (no tool_calls)
+        r2 = Mock()
+        r2.choices = [Mock()]
+        r2.choices[0].message = Mock()
+        r2.choices[0].message.content = "<think>回答准备好了</think>你喜欢猫！"
+        r2.choices[0].message.tool_calls = None
+        r2.usage = None
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(
+            side_effect=[r0, r1, r2]
+        )
+        client._client = mock_openai_client
+
+        async def mock_executor(tool_calls):
+            return [
+                {"tool_call_id": tc["id"], "content": f"[{tc['name']}] result"}
+                for tc in tool_calls
+            ]
+
+        content, metadata = await client.chat_with_tools(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[
+                {"type": "function", "function": {"name": "search_memory"}},
+                {"type": "function", "function": {"name": "roll_dice"}},
+            ],
+            tool_executor=mock_executor,
+            max_tool_rounds=5,
+        )
+
+        assert content == "你喜欢猫！"
+        assert metadata["tool_rounds"] == 2
+        assert metadata["total_tool_calls"] == 2
+
+        rr = metadata["round_records"]
+        assert len(rr) == 3  # 2 tool rounds + 1 final
+
+        # Round 0: tool call
+        assert rr[0]["round"] == 0
+        assert rr[0]["think"] == "<think>需要查询记忆</think>"
+        assert rr[0]["callback"] is None
+        assert rr[0]["tool_calls"] == [
+            {"id": "tc_1", "name": "search_memory", "arguments": '{"query":"猫"}'}
+        ]
+        assert rr[0]["tool_results"] == [
+            {"tool_call_id": "tc_1", "content": "[search_memory] result"}
+        ]
+
+        # Round 1: second tool call
+        assert rr[1]["round"] == 1
+        assert rr[1]["think"] == "<think>还需要掷骰</think>"
+        assert rr[1]["tool_calls"] == [
+            {"id": "tc_2", "name": "roll_dice", "arguments": '{"expr":"2d6"}'}
+        ]
+        assert rr[1]["tool_results"] == [
+            {"tool_call_id": "tc_2", "content": "[roll_dice] result"}
+        ]
+
+        # Round 2: final, no tool_calls, think preserved
+        assert rr[2]["round"] == 2
+        assert rr[2]["think"] == "<think>回答准备好了</think>"
+        assert rr[2]["tool_calls"] == []
+        assert rr[2]["tool_results"] == []
+
 
 class TestFilterThinkTags:
     """<think> 标签过滤（client 层模型输出归一化）"""
@@ -549,3 +694,32 @@ class TestFilterThinkTags:
         client = LLMClient(api_key="k", base_url="http://x", model="m")
         result = client._filter_think_tags("  \t\n  ")
         assert result == ""
+
+
+class TestExtractThink:
+    """_extract_think 功能验证"""
+
+    def test_extracts_single_think_block(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        think = client._extract_think("<think>用户问的是前两个观察</think>")
+        assert think == "<think>用户问的是前两个观察</think>"
+
+    def test_extracts_multiple_think_blocks(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        think = client._extract_think("<think>A</think>\n<think>B</think>")
+        assert think == "<think>A</think><think>B</think>"
+
+    def test_returns_none_when_no_think(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        think = client._extract_think("这是普通文本")
+        assert think is None
+
+    def test_handles_multiline_think(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        think = client._extract_think("<think>\n分析中...\n</think>")
+        assert think == "<think>\n分析中...\n</think>"
+
+    def test_only_extracts_think_blocks_not_surrounding_text(self):
+        client = LLMClient(api_key="k", base_url="http://x", model="m")
+        think = client._extract_think("你好<think>思考</think>再见")
+        assert think == "<think>思考</think>"

--- a/tests/unit/persona/test_phase7a.py
+++ b/tests/unit/persona/test_phase7a.py
@@ -104,6 +104,50 @@ async def test_trace_lifecycle(temp_db):
 
 
 @pytest.mark.asyncio
+async def test_trace_round_messages_round_trip(temp_db):
+    """round_messages 字段在 DB 存储和读取后字段正确保留"""
+    store = temp_db
+    rr = [
+        {
+            "round": 0,
+            "think": "<think>需要查记忆</think>",
+            "tool_calls": [{"id": "tc_1", "name": "search_memory", "arguments": '{"q":"猫"}'}],
+            "tool_results": [{"tool_call_id": "tc_1", "content": "找到 3 条记忆"}],
+            "callback": None,
+        },
+        {
+            "round": 1,
+            "think": "<think>准备回复</think>",
+            "tool_calls": [],
+            "tool_results": [],
+            "callback": None,
+        },
+    ]
+    trace = LLMTraceRecord(
+        session_id="s-rr",
+        user_id="u1",
+        model="gpt-4o",
+        tier="primary",
+        messages=json.dumps([{"role": "user", "content": "hi"}]),
+        response="reply",
+        round_messages=json.dumps(rr, ensure_ascii=False),
+        status="ok",
+    )
+    await store.add_llm_trace(trace)
+
+    traces = await store.get_llm_traces("u1", limit=5)
+    assert len(traces) == 1
+    stored_rr = json.loads(traces[0].round_messages)
+    assert len(stored_rr) == 2
+    assert stored_rr[0]["round"] == 0
+    assert stored_rr[0]["think"] == "<think>需要查记忆</think>"
+    assert stored_rr[0]["tool_calls"][0]["name"] == "search_memory"
+    assert stored_rr[0]["tool_results"][0]["content"] == "找到 3 条记忆"
+    assert stored_rr[1]["round"] == 1
+    assert stored_rr[1]["think"] == "<think>准备回复</think>"
+
+
+@pytest.mark.asyncio
 async def test_trace_enabled_false_does_not_create_task():
     router = LLMRouter("fake", "http://localhost", "fake", max_concurrent=1)
     router.trace_enabled = False
@@ -118,6 +162,7 @@ async def test_trace_enabled_false_does_not_create_task():
         messages=[],
         response="r",
         tool_calls=[],
+        round_records=[],
         latency_ms=100,
         tokens_in=1,
         tokens_out=1,

--- a/tests/unit/persona/test_round_messages_e2e.py
+++ b/tests/unit/persona/test_round_messages_e2e.py
@@ -1,0 +1,74 @@
+"""端到端验证 round_messages 完整流程"""
+import pytest
+import asyncio
+import aiosqlite
+import json
+from unittest.mock import Mock, AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_round_messages_e2e():
+    """通过 router._execute_and_trace 完整路径，验证 round_messages 写入 DB"""
+    from module.persona.llm.client import LLMClient
+    from module.persona.llm.router import LLMRouter
+    from module.persona.data.store import PersonaDataStore
+
+    db = await aiosqlite.connect(":memory:")
+    store = PersonaDataStore(db)
+    await store.ensure_tables()
+
+    router = LLMRouter(
+        primary_api_key="sk-test",
+        primary_base_url="https://api.test.com/v1",
+        primary_model="test-model",
+        max_concurrent=1,
+        data_store=store,
+        trace_enabled=True,
+    )
+
+    client = router.primary_client
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message = Mock()
+    mock_response.choices[0].message.content = "<think>简单思考</think>你好"
+    mock_response.choices[0].message.tool_calls = None
+    mock_response.usage = None
+
+    mock_openai = Mock()
+    mock_openai.chat.completions.create = AsyncMock(return_value=mock_response)
+    client._client = mock_openai
+
+    content, metadata = await router._execute_and_trace(
+        client=client,
+        tier_name="primary",
+        call_coro=client.chat_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_tool_rounds=3,
+        ),
+        session_id="s1",
+        user_id="u1",
+        group_id="g1",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=None,
+        model_tier="primary",
+        is_tools=False,
+    )
+
+    await asyncio.sleep(0.5)
+
+    cursor = await db.execute(
+        "SELECT id, status, round_messages FROM persona_llm_traces ORDER BY id DESC"
+    )
+    traces = await cursor.fetchall()
+
+    assert len(traces) == 1, f"Expected 1 trace, got {len(traces)}"
+    assert traces[0][1] == "ok"
+
+    data = json.loads(traces[0][2] or "[]")
+    assert len(data) >= 1
+    assert data[0]["think"] == "<think>简单思考</think>"
+    assert data[0]["tool_calls"] == []
+    assert data[0]["tool_results"] == []
+
+    await db.close()


### PR DESCRIPTION
## Summary

- `chat_with_tools` 新增 `round_records` 收集: 每轮 LLM 对应的 think 块、tool_calls 参数、tool_results 结果、callback 注入内容, 以结构化摘要存入 `round_messages` 字段
- schema → model → store → client → router 六层贯通, 新增 `_extract_think` 提取 think 标签, `_maybe_record_trace` 写入前加 100KB 上限
- 存量 DB 通过 `_ensure_llm_traces_round_messages` 子迁移兼容

## Test plan

- [x] 单元测试: `_extract_think` 5 条, `TestFilterThinkTags` 保持原有 7 条
- [x] 集成测试: 现有 `TestChatWithTools` 7 处增强 round_records 断言, 新增 think + 多轮 + 回调综合测试
- [x] DB 往返: `round_messages` 写入 → 读回 → 反序列化验证
- [x] E2E: `_execute_and_trace` → `_maybe_record_trace` → DB 完整路径
- [x] 全量: 555 tests passed