### PR TITLE
refactor(persona): 关系统一为按用户粒度存储，移除 group_id 维度

### DIFF
--- a/src/plugins/DicePP/module/persona/admin.py
+++ b/src/plugins/DicePP/module/persona/admin.py
@@ -74,8 +74,8 @@ class AdminDispatcher:
             ".ai admin stats - 查看今日 LLM 调用统计\n"
             ".ai admin errors - 查看最近 24h 错误摘要\n"
             ".ai admin debug - 查看当前上下文\n"
-            ".ai admin rel <用户ID> [群组ID] - 查看指定用户关系\n"
-            ".ai admin setrel <用户ID> <分数> [群组ID] - 修改好感度\n"
+            ".ai admin rel <用户ID> - 查看指定用户关系\n"
+            ".ai admin setrel <用户ID> <分数> - 修改好感度\n"
             ".ai admin reload - 热重载角色卡\n"
             ".ai admin events - 查看事件配置\n"
             ".ai admin list - 查看白名单\n"
@@ -174,7 +174,7 @@ class AdminDispatcher:
             lines.append("\n[状态] 模块未初始化")
             return "\n".join(lines)
         profile = await self.data_store.get_user_profile(user_id)
-        rel = await self._get_relationship_for_display(user_id, group_id)
+        rel = await self._get_relationship_for_display(user_id)
         lines.append(f"\n当前用户: {user_id}")
         if group_id:
             lines.append(f"当前群组: {group_id}")
@@ -231,14 +231,11 @@ class AdminDispatcher:
     async def _admin_rel(self, user_id: str, group_id: str, args: List[str]) -> str:
         rel_args = args[1:]
         if not rel_args:
-            return "用法: .ai admin rel <用户ID> [群组ID]"
+            return "用法: .ai admin rel <用户ID>"
         target_user = rel_args[0]
-        target_group = rel_args[1] if len(rel_args) > 1 else group_id
-        rel = await self._get_relationship_for_display(target_user, target_group)
+        rel = await self._get_relationship_for_display(target_user)
         profile = await self.data_store.get_user_profile(target_user)
         lines = [f"=== 用户 {target_user} 的关系详情 ==="]
-        if target_group:
-            lines.append(f"群组: {target_group}")
         if rel:
             lines.extend(self._format_relationship_base(rel))
             if self.app and self.app.get_character():
@@ -258,7 +255,7 @@ class AdminDispatcher:
     async def _admin_setrel(self, user_id: str, group_id: str, args: List[str]) -> str:
         setrel_args = args[1:]
         if len(setrel_args) < 2:
-            return "用法: .ai admin setrel <用户ID> <综合分数> [群组ID]"
+            return "用法: .ai admin setrel <用户ID> <综合分数>"
         target_user = setrel_args[0]
         try:
             new_score = float(setrel_args[1])
@@ -266,11 +263,10 @@ class AdminDispatcher:
             return "分数必须是数字"
         if new_score < 0 or new_score > 100:
             return "分数必须在 0-100 之间"
-        target_group = setrel_args[2] if len(setrel_args) > 2 else group_id
-        rel = await self.data_store.get_relationship(target_user, target_group)
+        rel = await self.data_store.get_relationship(target_user)
         if not rel:
             initial = self.app.get_initial_relationship() if self.app else 40.0
-            rel = await self.data_store.init_relationship(target_user, target_group, initial)
+            rel = await self.data_store.init_relationship(target_user, initial)
         rel.intimacy = new_score
         rel.passion = new_score
         rel.trust = new_score
@@ -493,12 +489,12 @@ class AdminDispatcher:
         return lines
 
     async def _get_relationship_for_display(
-        self, user_id: str, group_id: str
+        self, user_id: str
     ) -> Optional[Any]:
         """读取关系并应用惰性时间衰减（展示用，不写库）"""
         if not self.data_store:
             return None
-        rel = await self.data_store.get_relationship(user_id, group_id)
+        rel = await self.data_store.get_relationship(user_id)
         if not rel or not self.app or not self.app.get_decay_calculator() or not self.app.get_character():
             return rel
         return self.app.effective_relationship(rel)

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -186,7 +186,7 @@ class ChatSession:
 
             is_chat_message = not message.startswith(".") or message.lower().startswith(".ai")
             if self.config.relationship_refuse_enabled and not is_first and is_chat_message:
-                rel = await self.store.get_relationship(user_id, group_id)
+                rel = await self.store.get_relationship(user_id)
                 if rel:
                     if self.decay_calculator:
                         rel = self.decay_calculator.effective_relationship(rel)
@@ -566,10 +566,10 @@ class ChatSession:
     async def _update_interaction(
         self, user_id: str, group_id: str, user_msg: str, assistant_msg: str
     ) -> None:
-        rel = await self.store.get_relationship(user_id, group_id)
+        rel = await self.store.get_relationship(user_id)
         initial = float(self.character.extensions.initial_relationship)
         if not rel:
-            rel = await self.store.init_relationship(user_id, group_id, initial)
+            rel = await self.store.init_relationship(user_id, initial)
 
         now = persona_wall_now(self.config.timezone)
         decay_event: Optional[ScoreEvent] = None
@@ -598,7 +598,9 @@ class ChatSession:
                 f"应用时间衰减: {user_id} 衰减 {decay_event.deltas.intimacy:.2f}, 原因: {decay_event.reason}"
             )
 
-        key = f"{user_id}:{group_id}"
+        # 统一关系后 user_id 为唯一键；同一用户的私聊/群聊消息合并评分。
+        # group_id 仅记录触发评分的场景（ScoreEvent 审计字段）。
+        key = user_id
         if key not in self._pending_messages:
             self._pending_messages[key] = deque(maxlen=100)
         self._pending_messages[key].append({"role": "user", "content": user_msg, "created_at": now})
@@ -615,7 +617,7 @@ class ChatSession:
         if not self.scoring_agent:
             return
 
-        key = f"{user_id}:{group_id}"
+        key = user_id
         messages = list(self._pending_messages.get(key, []))
         if not messages:
             return
@@ -623,7 +625,7 @@ class ChatSession:
         messages_count = len(messages)
 
         profile = await self.store.get_user_profile(user_id)
-        rel = await self.store.get_relationship(user_id, group_id)
+        rel = await self.store.get_relationship(user_id)
 
         rel_for_scoring = rel
         if rel and self.decay_calculator:
@@ -864,7 +866,7 @@ class ChatSession:
     ) -> List[Dict[str, str]]:
         history_dicts, _ = await self._fetch_short_term_history(user_id, group_id)
         profile = await self.store.get_user_profile(user_id)
-        rel = await self.store.get_relationship(user_id, group_id)
+        rel = await self.store.get_relationship(user_id)
         warmth_label = self._resolve_warmth_label(user_id, rel)
         diary_context = await self._build_diary_context()
         lore_sections = self._build_lore_sections(history_dicts, current_message)

--- a/src/plugins/DicePP/module/persona/command.py
+++ b/src/plugins/DicePP/module/persona/command.py
@@ -475,7 +475,9 @@ class PersonaCommand(UserCommandBase):
             return "模块未初始化"
 
         profile = await self.data_store.get_user_profile(user_id)
-        rel = await self._get_relationship_for_display(user_id, group_id)
+        rel = await self.data_store.get_relationship(user_id)
+        if rel and self.app and self.app.get_decay_calculator() and self.app.get_character():
+            rel = self.app.effective_relationship(rel)
 
         lines = ["你的档案"]
 
@@ -490,7 +492,7 @@ class PersonaCommand(UserCommandBase):
             lines.extend(base_lines[1:])  # 去掉 [好感度] 标题
 
             try:
-                recent_events = await self.data_store.get_recent_score_events(user_id, group_id, limit=2)
+                recent_events = await self.data_store.get_recent_score_events(user_id, limit=2)
                 if len(recent_events) >= 2:
                     latest = recent_events[-1]
                     previous = recent_events[-2]
@@ -614,8 +616,8 @@ class PersonaCommand(UserCommandBase):
                 lines.append("")
                 lines.append("[管理员调试]")
                 lines.append(".ai admin debug - 调试信息")
-                lines.append(".ai admin rel <用户ID> [群组ID] - 查看关系")
-                lines.append(".ai admin setrel <用户ID> <分数> [群组ID] - 修改好感度")
+                lines.append(".ai admin rel <用户ID> - 查看关系")
+                lines.append(".ai admin setrel <用户ID> <分数> - 修改好感度")
                 lines.append(".ai admin reload - 热重载角色卡")
                 lines.append(".ai admin events - 事件配置")
                 lines.append(".ai admin today/yesterday - 查看今天/昨天的事件和日记")

--- a/src/plugins/DicePP/module/persona/data/migrations.py
+++ b/src/plugins/DicePP/module/persona/data/migrations.py
@@ -132,8 +132,7 @@ CREATE TABLE IF NOT EXISTS persona_user_profiles (
 
 CREATE_USER_RELATIONSHIPS_TABLE = """
 CREATE TABLE IF NOT EXISTS persona_user_relationships (
-    user_id TEXT NOT NULL,
-    group_id TEXT DEFAULT '',
+    user_id TEXT PRIMARY KEY,
     intimacy REAL DEFAULT 40.0,
     passion REAL DEFAULT 40.0,
     trust REAL DEFAULT 40.0,
@@ -142,8 +141,7 @@ CREATE TABLE IF NOT EXISTS persona_user_relationships (
     last_relationship_decay_applied_at TIMESTAMP,
     last_miss_sent_at TIMESTAMP,
     peak_stage INTEGER DEFAULT 0,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (user_id, group_id)
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 """
 

--- a/src/plugins/DicePP/module/persona/data/models.py
+++ b/src/plugins/DicePP/module/persona/data/models.py
@@ -42,7 +42,6 @@ class ScoreDeltas(BaseModel):
 class RelationshipState(BaseModel):
     """关系状态（四维好感度）"""
     user_id: str
-    group_id: str = ""  # 空字符串表示私聊
     intimacy: float = 40.0
     passion: float = 40.0
     trust: float = 40.0
@@ -171,6 +170,7 @@ class DailyUsage(BaseModel):
 class ScoreEvent(BaseModel):
     """评分事件记录"""
     user_id: str
+    # 关系统一后仅作审计，记录评分触发时的群组上下文；关系变更本身是用户级全局的
     group_id: str = ""
     deltas: ScoreDeltas
     composite_before: float

--- a/src/plugins/DicePP/module/persona/data/store.py
+++ b/src/plugins/DicePP/module/persona/data/store.py
@@ -88,6 +88,7 @@ class PersonaDataStore:
         await self._ensure_daily_events_context_summary()
         await self._ensure_scoring_failures_table()
         await self._ensure_llm_traces_round_messages()
+        await self._ensure_relationship_unified()
 
     async def _ensure_group_activity_daily_columns(self) -> None:
         """
@@ -261,6 +262,173 @@ class PersonaDataStore:
             await self.db.execute(
                 "ALTER TABLE persona_llm_traces ADD COLUMN round_messages TEXT DEFAULT ''"
             )
+
+    async def _ensure_relationship_unified(self) -> None:
+        """将 persona_user_relationships 从 (user_id, group_id) 迁移到 user_id 主键。
+
+        幂等：通过 PRAGMA table_info 检测 group_id 列是否存在，已迁移则跳过。
+        合并策略：取 last_interaction_at 最新行的基础数据，peak_stage 取 MAX，
+        last_miss_sent_at 取 MIN（最早非 NULL 值）。
+        崩溃恢复：若步骤 4-6 之间崩溃，_backup/_new 表残留由幂等守卫在下次
+        ensure_tables 时清理或恢复。
+        """
+        async with self.db.execute("PRAGMA table_info(persona_user_relationships)") as cursor:
+            rows = await cursor.fetchall()
+        col_names = {row[1] for row in rows}
+        if "group_id" not in col_names:
+            # 清理上次迁移可能残留的备份表（步骤 6 前崩溃所致）
+            await self.db.execute("DROP TABLE IF EXISTS persona_user_relationships_backup")
+            # 恢复：若旧表已被 RENAME 但 _new 未晋升（步骤 4a→4b 之间崩溃）
+            async with self.db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+                " AND name='persona_user_relationships_new'"
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row:
+                async with self.db.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                    " AND name='persona_user_relationships'"
+                ) as cur:
+                    main_exists = await cur.fetchone()
+                if main_exists:
+                    # 主表由 ALL_MIGRATIONS 的 CREATE IF NOT EXISTS 重建为空表，
+                    # _new 中才有合并后的数据 → 替换
+                    await self.db.execute("DROP TABLE persona_user_relationships")
+                await self.db.execute(
+                    "ALTER TABLE persona_user_relationships_new"
+                    " RENAME TO persona_user_relationships"
+                )
+                await self.db.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_pur_last_interaction "
+                    "ON persona_user_relationships(last_interaction_at DESC)"
+                )
+                logger.info("关系表迁移修复: 从 _new 中间表恢复主表")
+                await self.db.commit()
+            return  # 已迁移，跳过
+
+        logger.info("开始迁移 persona_user_relationships：移除 group_id，合并同用户记录")
+
+        # 1. 创建新表（无 group_id，主键 user_id）
+        # 先清理可能残留的中间表（上次迁移中途崩溃所致）
+        await self.db.execute("DROP TABLE IF EXISTS persona_user_relationships_new")
+        # 1b. 清理脏数据：user_id 为 NULL 的行无法迁入 PRIMARY KEY 表
+        cursor = await self.db.execute(
+            "DELETE FROM persona_user_relationships WHERE user_id IS NULL"
+        )
+        if cursor.rowcount:
+            logger.warning(
+                f"关系表迁移: 清理了 {cursor.rowcount} 行 user_id IS NULL 的脏数据"
+            )
+        await self.db.execute("""
+            CREATE TABLE persona_user_relationships_new (
+                user_id TEXT PRIMARY KEY,
+                intimacy REAL DEFAULT 40.0,
+                passion REAL DEFAULT 40.0,
+                trust REAL DEFAULT 40.0,
+                secureness REAL DEFAULT 40.0,
+                last_interaction_at TIMESTAMP,
+                last_relationship_decay_applied_at TIMESTAMP,
+                last_miss_sent_at TIMESTAMP,
+                peak_stage INTEGER DEFAULT 0,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # 2. 合并数据：用 CTE + ROW_NUMBER 取最新行，JOIN 子查询取聚合值
+        await self.db.execute("""
+            INSERT INTO persona_user_relationships_new
+            SELECT
+                latest.user_id,
+                latest.intimacy,
+                latest.passion,
+                latest.trust,
+                latest.secureness,
+                latest.last_interaction_at,
+                latest.last_relationship_decay_applied_at,
+                agg.min_miss_at AS last_miss_sent_at,
+                COALESCE(agg.max_peak, 0) AS peak_stage,
+                latest.updated_at
+            FROM (
+                SELECT *,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY user_id ORDER BY last_interaction_at DESC, updated_at DESC, ROWID DESC
+                       ) AS rn
+                FROM persona_user_relationships
+            ) AS latest
+            LEFT JOIN (
+                SELECT
+                    user_id,
+                    MAX(peak_stage) AS max_peak,
+                    MIN(last_miss_sent_at) AS min_miss_at
+                FROM persona_user_relationships
+                GROUP BY user_id
+            ) AS agg ON latest.user_id = agg.user_id
+            WHERE latest.rn = 1
+        """)
+
+        # 2b. 统计冗余行数（运维用）
+        async with self.db.execute(
+            "SELECT COUNT(*) - COUNT(DISTINCT user_id) FROM persona_user_relationships"
+        ) as cursor:
+            row = await cursor.fetchone()
+            redundant = row[0] if row else 0
+            if redundant:
+                logger.info(
+                    f"关系表迁移: {redundant} 行冗余数据因 (user_id,group_id) 被合并"
+                )
+
+        # 3. 验证新表行数 = 旧表 DISTINCT user_id 数
+        async with self.db.execute(
+            "SELECT COUNT(DISTINCT user_id) FROM persona_user_relationships"
+        ) as cursor:
+            row = await cursor.fetchone()
+            expected = row[0] if row else 0
+
+        async with self.db.execute(
+            "SELECT COUNT(*) FROM persona_user_relationships_new"
+        ) as cursor:
+            row = await cursor.fetchone()
+            actual = row[0] if row else 0
+
+        if actual != expected:
+            await self.db.execute("DROP TABLE persona_user_relationships_new")
+            raise RuntimeError(
+                f"关系表迁移行数不匹配: 期望 {expected} 行, 实际 {actual} 行. "
+                f"已回滚新表，旧数据完整保留"
+            )
+
+        # 4. 替换表：RENAME 旧表 → RENAME 新表 → DROP 旧表
+        await self.db.execute(
+            "ALTER TABLE persona_user_relationships RENAME TO persona_user_relationships_backup"
+        )
+        await self.db.execute(
+            "ALTER TABLE persona_user_relationships_new RENAME TO persona_user_relationships"
+        )
+
+        # 5. 验证新表可正常读写
+        async with self.db.execute(
+            "SELECT COUNT(*) FROM persona_user_relationships"
+        ) as cursor:
+            row = await cursor.fetchone()
+            verify_count = row[0] if row else 0
+        if verify_count != expected:
+            raise RuntimeError(
+                f"替换后验证失败: 期望 {expected} 行, 实际 {verify_count} 行"
+            )
+
+        # 6. 删除备份
+        await self.db.execute("DROP TABLE persona_user_relationships_backup")
+
+        # 7. 重建索引
+        await self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pur_last_interaction "
+            "ON persona_user_relationships(last_interaction_at DESC)"
+        )
+
+        await self.db.commit()
+        logger.info(
+            f"关系表迁移完成: 从多记录合并为 {actual} 条唯一用户记录"
+        )
 
     # ========== 消息相关 ==========
 
@@ -639,18 +807,18 @@ class PersonaDataStore:
                 return datetime.fromisoformat(row[0])
             return None
 
-    async def get_recent_score_events(self, user_id: str, group_id: str, limit: int = 2) -> List[ScoreEvent]:
+    async def get_recent_score_events(self, user_id: str, limit: int = 2) -> List[ScoreEvent]:
         """获取最近评分事件，用于趋势计算"""
         async with self.db.execute(
             """
             SELECT user_id, group_id, intimacy_delta, passion_delta, trust_delta, secureness_delta,
                    composite_before, composite_after, reason, conversation_digest, created_at
             FROM persona_score_history
-            WHERE user_id = ? AND group_id = ?
+            WHERE user_id = ?
             ORDER BY created_at DESC
             LIMIT ?
             """,
-            (user_id, group_id, limit)
+            (user_id, limit)
         ) as cursor:
             rows = await cursor.fetchall()
             events = []
@@ -1184,22 +1352,21 @@ class PersonaDataStore:
         )
         await self.db.commit()
 
-    async def get_relationship(self, user_id: str, group_id: str = "") -> Optional[RelationshipState]:
+    async def get_relationship(self, user_id: str) -> Optional[RelationshipState]:
         async with self.db.execute(
             """
             SELECT intimacy, passion, trust, secureness, last_interaction_at,
                    last_relationship_decay_applied_at, last_miss_sent_at, peak_stage, updated_at
             FROM persona_user_relationships
-            WHERE user_id = ? AND group_id = ?
+            WHERE user_id = ?
             """,
-            (user_id, group_id)
+            (user_id,)
         ) as cursor:
             row = await cursor.fetchone()
             if not row:
                 return None
             return RelationshipState(
                 user_id=user_id,
-                group_id=group_id,
                 intimacy=row[0],
                 passion=row[1],
                 trust=row[2],
@@ -1213,11 +1380,9 @@ class PersonaDataStore:
                 updated_at=datetime.fromisoformat(row[8]) if row[8] else None
             )
 
-    async def init_relationship(self, user_id: str, group_id: str, initial_score: float = 40.0) -> RelationshipState:
-        # 根据初始分数计算 peak_stage，确保新用户获得正确的阶段保护
+    async def init_relationship(self, user_id: str, initial_score: float = 40.0) -> RelationshipState:
         tmp_rel = RelationshipState(
             user_id=user_id,
-            group_id=group_id,
             intimacy=initial_score,
             passion=initial_score,
             trust=initial_score,
@@ -1227,14 +1392,13 @@ class PersonaDataStore:
         await self.db.execute(
             """
             INSERT OR IGNORE INTO persona_user_relationships
-            (user_id, group_id, intimacy, passion, trust, secureness,
+            (user_id, intimacy, passion, trust, secureness,
              last_interaction_at, last_relationship_decay_applied_at,
              last_miss_sent_at, peak_stage, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 user_id,
-                group_id,
                 initial_score,
                 initial_score,
                 initial_score,
@@ -1247,9 +1411,9 @@ class PersonaDataStore:
             )
         )
         await self.db.commit()
-        rel = await self.get_relationship(user_id, group_id)
+        rel = await self.get_relationship(user_id)
         if rel is None:
-            return RelationshipState(user_id=user_id, group_id=group_id)
+            return RelationshipState(user_id=user_id)
         return rel
 
     async def update_relationship(self, rel: RelationshipState) -> None:
@@ -1266,11 +1430,11 @@ class PersonaDataStore:
         await self.db.execute(
             """
             INSERT INTO persona_user_relationships
-            (user_id, group_id, intimacy, passion, trust, secureness,
+            (user_id, intimacy, passion, trust, secureness,
              last_interaction_at, last_relationship_decay_applied_at,
              last_miss_sent_at, peak_stage, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(user_id, group_id) DO UPDATE SET
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET
                 intimacy = excluded.intimacy,
                 passion = excluded.passion,
                 trust = excluded.trust,
@@ -1283,7 +1447,6 @@ class PersonaDataStore:
             """,
             (
                 rel.user_id,
-                rel.group_id,
                 rel.intimacy,
                 rel.passion,
                 rel.trust,
@@ -1299,42 +1462,33 @@ class PersonaDataStore:
         )
         await self.db.commit()
 
-    async def get_top_relationships(self, group_id: str = "", limit: int = 10) -> List[RelationshipState]:
-        # 私聊关系在库中一般为 ''；兼容历史 NULL 行
-        if group_id == "":
-            where_clause = "COALESCE(group_id, '') = ''"
-            params: tuple = (limit,)
-        else:
-            where_clause = "group_id = ?"
-            params = (group_id, limit)
+    async def get_top_relationships(self, limit: int = 10) -> List[RelationshipState]:
         async with self.db.execute(
-            f"""
-            SELECT user_id, group_id, intimacy, passion, trust, secureness,
+            """
+            SELECT user_id, intimacy, passion, trust, secureness,
                    last_interaction_at, last_relationship_decay_applied_at,
                    last_miss_sent_at, peak_stage, updated_at
             FROM persona_user_relationships
-            WHERE {where_clause}
             ORDER BY (intimacy * 0.3 + passion * 0.2 + trust * 0.3 + secureness * 0.2) DESC
             LIMIT ?
             """,
-            params,
+            (limit,),
         ) as cursor:
             rows = await cursor.fetchall()
             return [
                 RelationshipState(
                     user_id=row[0],
-                    group_id=row[1] if row[1] is not None else "",
-                    intimacy=row[2],
-                    passion=row[3],
-                    trust=row[4],
-                    secureness=row[5],
-                    last_interaction_at=datetime.fromisoformat(row[6]) if row[6] else None,
+                    intimacy=row[1],
+                    passion=row[2],
+                    trust=row[3],
+                    secureness=row[4],
+                    last_interaction_at=datetime.fromisoformat(row[5]) if row[5] else None,
                     last_relationship_decay_applied_at=(
-                        datetime.fromisoformat(row[7]) if row[7] else None
+                        datetime.fromisoformat(row[6]) if row[6] else None
                     ),
-                    last_miss_sent_at=datetime.fromisoformat(row[8]) if row[8] else None,
-                    peak_stage=row[9] if row[9] is not None else 0,
-                    updated_at=datetime.fromisoformat(row[10]) if row[10] else None
+                    last_miss_sent_at=datetime.fromisoformat(row[7]) if row[7] else None,
+                    peak_stage=row[8] if row[8] is not None else 0,
+                    updated_at=datetime.fromisoformat(row[9]) if row[9] else None
                 )
                 for row in rows
             ]
@@ -1660,29 +1814,28 @@ class PersonaDataStore:
         """列出所有关系行，无过滤（用于每日衰减批处理等）。"""
         async with self.db.execute(
             """
-            SELECT user_id, group_id, intimacy, passion, trust, secureness,
+            SELECT user_id, intimacy, passion, trust, secureness,
                    last_interaction_at, last_relationship_decay_applied_at,
                    last_miss_sent_at, peak_stage, updated_at
             FROM persona_user_relationships
-            ORDER BY user_id, group_id
+            ORDER BY user_id
             """
         ) as cursor:
             rows = await cursor.fetchall()
             return [
                 RelationshipState(
                     user_id=row[0],
-                    group_id=row[1] if row[1] is not None else "",
-                    intimacy=row[2],
-                    passion=row[3],
-                    trust=row[4],
-                    secureness=row[5],
-                    last_interaction_at=datetime.fromisoformat(row[6]) if row[6] else None,
+                    intimacy=row[1],
+                    passion=row[2],
+                    trust=row[3],
+                    secureness=row[4],
+                    last_interaction_at=datetime.fromisoformat(row[5]) if row[5] else None,
                     last_relationship_decay_applied_at=(
-                        datetime.fromisoformat(row[7]) if row[7] else None
+                        datetime.fromisoformat(row[6]) if row[6] else None
                     ),
-                    last_miss_sent_at=datetime.fromisoformat(row[8]) if row[8] else None,
-                    peak_stage=row[9] if row[9] is not None else 0,
-                    updated_at=datetime.fromisoformat(row[10]) if row[10] else None,
+                    last_miss_sent_at=datetime.fromisoformat(row[7]) if row[7] else None,
+                    peak_stage=row[8] if row[8] is not None else 0,
+                    updated_at=datetime.fromisoformat(row[9]) if row[9] else None,
                 )
                 for row in rows
             ]
@@ -1701,7 +1854,7 @@ class PersonaDataStore:
 
         async with self.db.execute(
             """
-            SELECT user_id, group_id, intimacy, passion, trust, secureness,
+            SELECT user_id, intimacy, passion, trust, secureness,
                    last_interaction_at, last_relationship_decay_applied_at,
                    last_miss_sent_at, peak_stage, updated_at
             FROM persona_user_relationships
@@ -1715,18 +1868,17 @@ class PersonaDataStore:
             return [
                 RelationshipState(
                     user_id=row[0],
-                    group_id=row[1] or "",
-                    intimacy=row[2],
-                    passion=row[3],
-                    trust=row[4],
-                    secureness=row[5],
-                    last_interaction_at=datetime.fromisoformat(row[6]) if row[6] else None,
+                    intimacy=row[1],
+                    passion=row[2],
+                    trust=row[3],
+                    secureness=row[4],
+                    last_interaction_at=datetime.fromisoformat(row[5]) if row[5] else None,
                     last_relationship_decay_applied_at=(
-                        datetime.fromisoformat(row[7]) if row[7] else None
+                        datetime.fromisoformat(row[6]) if row[6] else None
                     ),
-                    last_miss_sent_at=datetime.fromisoformat(row[8]) if row[8] else None,
-                    peak_stage=row[9] if row[9] is not None else 0,
-                    updated_at=datetime.fromisoformat(row[10]) if row[10] else None
+                    last_miss_sent_at=datetime.fromisoformat(row[7]) if row[7] else None,
+                    peak_stage=row[8] if row[8] is not None else 0,
+                    updated_at=datetime.fromisoformat(row[9]) if row[9] else None
                 )
                 for row in rows
             ]

--- a/src/plugins/DicePP/module/persona/life/proactive_scheduler.py
+++ b/src/plugins/DicePP/module/persona/life/proactive_scheduler.py
@@ -425,7 +425,7 @@ class ProactiveScheduler(BoundaryReceiver):
         try:
             # 获取目标上下文
             user_profile = await self.data_store.get_user_profile(target.user_id)
-            rel = await self.data_store.get_relationship(target.user_id, target.group_id)
+            rel = await self.data_store.get_relationship(target.user_id)
 
             warmth_label = ""
             relationship_score = 0.0

--- a/src/plugins/DicePP/module/persona/life/simulator.py
+++ b/src/plugins/DicePP/module/persona/life/simulator.py
@@ -181,7 +181,8 @@ class LifeSimulator:
                 await self.store.add_score_event(
                     ScoreEvent(
                         user_id=rel.user_id,
-                        group_id=rel.group_id,
+                        # 关系统一后衰减为全局行为，group_id 仅作审计（reason 字段已记录衰减标识）
+                        group_id="",
                         deltas=deltas,
                         composite_before=composite_before,
                         composite_after=rel.composite_score,

--- a/src/plugins/DicePP/module/persona/life/target.py
+++ b/src/plugins/DicePP/module/persona/life/target.py
@@ -98,12 +98,13 @@ class TargetSelector:
         # === Normal 策略 ===
         try:
             high_score = await self.data_store.get_top_relationships(limit=20)
+            logger.debug(f"Normal 策略: get_top_relationships 返回 {len(high_score)} 个候选")
             for rel in high_score:
                 eff = effective_for_proactive(rel, self._decay_calculator, self._character)
                 key = f"user:{rel.user_id}"
                 if key in seen_ids:
                     continue
-                if eff.composite_score >= 60 and not rel.group_id:
+                if eff.composite_score >= 60:
                     seen_ids.add(key)
                     targets.append(
                         ShareTarget(
@@ -113,7 +114,7 @@ class TargetSelector:
                             policy="normal",
                         )
                     )
-                elif 40 <= eff.composite_score < 60 and not rel.group_id:
+                elif 40 <= eff.composite_score < 60:
                     seen_ids.add(key)
                     targets.append(
                         ShareTarget(

--- a/tests/integration/persona/test_command.py
+++ b/tests/integration/persona/test_command.py
@@ -281,8 +281,8 @@ class TestAdminCommands(IsolatedAsyncioTestCase):
         assert "调试信息" in _get_sent_content(self.cmd)
 
     async def test_admin_rel(self):
-        rel = RelationshipState(user_id="u1", group_id="", intimacy=30, passion=30, trust=30, secureness=30)
-        self.cmd._get_relationship_for_display = AsyncMock(return_value=rel)
+        rel = RelationshipState(user_id="u1", intimacy=30, passion=30, trust=30, secureness=30)
+        self.cmd.admin_dispatcher._get_relationship_for_display = AsyncMock(return_value=rel)
         self.store.get_user_profile = AsyncMock(return_value=None)
         meta = _make_private_meta(".ai admin rel u1", user_id=self.user_id)
         await self.cmd.process_msg(".ai admin rel u1", meta, "admin")
@@ -290,7 +290,7 @@ class TestAdminCommands(IsolatedAsyncioTestCase):
 
     async def test_admin_setrel(self):
         self.store.get_relationship = AsyncMock(return_value=None)
-        self.store.init_relationship = AsyncMock(return_value=RelationshipState(user_id="u1", group_id=""))
+        self.store.init_relationship = AsyncMock(return_value=RelationshipState(user_id="u1"))
         meta = _make_private_meta(".ai admin setrel u1 50", user_id=self.user_id)
         await self.cmd.process_msg(".ai admin setrel u1 50", meta, "admin")
         assert "已设置用户 u1 的好感度为 50.00" in _get_sent_content(self.cmd)
@@ -393,12 +393,13 @@ class TestUserCommands(IsolatedAsyncioTestCase):
         assert "已启用" in _get_sent_content(self.cmd)
 
     async def test_profile(self):
-        rel = RelationshipState(user_id="user", group_id="", intimacy=30, passion=30, trust=30, secureness=30)
-        self.cmd._get_relationship_for_display = AsyncMock(return_value=rel)
+        rel = RelationshipState(user_id="user", intimacy=30, passion=30, trust=30, secureness=30)
+        self.store.get_relationship = AsyncMock(return_value=rel)
         self.store.get_user_profile = AsyncMock(return_value=UserProfile(user_id="user", facts={"name": "Xiao"}))
         self.store.get_recent_score_events = AsyncMock(return_value=[])
         self.store.get_earliest_message_time = AsyncMock(return_value=None)
         self.store.count_messages = AsyncMock(return_value=5)
+        self.cmd.app.get_decay_calculator = MagicMock(return_value=None)
         meta = _make_private_meta(".ai profile")
         await self.cmd.process_msg(".ai profile", meta, None)
         assert "你的档案" in _get_sent_content(self.cmd)

--- a/tests/module/persona/life/test_target_selector.py
+++ b/tests/module/persona/life/test_target_selector.py
@@ -49,7 +49,6 @@ async def test_force_and_normal_dedup(mock_data_store, bot_config):
 
     rel = MagicMock()
     rel.user_id = "u1"
-    rel.group_id = ""
     rel.composite_score = 80
     mock_data_store.get_top_relationships = AsyncMock(return_value=[rel])
 
@@ -70,7 +69,6 @@ def test_is_force_user(mock_data_store, bot_config):
 async def test_normal_high_score_user(mock_data_store, bot_config):
     rel = MagicMock()
     rel.user_id = "u3"
-    rel.group_id = ""
     rel.composite_score = 75
     mock_data_store.get_top_relationships = AsyncMock(return_value=[rel])
 
@@ -86,7 +84,6 @@ async def test_normal_high_score_user(mock_data_store, bot_config):
 async def test_normal_medium_score_user(mock_data_store, bot_config):
     rel = MagicMock()
     rel.user_id = "u4"
-    rel.group_id = ""
     rel.composite_score = 50
     mock_data_store.get_top_relationships = AsyncMock(return_value=[rel])
 

--- a/tests/unit/persona/test_chat_session.py
+++ b/tests/unit/persona/test_chat_session.py
@@ -138,7 +138,7 @@ async def test_first_message_skipped_in_group_chat():
 async def test_refuse_triggers_at_warmth_zero(monkeypatch):
     """warmth_level=0 时按概率返回 refuse 文案，跳过 LLM"""
     rel = RelationshipState(
-        user_id="u1", group_id="",
+        user_id="u1",
         intimacy=0, passion=0, trust=0, secureness=0,
     )
     session = _make_session(
@@ -166,7 +166,7 @@ async def test_refuse_does_not_trigger_above_warmth_zero(monkeypatch):
     """warmth_level>0 时不进入拒绝分支"""
     # 高分 → warmth_level>0
     rel = RelationshipState(
-        user_id="u1", group_id="",
+        user_id="u1",
         intimacy=80, passion=80, trust=80, secureness=80,
     )
     session = _make_session(
@@ -313,7 +313,7 @@ class TestDecayInChatSession:
         ))
         session.decay_calculator = decay_calc
 
-        rel = RelationshipState(user_id="u1", group_id="")
+        rel = RelationshipState(user_id="u1")
         session.store.get_relationship = AsyncMock(return_value=rel)
         session.store.update_relationship = AsyncMock()
         session.store.add_score_event = AsyncMock()

--- a/tests/unit/persona/test_data_store.py
+++ b/tests/unit/persona/test_data_store.py
@@ -172,29 +172,28 @@ class TestRelationshipCRUD:
     @pytest.mark.asyncio
     async def test_init_and_get_relationship(self, temp_db):
         store = temp_db
-        rel = await store.init_relationship("u1", "g1", initial_score=40.0)
+        rel = await store.init_relationship("u1", initial_score=40.0)
         assert rel.user_id == "u1"
-        assert rel.group_id == "g1"
         assert rel.intimacy == 40.0
         assert rel.passion == 40.0
 
     @pytest.mark.asyncio
     async def test_update_relationship(self, temp_db):
         store = temp_db
-        rel = await store.init_relationship("u1", "g1", initial_score=30.0)
+        rel = await store.init_relationship("u1", initial_score=30.0)
         rel.intimacy = 50.0
         rel.passion = 45.0
         await store.update_relationship(rel)
 
-        rel2 = await store.get_relationship("u1", "g1")
+        rel2 = await store.get_relationship("u1")
         assert rel2.intimacy == 50.0
         assert rel2.passion == 45.0
 
     @pytest.mark.asyncio
     async def test_list_all_relationships_raw(self, temp_db):
         store = temp_db
-        await store.init_relationship("u1", "g1", 30.0)
-        await store.init_relationship("u2", "g1", 40.0)
+        await store.init_relationship("u1", 30.0)
+        await store.init_relationship("u2", 40.0)
 
         rels = await store.list_all_relationships_raw()
         assert len(rels) == 2
@@ -204,7 +203,7 @@ class TestRelationshipCRUD:
     @pytest.mark.asyncio
     async def test_list_active_relationships(self, temp_db):
         store = temp_db
-        await store.init_relationship("u1", "g1", 30.0)
+        await store.init_relationship("u1", 30.0)
         rels = await store.list_active_relationships(min_score=0, active_within_days=30)
         assert len(rels) >= 1
 
@@ -226,7 +225,7 @@ class TestScoreEventCRUD:
         )
         await store.add_score_event(event)
 
-        events = await store.get_recent_score_events("u1", "g1", limit=5)
+        events = await store.get_recent_score_events("u1", limit=5)
         assert len(events) == 1
         assert events[0].reason == "test"
         assert events[0].deltas.intimacy == 2.0

--- a/tests/unit/persona/test_decay_calculator.py
+++ b/tests/unit/persona/test_decay_calculator.py
@@ -19,7 +19,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             last_interaction_at=datetime.now() - timedelta(days=1),
             last_miss_sent_at=datetime.now() - timedelta(days=1),
@@ -31,7 +30,7 @@ class TestDecayCalculatorEdgeCases:
     def test_no_last_interaction_returns_zero(self):
         config = DecayConfig(enabled=True)
         calc = DecayCalculator(config)
-        rel = RelationshipState(user_id="u1", group_id="", intimacy=50.0, last_interaction_at=None)
+        rel = RelationshipState(user_id="u1", intimacy=50.0, last_interaction_at=None)
         deltas, reason = calc.calculate_decay(rel)
         assert deltas.intimacy == 0.0
         assert "无上次互动记录" in reason
@@ -42,7 +41,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             last_interaction_at=datetime.now() - timedelta(days=1),
             last_miss_sent_at=None,
@@ -56,7 +54,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             last_interaction_at=datetime.now() - timedelta(hours=4),
             last_miss_sent_at=datetime.now() - timedelta(hours=4),
@@ -76,7 +73,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=25.0,
             passion=25.0,
             trust=25.0,
@@ -101,7 +97,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=20.0,
             passion=20.0,
             trust=20.0,
@@ -125,7 +120,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=82.0,
             passion=82.0,
             trust=82.0,
@@ -149,7 +143,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=80.0,
             passion=80.0,
             trust=80.0,
@@ -173,7 +166,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=58.0,
             passion=58.0,
             trust=58.0,
@@ -197,7 +189,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=80.0,
             passion=80.0,
             trust=80.0,
@@ -214,7 +205,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             last_interaction_at=datetime.now() - timedelta(hours=2),
             last_miss_sent_at=datetime.now() - timedelta(hours=2),
@@ -227,7 +217,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             last_interaction_at=datetime.now() - timedelta(days=1),
             last_miss_sent_at=None,
@@ -239,7 +228,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             last_interaction_at=datetime.now() - timedelta(minutes=30),
             last_miss_sent_at=datetime.now() - timedelta(minutes=30),
@@ -251,7 +239,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             last_interaction_at=datetime.now() - timedelta(days=1),
             last_miss_sent_at=datetime.now() - timedelta(days=1),
@@ -261,7 +248,7 @@ class TestDecayCalculatorEdgeCases:
     def test_should_apply_decay_false_no_interaction(self):
         config = DecayConfig(enabled=True)
         calc = DecayCalculator(config)
-        rel = RelationshipState(user_id="u1", group_id="", intimacy=50.0, last_interaction_at=None)
+        rel = RelationshipState(user_id="u1", intimacy=50.0, last_interaction_at=None)
         assert calc.should_apply_decay(rel) is False
 
     def test_effective_relationship_returns_copy(self):
@@ -274,7 +261,6 @@ class TestDecayCalculatorEdgeCases:
         calc = DecayCalculator(config)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=50.0,
             passion=50.0,
             trust=50.0,
@@ -301,7 +287,6 @@ class TestDecayCalculatorEdgeCases:
         now = datetime(2026, 1, 2, 12, 0, 0)
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=80.0,
             passion=80.0,
             trust=80.0,

--- a/tests/unit/persona/test_decay_incremental.py
+++ b/tests/unit/persona/test_decay_incremental.py
@@ -22,7 +22,6 @@ def test_decay_incremental_same_moment_no_double_apply():
     )
     rel = RelationshipState(
         user_id="u1",
-        group_id="",
         intimacy=80.0,
         passion=80.0,
         trust=80.0,
@@ -56,7 +55,6 @@ def test_decay_incremental_after_batch_user_message_only_new_idle():
     )
     rel = RelationshipState(
         user_id="u1",
-        group_id="",
         intimacy=80.0,
         passion=80.0,
         trust=80.0,
@@ -91,7 +89,6 @@ def test_decay_after_miss_accounts_full_idle():
     )
     rel = RelationshipState(
         user_id="u1",
-        group_id="",
         intimacy=80.0,
         passion=80.0,
         trust=80.0,
@@ -131,7 +128,6 @@ def test_decay_switch_off_then_on():
     )
     rel = RelationshipState(
         user_id="u1",
-        group_id="",
         intimacy=80.0,
         passion=80.0,
         trust=80.0,

--- a/tests/unit/persona/test_decay_lazy.py
+++ b/tests/unit/persona/test_decay_lazy.py
@@ -19,7 +19,6 @@ def test_effective_relationship_leaves_original_unchanged():
     )
     rel = RelationshipState(
         user_id="u1",
-        group_id="",
         intimacy=50.0,
         passion=50.0,
         trust=50.0,

--- a/tests/unit/persona/test_group_activity_store.py
+++ b/tests/unit/persona/test_group_activity_store.py
@@ -58,26 +58,26 @@ async def test_group_activity_decay_uses_config():
 
 
 @pytest.mark.asyncio
-async def test_get_top_relationships_includes_null_group_id_as_private():
+async def test_get_top_relationships_global_ranking():
     async with aiosqlite.connect(":memory:") as db:
         store = PersonaDataStore(db)
         await store.ensure_tables()
         await db.execute(
             """
             INSERT INTO persona_user_relationships
-            (user_id, group_id, intimacy, passion, trust, secureness, last_interaction_at, updated_at)
-            VALUES ('u_null', NULL, 80, 80, 80, 80, datetime('now'), datetime('now'))
+            (user_id, intimacy, passion, trust, secureness, last_interaction_at, updated_at)
+            VALUES ('u_high', 80, 80, 80, 80, datetime('now'), datetime('now'))
             """,
         )
         await db.execute(
             """
             INSERT INTO persona_user_relationships
-            (user_id, group_id, intimacy, passion, trust, secureness, last_interaction_at, updated_at)
-            VALUES ('u_empty', '', 70, 70, 70, 70, datetime('now'), datetime('now'))
+            (user_id, intimacy, passion, trust, secureness, last_interaction_at, updated_at)
+            VALUES ('u_mid', 70, 70, 70, 70, datetime('now'), datetime('now'))
             """,
         )
         await db.commit()
-        top = await store.get_top_relationships(group_id="", limit=10)
+        top = await store.get_top_relationships(limit=10)
         ids = {r.user_id for r in top}
-        assert "u_null" in ids
-        assert "u_empty" in ids
+        assert "u_high" in ids
+        assert "u_mid" in ids

--- a/tests/unit/persona/test_life_simulator.py
+++ b/tests/unit/persona/test_life_simulator.py
@@ -238,7 +238,7 @@ async def test_tick_daily_applies_relationship_decay():
     ))
     sim.decay_calculator = decay_calc
 
-    rel = RelationshipState(user_id="u1", group_id="")
+    rel = RelationshipState(user_id="u1")
     sim.store.list_all_relationships_raw = AsyncMock(return_value=[rel])
 
     await sim.tick_daily()

--- a/tests/unit/persona/test_phase3_features.py
+++ b/tests/unit/persona/test_phase3_features.py
@@ -146,7 +146,6 @@ class TestWarmthLevelRefuse:
         """好感度 5 分应该在冷淡区间（0）"""
         rel = RelationshipState(
             user_id="test",
-            group_id="",
             intimacy=5.0,
             passion=5.0,
             trust=5.0,
@@ -163,7 +162,6 @@ class TestWarmthLevelRefuse:
         """好感度 30 分应该在疏远区间（1）"""
         rel = RelationshipState(
             user_id="test",
-            group_id="",
             intimacy=30.0,
             passion=30.0,
             trust=30.0,

--- a/tests/unit/persona/test_scheduler.py
+++ b/tests/unit/persona/test_scheduler.py
@@ -293,7 +293,6 @@ class TestProactiveSchedulerMissYou:
         )
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=10,
             passion=10,
             trust=10,
@@ -313,7 +312,6 @@ class TestProactiveSchedulerMissYou:
         )
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=60,
             passion=60,
             trust=60,
@@ -333,7 +331,6 @@ class TestProactiveSchedulerMissYou:
         )
         rel = RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=60,
             passion=60,
             trust=60,
@@ -391,7 +388,6 @@ class TestProactiveSchedulerMissProbability:
     def _make_rel(self, score: float, fake_now: datetime) -> RelationshipState:
         return RelationshipState(
             user_id="u1",
-            group_id="",
             intimacy=score,
             passion=score,
             trust=score,

--- a/tests/unit/persona/test_scheduler_context.py
+++ b/tests/unit/persona/test_scheduler_context.py
@@ -107,7 +107,7 @@ class TestBuildAndGenerateShareMessage:
         """当有关系记录时 warmth_label 和 score 正确解析"""
         from plugins.DicePP.module.persona.life.models import ShareTarget
 
-        rel = RelationshipState(user_id="u1", group_id="", intimacy=65.0, passion=60.0, trust=70.0, secureness=60.0)
+        rel = RelationshipState(user_id="u1", intimacy=65.0, passion=60.0, trust=70.0, secureness=60.0)
         mock_data_store.get_relationship = AsyncMock(return_value=rel)
 
         mock_agent = MagicMock()
@@ -302,7 +302,7 @@ class TestFormatRecentHistory:
         msg.content = "你好"
         msg.created_at = datetime(2026, 5, 11, 9, 15)
         result = ProactiveScheduler._format_recent_history(self._mock_scheduler(), [msg])
-        assert "[09:15] 用户: 你好" in result
+        assert "[05-11 09:15] 用户: 你好" in result
 
 
 if __name__ == "__main__":

--- a/tests/unit/persona/test_store_migration.py
+++ b/tests/unit/persona/test_store_migration.py
@@ -1,7 +1,8 @@
-"""旧 schema 迁移回归测试：验证 peak_stage backfill 正确性。"""
+"""旧 schema 迁移回归测试：验证 peak_stage backfill 正确性，以及
+_ensure_relationship_unified 合并迁移正确性。"""
 
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from plugins.DicePP.module.persona.data.store import PersonaDataStore
 from plugins.DicePP.module.persona.data.models import RelationshipState
@@ -77,7 +78,7 @@ class TestPeakStageBackfill:
             "u_exact_20": 1,
         }
         for user_id, expected_stage in expected.items():
-            rel = await store.get_relationship(user_id, "")
+            rel = await store.get_relationship(user_id)
             assert rel is not None, f"user {user_id} not found"
             assert rel.peak_stage == expected_stage, (
                 f"user {user_id}: expected peak_stage={expected_stage}, got {rel.peak_stage}"
@@ -89,7 +90,7 @@ class TestPeakStageBackfill:
         store = old_schema_db
 
         # 先手动设置一个非零值
-        rel = await store.get_relationship("u_cold", "")
+        rel = await store.get_relationship("u_cold")
         rel.peak_stage = 3
         await store.update_relationship(rel)
 
@@ -97,43 +98,67 @@ class TestPeakStageBackfill:
         await store.ensure_tables()
 
         # peak_stage 应保持为 3（不被 backfill 覆盖）
-        rel2 = await store.get_relationship("u_cold", "")
+        rel2 = await store.get_relationship("u_cold")
         assert rel2.peak_stage == 3
 
 
 @pytest.fixture
-async def old_schema_daily_events_db():
-    """创建模拟旧 schema 的 daily_events 表（无 context_summary 列）。"""
+async def old_multi_record_db():
+    """创建含 group_id 列的旧 schema 数据库，同一用户有多条记录。"""
     import aiosqlite
 
     async with aiosqlite.connect(":memory:") as db:
         await db.execute(
             """
-            CREATE TABLE persona_daily_events (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                date TEXT NOT NULL,
-                event_type TEXT NOT NULL,
-                description TEXT NOT NULL,
-                reaction TEXT DEFAULT '',
-                share_desire REAL DEFAULT 0.0,
-                duration_minutes INTEGER DEFAULT 0,
-                system_prompt_digest TEXT DEFAULT '',
-                raw_response TEXT DEFAULT '',
-                energy_delta INTEGER,
-                mood_delta INTEGER,
-                health_delta INTEGER,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            CREATE TABLE persona_user_relationships (
+                user_id TEXT NOT NULL,
+                group_id TEXT DEFAULT '',
+                intimacy REAL DEFAULT 40.0,
+                passion REAL DEFAULT 40.0,
+                trust REAL DEFAULT 40.0,
+                secureness REAL DEFAULT 40.0,
+                last_interaction_at TIMESTAMP,
+                last_relationship_decay_applied_at TIMESTAMP,
+                last_miss_sent_at TIMESTAMP,
+                peak_stage INTEGER DEFAULT 0,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (user_id, group_id)
             )
             """
         )
-        # 插入一条旧数据
+        # u_single: 单条记录 → 直接复制
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
         await db.execute(
             """
-            INSERT INTO persona_daily_events
-            (date, event_type, description)
-            VALUES (?, ?, ?)
+            INSERT INTO persona_user_relationships
+            (user_id, group_id, intimacy, passion, trust, secureness,
+             last_interaction_at, peak_stage, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            ("2024-01-01", "system", "旧事件"),
+            ("u_single", "g1", 50.0, 50.0, 50.0, 50.0, t0.isoformat(), 2, t0.isoformat()),
+        )
+        # u_multi: 两条记录（私聊 + 群聊）→ 应合并为一条
+        t1 = datetime(2026, 1, 1, 10, 0, 0)  # 较早（群聊）
+        t2 = datetime(2026, 1, 2, 10, 0, 0)  # 较新（私聊）
+        await db.execute(
+            """
+            INSERT INTO persona_user_relationships
+            (user_id, group_id, intimacy, passion, trust, secureness,
+             last_interaction_at, peak_stage, last_miss_sent_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("u_multi", "g1", 20.0, 20.0, 20.0, 20.0,
+             t1.isoformat(), 1, t1.isoformat(), t1.isoformat()),
+        )
+        await db.execute(
+            """
+            INSERT INTO persona_user_relationships
+            (user_id, group_id, intimacy, passion, trust, secureness,
+             last_interaction_at, peak_stage, last_miss_sent_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("u_multi", "", 55.0, 55.0, 55.0, 55.0,
+             t2.isoformat(), 3, None, t2.isoformat()),
         )
         await db.commit()
 
@@ -142,44 +167,101 @@ async def old_schema_daily_events_db():
         yield store
 
 
-class TestContextSummaryMigration:
-    """测试 context_summary 列迁移：旧 schema → 新列添加 + 幂等。"""
+class TestRelationshipUnifiedMigration:
+    """测试 _ensure_relationship_unified 迁移：去 group_id、合并多行。"""
 
     @pytest.mark.asyncio
-    async def test_migration_adds_context_summary_column(self, old_schema_daily_events_db):
-        """旧 schema 表经 ensure_tables 后应增加 context_summary 列且旧行值为 ''。"""
-        store = old_schema_daily_events_db
-
-        # 验证 PRAGMA 中列已存在
-        async with store.db.execute("PRAGMA table_info(persona_daily_events)") as cursor:
+    async def test_no_group_id_column(self, old_multi_record_db):
+        """迁移后新表不应包含 group_id 列。"""
+        store = old_multi_record_db
+        async with store.db.execute(
+            "PRAGMA table_info(persona_user_relationships)"
+        ) as cursor:
             rows = await cursor.fetchall()
         col_names = {row[1] for row in rows}
-        assert "context_summary" in col_names
-
-        # 旧行回读 context_summary 为空字符串
-        events = await store.get_daily_events("2024-01-01")
-        assert len(events) == 1
-        assert events[0].context_summary == ""
+        assert "group_id" not in col_names
 
     @pytest.mark.asyncio
-    async def test_migration_idempotent(self, old_schema_daily_events_db):
-        """重复调用 ensure_tables 不报错且列不变。"""
-        store = old_schema_daily_events_db
-        await store.ensure_tables()  # 第二次调用
+    async def test_single_record_direct_copy(self, old_multi_record_db):
+        """单条记录的用户直接复制，分数不变。"""
+        store = old_multi_record_db
+        rel = await store.get_relationship("u_single")
+        assert rel is not None
+        assert rel.intimacy == 50.0
+        assert rel.passion == 50.0
+        assert rel.peak_stage == 2
 
-        async with store.db.execute("PRAGMA table_info(persona_daily_events)") as cursor:
-            rows = await cursor.fetchall()
-        col_names = {row[1] for row in rows}
-        assert "context_summary" in col_names
+    @pytest.mark.asyncio
+    async def test_multi_record_merge_latest_wins(self, old_multi_record_db):
+        """同一用户多条记录：intimacy 取 last_interaction_at 最新行的值。"""
+        store = old_multi_record_db
+        rel = await store.get_relationship("u_multi")
+        assert rel is not None
+        # 最新行 (t2) 的 intimacy=55
+        assert rel.intimacy == 55.0
+        assert rel.passion == 55.0
 
-        # 写入新数据验证列可正常使用
-        await store.add_daily_event(
-            date="2024-01-01",
-            event_type="system",
-            description="新事件",
-            context_summary="新摘要",
+    @pytest.mark.asyncio
+    async def test_multi_record_peak_stage_takes_max(self, old_multi_record_db):
+        """同一用户多条记录：peak_stage 取 MAX。"""
+        store = old_multi_record_db
+        rel = await store.get_relationship("u_multi")
+        # t1 的 peak_stage=1, t2 的 peak_stage=3 → MAX = 3
+        assert rel.peak_stage == 3
+
+    @pytest.mark.asyncio
+    async def test_multi_record_miss_sent_at_takes_min(self, old_multi_record_db):
+        """同一用户多条记录：last_miss_sent_at 取 MIN（最早非 NULL）。"""
+        store = old_multi_record_db
+        rel = await store.get_relationship("u_multi")
+        # t1 miss_at = t1, t2 miss_at = NULL → MIN = t1
+        t1 = datetime(2026, 1, 1, 10, 0, 0)
+        assert rel.last_miss_sent_at == t1
+
+    @pytest.mark.asyncio
+    async def test_idempotent_skip_on_second_run(self, old_multi_record_db):
+        """已迁移的库再次 ensure_tables 应跳过，不抛异常。"""
+        store = old_multi_record_db
+        # 第二次 ensure_tables
+        await store.ensure_tables()
+        # u_single 应仍存在且数据不变
+        rel = await store.get_relationship("u_single")
+        assert rel is not None
+        assert rel.intimacy == 50.0
+
+    @pytest.mark.asyncio
+    async def test_orphan_backup_table_cleanup(self, old_multi_record_db):
+        """模拟步骤 6 前崩溃：_backup 表残留，下次 ensure_tables 应自动清理。"""
+        store = old_multi_record_db
+        await store.db.execute(
+            "CREATE TABLE persona_user_relationships_backup AS SELECT * FROM persona_user_relationships"
         )
-        events = await store.get_daily_events("2024-01-01")
-        assert len(events) == 2
-        new_ev = [e for e in events if e.context_summary == "新摘要"][0]
-        assert new_ev.description == "新事件"
+        await store.db.commit()
+        await store.ensure_tables()
+        async with store.db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='persona_user_relationships_backup'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is None
+
+    @pytest.mark.asyncio
+    async def test_orphan_new_table_recovery(self, old_multi_record_db):
+        """模拟步骤 4a→4b 之间崩溃：_new 孤儿表，主表缺失，应自动恢复。"""
+        store = old_multi_record_db
+        rel = await store.get_relationship("u_single")
+        assert rel is not None
+
+        # 模拟：旧表已 RENAME→_backup，_new 存在但未晋升为主表
+        await store.db.execute("DROP TABLE IF EXISTS persona_user_relationships_backup")
+        await store.db.execute(
+            "ALTER TABLE persona_user_relationships RENAME TO persona_user_relationships_backup"
+        )
+        await store.db.execute(
+            "CREATE TABLE persona_user_relationships_new AS SELECT * FROM persona_user_relationships_backup"
+        )
+        await store.db.commit()
+
+        await store.ensure_tables()
+        rel2 = await store.get_relationship("u_single")
+        assert rel2 is not None
+        assert rel2.intimacy == 50.0


### PR DESCRIPTION
## Summary
- `persona_user_relationships` 主键从 `(user_id, group_id)` 改为 `user_id`，同一用户的私聊和群聊互动累积到同一条记录
- 启动时自动迁移旧数据：检测 `group_id` 列 → 建新表 → CTE+ROW_NUMBER 合并多行（最新互动为基础，peak_stage 取 MAX，last_miss_sent_at 取 MIN）→ 替换旧表。含崩溃恢复
- `ScoreEvent.group_id` 保留为审计字段，`_pending_messages` 键简化为 `user_id`
- 想念检查不再因分场景记录误触，`.ai profile` 展示统一好感度，`get_top_relationships()` 返回全局排行

## Test plan
- [x] 全量 persona 测试套件通过 (631/631)
- [x] 旧 schema 迁移合并测试（单记录、多记录、幂等）
- [x] 崩溃恢复场景测试（_backup 残留清理、_new 孤儿恢复）
- [ ] 生产数据库备份后执行迁移无异常（需手动在部署时验证）