### PR TITLE
refactor(persona): 统一 LLM 调用路径为单一 generate() 入口

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -36,3 +36,15 @@
   - 短期可降低 `max_short_term_chars` 缓解，但长期需要摘要机制
   - 影响面: `context.py` `ContextBuilder.build`、`_format_short_term`、session 截断策略
 
+
+### [B-260512-f2d8a1] tool_choice="required" 场景缺少显式终止机制
+- 创建: 2026-05-12
+- 问题表现:
+  - `tool_choice="required"` 下 LLM 完成工具调用后无法表达"我已做完"——它必须继续调工具直到 `max_total_rounds` 耗尽
+  - 单工具 CollectExecutor 场景首轮收集成功后 100% 浪费
+  - 当前通过 `max_tool_rounds=1` + 早退 break 缓解，多工具场景依赖硬上限
+- 工作计划:
+  - 引入 `finish_task` 工具：LLM 完成后主动调用声明结束，循环检测到后立即终止
+  - 作为通用终止方案，统一单工具和多工具场景
+  - 影响面: `client.py:_generate_with_tools` 循环终止条件、后台 Agent prompt
+  - 前置条件: 当前 `max_tool_rounds=1` 已覆盖，本条为架构扩展预留

--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -69,8 +69,8 @@ class PersonaConfig(BaseModel):
     )
 
     # ── Phase 3: 工具调用
-    tools_enabled: bool = True
-    tools_max_rounds: int = 5  # 工具调用最大轮次
+    tools_max_rounds: int = 5  # 聊天工具调用最大轮次
+    background_llm_max_tool_rounds: int = 1  # 后台单工具场景最大轮次（首轮收集即终止）
 
     # ── Phase 3: 日记上下文长度限制
     max_diary_context_chars: int = 500  # 日记注入上下文的最大字符数

--- a/src/plugins/DicePP/module/persona/chat/scoring.py
+++ b/src/plugins/DicePP/module/persona/chat/scoring.py
@@ -9,6 +9,7 @@ from nonebot.log import logger
 from pydantic import BaseModel
 from ..data.models import ScoreDeltas, UserProfile, RelationshipState, ModelTier
 from ..llm.router import LLMRouter
+from ..llm.collect_executor import CollectExecutor
 from ..utils.json_helpers import safe_json_loads
 from ..wall_clock import persona_wall_now, format_timestamp
 
@@ -24,9 +25,11 @@ class ScoringAnalysisResult(BaseModel):
 class ScoringAgent:
     """评分 Agent - 批量分析对话提取用户档案和好感度变化"""
 
-    def __init__(self, llm_router: LLMRouter, timezone: str = "Asia/Shanghai"):
+    def __init__(self, llm_router: LLMRouter, timezone: str = "Asia/Shanghai",
+                 max_tool_rounds: int = 3):
         self.llm_router = llm_router
         self.timezone = timezone
+        self.max_tool_rounds = max_tool_rounds
 
     async def batch_analyze(
         self,
@@ -40,21 +43,88 @@ class ScoringAgent:
             relationship
         )
 
-        # 调用辅助模型
-        response = await self.llm_router.generate(
-            messages=[{"role": "user", "content": prompt}],
-            model_tier=ModelTier.AUXILIARY,
-        )
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "score_relationship",
+                    "description": "输出好感度变化分析和用户事实提取结果",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "deltas": {
+                                "type": "object",
+                                "properties": {
+                                    "intimacy": {"type": "number", "description": "亲密度变化，范围 -5.0 到 +5.0"},
+                                    "passion": {"type": "number", "description": "激情变化"},
+                                    "trust": {"type": "number", "description": "信任变化"},
+                                    "secureness": {"type": "number", "description": "安全感变化"},
+                                },
+                                "required": ["intimacy", "passion", "trust", "secureness"],
+                            },
+                            "facts": {
+                                "type": "object",
+                                "description": "提取或更新的用户事实，key-value 形式",
+                            },
+                        },
+                        "required": ["deltas", "facts"],
+                    },
+                },
+            }
+        ]
 
-        # 解析结果
-        deltas, facts, parse_error = self._parse_response(response)
+        executor = CollectExecutor()
 
-        return ScoringAnalysisResult(
-            deltas=deltas,
-            facts=facts,
-            raw_response=response,
-            parse_error=parse_error,
-        )
+        try:
+            content, metadata = await self.llm_router.generate(
+                messages=[{"role": "user", "content": prompt}],
+                tools=tools,
+                tool_executor=executor,
+                max_tool_rounds=self.max_tool_rounds,
+                model_tier=ModelTier.AUXILIARY,
+            )
+        except Exception as e:
+            logger.error(f"评分 LLM 调用失败: {e}")
+            return ScoringAnalysisResult(
+                deltas=ScoreDeltas(),
+                facts={},
+                parse_error=f"LLM 调用失败: {type(e).__name__}: {e}",
+            )
+
+        if not executor.collected:
+            raw_response = content if content else ""
+            deltas, facts, parse_error = self._parse_response(raw_response)
+            return ScoringAnalysisResult(
+                deltas=deltas,
+                facts=facts,
+                raw_response=raw_response,
+                parse_error=parse_error,
+            )
+
+        raw_args = executor.collected[0]["arguments"]
+        data = safe_json_loads(raw_args, fallback=None, log_prefix="评分解析")
+        if not isinstance(data, dict):
+            return ScoringAnalysisResult(
+                deltas=ScoreDeltas(),
+                facts={},
+                raw_response=raw_args,
+                parse_error=f"JSON 解析失败或返回非 dict: type={type(data).__name__}",
+            )
+        try:
+            deltas, facts = self._extract_result(data)
+            return ScoringAnalysisResult(
+                deltas=deltas,
+                facts=facts,
+                raw_response=json.dumps(data, ensure_ascii=False),
+                parse_error="",
+            )
+        except Exception as exc:
+            return ScoringAnalysisResult(
+                deltas=ScoreDeltas(),
+                facts={},
+                raw_response=raw_args,
+                parse_error=f"提取评分结果异常: {type(exc).__name__}: {exc}",
+            )
 
     def _build_analysis_prompt(
         self,
@@ -94,19 +164,7 @@ class ScoringAgent:
 ## 已知的用户信息
 {existing_facts}
 
-## 输出格式（严格 JSON）
-{{
-  "deltas": {{
-    "intimacy": 0.0,  // 亲密度变化，范围 -5.0 到 +5.0
-    "passion": 0.0,   // 激情变化
-    "trust": 0.0,     // 信任变化
-    "secureness": 0.0 // 安全感变化
-  }},
-  "facts": {{
-    // 提取或更新的用户事实，key-value 形式
-    // 只包含新发现或需要更新的信息
-  }}
-}}
+你必须通过调用 score_relationship 工具来输出结果，不要直接回复文本。
 
 注意：
 - 好感度变化基于用户的态度、话题深度、情感表达

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -55,7 +55,6 @@ class ChatConfig:
     max_short_term_chars: int = 1500
     timezone: str = "Asia/Shanghai"
     lore_token_budget: int = 300
-    tools_enabled: bool = True
     tools_max_rounds: int = 5
     relationship_refuse_enabled: bool = False
     relationship_refuse_prob_base: float = 0.5
@@ -81,7 +80,6 @@ class ChatConfig:
             max_short_term_chars=persona.max_short_term_chars,
             timezone=persona.timezone,
             lore_token_budget=persona.lore_token_budget,
-            tools_enabled=persona.tools_enabled,
             tools_max_rounds=persona.tools_max_rounds,
             relationship_refuse_enabled=persona.relationship_refuse_enabled,
             relationship_refuse_prob_base=persona.relationship_refuse_prob_base,
@@ -254,17 +252,7 @@ class ChatSession:
 
         messages_for_llm = await self._build_messages(user_id, group_id, current_message)
 
-        if self.config.tools_enabled:
-            logger.debug(f"对话走 tools 路径: user={user_id}, tools_enabled=true")
-            response = await self._chat_with_tools(user_id, group_id, messages_for_llm)
-        else:
-            logger.debug(f"对话走普通路径: user={user_id}, tools_enabled=false")
-            response = await self.router.generate(
-                messages=messages_for_llm,
-                model_tier=ModelTier.PRIMARY,
-                user_id=user_id,
-                group_id=group_id,
-            )
+        response = await self._chat_with_tools(user_id, group_id, messages_for_llm)
 
         if isinstance(response, self._SegmentedSentinel):
             # 分段路径：历史已由 _chat_with_tools 写入，跳过重复持久化
@@ -431,12 +419,13 @@ class ChatSession:
         )
         tool_executor = self.tool_registry.make_executor_for(ToolDomain.CHAT, ctx=ctx)
 
-        content, metadata = await self.router.generate_with_tools(
+        content, metadata = await self.router.generate(
             messages=messages,
             tools=tools,
             tool_executor=tool_executor,
-            model_tier=ModelTier.PRIMARY,
+            tool_choice="required" if segment_state else "auto",
             max_tool_rounds=self.config.tools_max_rounds,
+            model_tier=ModelTier.PRIMARY,
             user_id=user_id,
             group_id=group_id,
             on_round_complete=(

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -216,7 +216,8 @@ def _build_chat(
     segment_dispatcher: Optional[SegmentDispatcher] = None,
 ) -> ChatSession:
     """组装 ChatSession"""
-    scoring_agent = ScoringAgent(router, timezone=config.timezone)
+    scoring_agent = ScoringAgent(router, timezone=config.timezone,
+                                 max_tool_rounds=config.background_llm_max_tool_rounds)
     from .chat.context import SegmentGuide
 
     segment_guide = None

--- a/src/plugins/DicePP/module/persona/life/event_agent.py
+++ b/src/plugins/DicePP/module/persona/life/event_agent.py
@@ -10,8 +10,8 @@ from typing import List, Literal, Optional
 from datetime import datetime
 import json
 from nonebot.log import logger
-from ..llm import ForcedToolError
 from ..llm.router import LLMRouter
+from ..llm.collect_executor import CollectExecutor
 from ..data.models import ModelTier
 from typing import TYPE_CHECKING
 
@@ -128,6 +128,11 @@ class EventGenerationAgent:
             getattr(config, "background_llm_timeout_seconds", _DEFAULT_BG_TIMEOUT)
             if config
             else _DEFAULT_BG_TIMEOUT
+        )
+        self._max_tool_rounds = (
+            getattr(config, "background_llm_max_tool_rounds", 1)
+            if config
+            else 1
         )
 
     @staticmethod
@@ -272,22 +277,28 @@ class EventGenerationAgent:
         ]
 
         try:
-            # 使用强制 tool_choice 确保只发一轮请求
-            content, metadata = await self.llm_router.generate_with_forced_tool(
+            max_tool_rounds = self._max_tool_rounds
+            executor = CollectExecutor()
+
+            content, metadata = await self.llm_router.generate(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
                 tools=tools,
-                tool_name="record_event",
+                tool_executor=executor,
+                max_tool_rounds=max_tool_rounds,
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.9,
                 timeout=self._bg_timeout,
             )
 
-            # tool-call 输出（generate_with_forced_tool）：args 已是合法 JSON，
-            # 解析失败属真异常，由外层 except 捕获走 fallback。
-            args = json.loads(content)
+            if not executor.collected:
+                logger.warning("事件生成: LLM 未调用 record_event 工具")
+                raise ValueError("LLM 未调用 record_event")
+
+            raw_args = executor.collected[0]["arguments"]
+            args = json.loads(raw_args)
             description = str(args.get("description", "")).strip().strip('"').strip("'")
             if not description:
                 description = "我正在房间里休息。"
@@ -295,10 +306,8 @@ class EventGenerationAgent:
 
             context_summary = str(args.get("context_summary", "")).strip().strip('"').strip("'")
             if not context_summary:
-                # fallback: 用 description 前 60 字
                 context_summary = description[:60]
 
-            # 解析可选的 delta 值
             def _parse_delta(val) -> Optional[int]:
                 if val is None:
                     return None
@@ -443,21 +452,28 @@ class EventGenerationAgent:
         ]
 
         try:
-            content, metadata = await self.llm_router.generate_with_forced_tool(
+            max_tool_rounds = self._max_tool_rounds
+            executor = CollectExecutor()
+
+            content, metadata = await self.llm_router.generate(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
                 tools=tools,
-                tool_name="record_reaction",
+                tool_executor=executor,
+                max_tool_rounds=max_tool_rounds,
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.9,
                 timeout=self._bg_timeout,
             )
 
-            # tool-call 输出（generate_with_forced_tool）：args 已是合法 JSON，
-            # 解析失败属真异常，由外层 except 捕获走 fallback。
-            args = json.loads(content)
+            if not executor.collected:
+                logger.warning("反应生成: LLM 未调用 record_reaction 工具")
+                raise ValueError("LLM 未调用 record_reaction")
+
+            raw_args = executor.collected[0]["arguments"]
+            args = json.loads(raw_args)
             reaction = str(args.get("reaction", "")).strip().strip('"').strip("'")
             if not reaction:
                 reaction = f"（{character_name}默默地想着这件事）"
@@ -553,7 +569,7 @@ class EventGenerationAgent:
 
 注意：事件描述是第三人称客观记录，反应是角色第一人称自述。请将两者统一转换为日记口吻。
 
-只输出日记内容，不要添加日期或标题。"""
+你必须通过调用 record_diary_entry 工具来输出日记内容，不要直接回复文本。"""
 
         # 构建事件上下文（带时间戳）
         events_lines = []
@@ -579,18 +595,54 @@ class EventGenerationAgent:
         logger.debug("[prompt:system_diary]\n{}", system_prompt)
         logger.debug("[prompt:user_diary]\n{}", user_prompt)
 
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "record_diary_entry",
+                    "description": "记录日记内容",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "diary": {
+                                "type": "string",
+                                "description": "日记内容，100-300字，第一人称",
+                            },
+                        },
+                        "required": ["diary"],
+                    },
+                },
+            }
+        ]
+
         try:
-            response = await self.llm_router.generate(
+            max_tool_rounds = self._max_tool_rounds
+            executor = CollectExecutor()
+
+            content, metadata = await self.llm_router.generate(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
+                tools=tools,
+                tool_executor=executor,
+                max_tool_rounds=max_tool_rounds,
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.85,
                 timeout=self._bg_timeout,
             )
 
-            diary = response.strip()
+            if not executor.collected:
+                logger.warning("日记生成: LLM 未调用 record_diary_entry 工具")
+                return "今天发生了一些事，但我太累了，简单记录一下。"
+
+            raw_args = executor.collected[0]["arguments"]
+            args = json.loads(raw_args)
+            diary = str(args.get("diary", "")).strip()
+
+            if not diary:
+                return "今天发生了一些事，但我太累了，简单记录一下。"
+
             if len(diary) > 300:
                 diary = diary[:297] + "..."
 
@@ -605,9 +657,10 @@ class EventGenerationAgent:
         """
         为指定目标生成个性化分享消息。
 
-        使用 AUXILIARY tier 模型，通过 generate_with_forced_tool 强制输出。
-        超时与重试由配置项 background_llm_timeout_seconds /
-        proactive_share_max_retries / proactive_share_backoff_base_seconds 控制。
+        使用 AUXILIARY tier 模型，通过 generate() 工具路径 +
+        CollectExecutor 收集结果。client.generate() 内建 L1 纠正注入和 API
+        级重试（3 次指数退避）。超时由 background_llm_timeout_seconds 控制。
+        JSON 解析失败或空消息时最多额外重试 2 次（指数退避）。
         彻底失败返回 None（调用方应静默丢弃）。
 
         Args:
@@ -733,54 +786,58 @@ class EventGenerationAgent:
             }
         ]
 
-        max_retries = getattr(self.config, "proactive_share_max_retries", 3) if self.config else 3
-        timeout_seconds = self._bg_timeout
-        backoff_base = getattr(self.config, "proactive_share_backoff_base_seconds", 2) if self.config else 2
         max_chars = getattr(self.config, "proactive_share_max_chars", 200) if self.config else 200
-
         max_chars = max(10, max_chars)
+        max_tool_rounds = self._max_tool_rounds
+        max_parse_retries = 2
+        backoff_base = getattr(self.config, "proactive_share_backoff_base_seconds", 2) if self.config else 2
 
-        for attempt in range(1, max_retries + 2):  # 原始 + max_retries 次重试
+        for attempt in range(max_parse_retries + 1):
+            executor = CollectExecutor()
+
             try:
-                content, metadata = await self.llm_router.generate_with_forced_tool(
+                content, metadata = await self.llm_router.generate(
                     messages=[
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": user_prompt},
                     ],
                     tools=tools,
-                    tool_name="record_share_message",
+                    tool_executor=executor,
+                    max_tool_rounds=max_tool_rounds,
                     model_tier=ModelTier.AUXILIARY,
                     temperature=0.85,
-                    timeout=timeout_seconds,
+                    timeout=self._bg_timeout,
                 )
-            except ForcedToolError as e:
-                logger.warning(
-                    f"分享消息强制工具调用失败（第{attempt}次）: {e}"
-                )
-                if attempt < max_retries + 1:
-                    backoff = backoff_base ** attempt
-                    await asyncio.sleep(backoff)
-                continue
+            except Exception as e:
+                logger.error(f"分享消息生成失败: {e}")
+                return None
 
+            if not executor.collected:
+                logger.warning("分享消息: LLM 未调用 record_share_message 工具")
+                return None
+
+            raw_args = executor.collected[0]["arguments"]
             try:
-                args = json.loads(content)
+                args = json.loads(raw_args)
             except json.JSONDecodeError as je:
                 logger.warning(
-                    f"分享消息 JSON 解析失败（第{attempt}次）: {je}, "
-                    f"content={content[:100]!r}"
+                    f"分享消息 JSON 解析失败（第{attempt + 1}次）: {je}, "
+                    f"content={raw_args[:100]!r}"
                 )
-                if attempt < max_retries + 1:
-                    backoff = backoff_base ** attempt
+                if attempt < max_parse_retries:
+                    backoff = backoff_base ** (attempt + 1)
                     await asyncio.sleep(backoff)
-                continue
+                    continue
+                return None
 
             message = str(args.get("message", "")).strip().strip('"').strip("'")
             if not message:
-                logger.warning(f"分享消息生成结果为空（第{attempt}次）")
-                if attempt < max_retries + 1:
-                    backoff = backoff_base ** attempt
+                logger.warning(f"分享消息生成结果为空（第{attempt + 1}次）")
+                if attempt < max_parse_retries:
+                    backoff = backoff_base ** (attempt + 1)
                     await asyncio.sleep(backoff)
-                continue
+                    continue
+                return None
 
             if len(message) > max_chars:
                 original_len = len(message)

--- a/src/plugins/DicePP/module/persona/life/observation.py
+++ b/src/plugins/DicePP/module/persona/life/observation.py
@@ -10,6 +10,7 @@
   避免冷清群迟迟达不到阈值。
 - 阈值因此会在 `min_threshold`～`max_threshold` 之间浮动；爆发期可能接近上限，需调参时改构造参数。
 """
+import json
 import re
 from dataclasses import dataclass
 from typing import List, Dict, Optional, Set, Any
@@ -17,7 +18,7 @@ from datetime import datetime, timedelta
 from nonebot.log import logger
 from .event_agent import EventGenerationAgent
 from ..data.store import PersonaDataStore
-from ..utils.json_helpers import safe_json_loads
+
 from ..wall_clock import persona_wall_now, format_timestamp
 
 
@@ -319,6 +320,11 @@ class ObservationExtractor:
             if config
             else 90
         )
+        self._max_tool_rounds = (
+            getattr(config, "background_llm_max_tool_rounds", 1)
+            if config
+            else 1
+        )
         self._prune_observations_keep = prune_observations_keep
 
     async def extract_observations(
@@ -394,6 +400,7 @@ class ObservationExtractor:
             [{"what": ..., "why": ...}, ...]
         """
         from ..data.models import ModelTier
+        from ..llm.collect_executor import CollectExecutor
 
         # 构建提示
         system_prompt = """你是一个观察者。从以下群聊消息中提取1-3条有价值的观察。
@@ -403,41 +410,70 @@ class ObservationExtractor:
 2. 记录谁参与了、发生了什么、为什么值得记住
 3. 简洁具体，每条20-50字
 
-输出格式（JSON）:
-[
-  {"what": "发生了什么", "why": "为什么值得记住"},
-  ...
-]
-
-只输出JSON，不要其他内容。"""
+你必须通过调用 note_observation 工具来输出结果，每次调用记录一条观察。"""
 
         user_prompt = f"群聊消息:\n{messages_text}\n\n请提取观察:"
 
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "note_observation",
+                    "description": "记录一条从群聊中提取的观察",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "what": {
+                                "type": "string",
+                                "description": "发生了什么，20-50字",
+                            },
+                            "why": {
+                                "type": "string",
+                                "description": "为什么值得记住",
+                            },
+                        },
+                        "required": ["what", "why"],
+                    },
+                },
+            }
+        ]
+
         try:
-            # 使用 EventGenerationAgent 的 llm_router 进行提取
             if not self.event_agent or not self.event_agent.llm_router:
                 logger.warning("LLM 路由器未初始化，跳过观察提取")
                 return []
 
-            response = await self.event_agent.llm_router.generate(
+            max_tool_rounds = self._max_tool_rounds
+            executor = CollectExecutor()
+
+            content, metadata = await self.event_agent.llm_router.generate(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
+                tools=tools,
+                tool_executor=executor,
+                max_tool_rounds=max_tool_rounds,
                 model_tier=ModelTier.AUXILIARY,
                 temperature=0.7,
                 timeout=self._bg_timeout,
             )
 
-            # 解析 JSON 响应：自由文本可能含 markdown 围栏，走统一容错
-            observations = safe_json_loads(response, fallback=None, log_prefix="观察提取")
-            if isinstance(observations, list):
-                return observations
-            if isinstance(observations, dict):
-                return [observations]
-            if observations is not None:
-                logger.warning(f"LLM 返回了非列表/字典格式: {response[:100]}")
-            return []
+            observations = []
+            if not executor.collected:
+                logger.warning("观察提取: LLM 未调用 note_observation 工具")
+                return []
+            for entry in executor.collected:
+                try:
+                    args = json.loads(entry["arguments"])
+                    observations.append({
+                        "what": args.get("what", ""),
+                        "why": args.get("why", ""),
+                    })
+                except json.JSONDecodeError:
+                    logger.warning(f"观察提取 JSON 解析失败: {entry['arguments'][:100]!r}")
+                    continue
+            return observations
 
         except Exception as e:
             logger.error(f"LLM 调用失败: {e}")

--- a/src/plugins/DicePP/module/persona/llm/__init__.py
+++ b/src/plugins/DicePP/module/persona/llm/__init__.py
@@ -1,1 +1,2 @@
-from .client import ForcedToolError, LLMClient
+from .client import LLMClient
+from .collect_executor import CollectExecutor

--- a/src/plugins/DicePP/module/persona/llm/client.py
+++ b/src/plugins/DicePP/module/persona/llm/client.py
@@ -30,13 +30,6 @@ _RETRYABLE_KEYWORDS = (
 )
 
 
-class ForcedToolError(Exception):
-    """LLM 未按 tool_choice 要求调用指定工具"""
-
-    def __init__(self, message: str, raw_content: str = ""):
-        super().__init__(message)
-        self.raw_content = raw_content
-
 
 @dataclass
 class RoundResult:
@@ -92,218 +85,154 @@ class LLMClient:
         content = content.strip()
         return content
 
-    async def chat(
-        self,
-        messages: List[Dict[str, str]],
-        timeout: int = 30,
-        max_retries: int = 3,
-        temperature: Optional[float] = None,
-    ) -> tuple[str, dict]:
-        """
-        发送聊天请求
-        
-        Args:
-            messages: 消息列表，格式 [{"role": "user", "content": "..."}, ...]
-            timeout: 超时时间（秒）
-            max_retries: 最大重试次数
-            
-        Returns:
-            (回复文本, 元数据字典)
-            
-        Raises:
-            TimeoutError: 请求超时
-            Exception: API 调用失败
-        """
-        client = self._get_client()
-        
-        last_error = None
-        retry_delay = 2  # 初始重试延迟（秒）
-        
-        for attempt in range(max_retries + 1):
-            try:
-                start_time = time.monotonic()
-                
-                create_kwargs: Dict[str, Any] = {
-                    "model": self.model,
-                    "messages": messages,
-                }
-                if temperature is not None:
-                    create_kwargs["temperature"] = temperature
+    # ── L1 纠正消息 ──
+    _L1_CORRECTION_MESSAGE: Dict[str, str] = {
+        "role": "user",
+        "content": (
+            "[系统指令] 你必须调用工具来完成任务。"
+            "不要直接输出文本——只能通过调用工具来输出结果。"
+        ),
+    }
 
-                response = await asyncio.wait_for(
-                    client.chat.completions.create(**create_kwargs),
-                    timeout=timeout
-                )
-                
-                latency = time.monotonic() - start_time
-                
-                # 提取回复文本
-                content = response.choices[0].message.content or ""
-
-                # 过滤 <think>...</think> 思考过程（MiniMax-M2.7 等模型）
-                content = self._filter_think_tags(content)
-
-                # 构建元数据
-                metadata = {
-                    "latency": latency,
-                    "model": self.model,
-                    "tokens_input": response.usage.prompt_tokens if response.usage else 0,
-                    "tokens_output": response.usage.completion_tokens if response.usage else 0,
-                }
-                
-                return content, metadata
-
-            except asyncio.TimeoutError as e:
-                last_error = e
-                if attempt < max_retries:
-                    await asyncio.sleep(retry_delay)
-                    retry_delay *= 2  # 指数退避
-                continue
-                
-            except Exception as e:
-                last_error = e
-                error_msg = str(e).lower()
-                
-                # 检查是否需要重试的错误
-                retryable = any(keyword in error_msg for keyword in _RETRYABLE_KEYWORDS)
-                
-                if retryable and attempt < max_retries:
-                    await asyncio.sleep(retry_delay)
-                    retry_delay *= 2
-                    continue
-                else:
-                    raise
-        
-        # 所有重试都失败了
-        raise last_error or Exception("LLM request failed after retries")
-
-    async def generate_with_forced_tool(
+    async def generate(
         self,
         messages: List[Dict],
-        tools: List[Dict],
-        tool_name: str,
-        timeout: int = 30,
-        temperature: Optional[float] = None,
-        max_retries: int = 3,
-    ) -> tuple[str, dict]:
-        """
-        强制调用指定工具，只发一轮请求，直接返回工具参数 JSON 字符串。
-        """
-        client = self._get_client()
-        last_error = None
-        retry_delay = 2
-
-        for attempt in range(max_retries + 1):
-            try:
-                start_time = time.monotonic()
-                create_kwargs: Dict[str, Any] = {
-                    "model": self.model,
-                    "messages": messages,
-                    "tools": tools,
-                    "tool_choice": {"type": "function", "function": {"name": tool_name}},
-                }
-                if temperature is not None:
-                    create_kwargs["temperature"] = temperature
-
-                response = await asyncio.wait_for(
-                    client.chat.completions.create(**create_kwargs),
-                    timeout=timeout
-                )
-                latency = time.monotonic() - start_time
-
-                message = response.choices[0].message
-                if message.tool_calls:
-                    tc = message.tool_calls[0]
-                    args = tc.function.arguments
-                    metadata = {
-                        "latency": latency,
-                        "model": self.model,
-                        "tool_name": tc.function.name,
-                        "tool_names": [tc.function.name],
-                        "tokens_input": response.usage.prompt_tokens if response.usage else 0,
-                        "tokens_output": response.usage.completion_tokens if response.usage else 0,
-                    }
-                    return args, metadata
-
-                # LLM 未按 tool_choice 调用指定工具。此类错误在下方 except 块中
-                # 会被识别为 ForcedToolError 并触发重试（max_retries 次）。
-                raw_content = getattr(message, "content", "") or ""
-                content_preview = raw_content[:200]
-                raise ForcedToolError(
-                    f"模型未按 tool_choice 调用强制工具 '{tool_name}'，"
-                    f"返回内容: {content_preview!r}",
-                    raw_content=raw_content,
-                )
-
-            except asyncio.TimeoutError as e:
-                last_error = e
-                if attempt < max_retries:
-                    await asyncio.sleep(retry_delay)
-                    retry_delay *= 2
-                continue
-            except Exception as e:
-                last_error = e
-                error_msg = str(e).lower()
-                retryable = (
-                    any(keyword in error_msg for keyword in _RETRYABLE_KEYWORDS)
-                    or isinstance(e, ForcedToolError)
-                )
-                if retryable and attempt < max_retries:
-                    await asyncio.sleep(retry_delay)
-                    retry_delay *= 2
-                    continue
-                else:
-                    raise
-
-        raise last_error or Exception("LLM forced tool request failed after retries")
-
-    # ── Phase 3: 工具调用
-    async def chat_with_tools(
-        self,
-        messages: List[Dict],
-        tools: List[Dict],
+        tools: Optional[List[Dict]] = None,
+        tool_choice: Optional[str] = None,
         tool_executor: Optional[ToolExecutor] = None,
         max_tool_rounds: int = 5,
         timeout: int = 60,
         temperature: Optional[float] = None,
+        max_retries: int = 3,
         on_round_complete: Optional[
             Callable[[int, RoundResult, List[Dict]], Awaitable[Optional[Dict]]]
         ] = None,
         max_round_callbacks: int = 3,
     ) -> tuple[str, dict]:
         """
-        支持多轮工具调用的对话（完整循环实现）
-
-        流程:
-        1. 调用 LLM，传入 tools
-        2. 如果 LLM 返回 tool_calls，调用 tool_executor 执行工具
-        3. 将工具结果追加到 messages
-        4. 重复直到 LLM 不调用工具或达到最大轮次
+        统一 LLM 生成入口，参数化控制工具调用与多轮循环。
 
         Args:
             messages: 消息列表
-            tools: 工具定义列表（OpenAI function calling 格式）
-            tool_executor: 工具执行回调函数，接收 tool_calls 列表，返回 tool_results 列表
-                格式: async def executor(tool_calls: List[Dict]) -> List[Dict]
-                其中 tool_calls: [{"id": str, "name": str, "arguments": str}]
-                返回: [{"tool_call_id": str, "content": str}]
-            max_tool_rounds: 最多多少轮工具调用
-            timeout: 单次调用超时时间
+            tools: 工具定义列表（None/空 → 纯文本路径）
+            tool_choice: None | "auto" | "required"。tools 非空且未设置时默认 "required"
+            tool_executor: 工具执行回调
+            max_tool_rounds: 最多工具调用轮次
+            timeout: 单次调用超时（秒）
             temperature: 采样温度
-            on_round_complete: 每轮 LLM 响应后的回调；返回 dict 则注入消息并继续，
-                返回 None 则走原流程（处理 tool_calls 或返回 content）。
-            max_round_callbacks: 回调注入最大次数。
+            max_retries: 纯文本路径最大重试次数
+            on_round_complete: L2 领域回调，每轮 LLM 响应后调用
+            max_round_callbacks: L1+L2 回调注入最大次数
 
         Returns:
-            (最终回复文本, 元数据字典)。metadata 含 round_records 列表，
-            每轮记录 think/tool_calls/tool_results/callback。
+            (content, metadata)
         """
         client = self._get_client()
-        current_messages = list(messages)  # 复制一份，避免修改原列表
+
+        # ── 纯文本路径 ──
+        if not tools:
+            return await self._generate_text(
+                client, messages, timeout, temperature, max_retries
+            )
+
+        # ── 工具路径 ──
+        if tool_choice is None:
+            tool_choice = "required"
+
+        return await self._generate_with_tools(
+            client, messages, tools, tool_choice, tool_executor,
+            max_tool_rounds, timeout, temperature,
+            on_round_complete, max_round_callbacks,
+        )
+
+    async def _generate_text(
+        self,
+        client: Any,
+        messages: List[Dict],
+        timeout: int,
+        temperature: Optional[float],
+        max_retries: int,
+    ) -> tuple[str, dict]:
+        """纯文本路径：单次请求 + 退避重试"""
+        last_error = None
+        retry_delay = 2
+
+        for attempt in range(max_retries + 1):
+            try:
+                start_time = time.monotonic()
+
+                create_kwargs: Dict[str, Any] = {
+                    "model": self.model,
+                    "messages": messages,
+                }
+                if temperature is not None:
+                    create_kwargs["temperature"] = temperature
+
+                response = await asyncio.wait_for(
+                    client.chat.completions.create(**create_kwargs),
+                    timeout=timeout,
+                )
+
+                latency = time.monotonic() - start_time
+                content = self._filter_think_tags(
+                    response.choices[0].message.content or ""
+                )
+
+                metadata = {
+                    "latency": latency,
+                    "model": self.model,
+                    "tokens_input": response.usage.prompt_tokens if response.usage else 0,
+                    "tokens_output": response.usage.completion_tokens if response.usage else 0,
+                    "tool_rounds": 0,
+                    "tool_names": [],
+                    "cached_tokens": self._get_cached_tokens(response),
+                    "round_records": [],
+                }
+
+                return content, metadata
+
+            except asyncio.TimeoutError as e:
+                last_error = e
+                if attempt < max_retries:
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
+                continue
+
+            except Exception as e:
+                last_error = e
+                error_msg = str(e).lower()
+                retryable = any(
+                    keyword in error_msg for keyword in _RETRYABLE_KEYWORDS
+                )
+                if retryable and attempt < max_retries:
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
+                    continue
+                raise
+
+        raise last_error or Exception("LLM request failed after retries")
+
+    async def _generate_with_tools(
+        self,
+        client: Any,
+        messages: List[Dict],
+        tools: List[Dict],
+        tool_choice: str,
+        tool_executor: Optional[ToolExecutor],
+        max_tool_rounds: int,
+        timeout: int,
+        temperature: Optional[float],
+        on_round_complete: Optional[
+            Callable[[int, RoundResult, List[Dict]], Awaitable[Optional[Dict]]]
+        ],
+        max_round_callbacks: int,
+    ) -> tuple[str, dict]:
+        """工具路径：多轮循环，L1/L2 纠正回调"""
+        current_messages = list(messages)
         round_records: List[Dict[str, Any]] = []
         total_tool_calls = 0
         all_tool_names: List[str] = []
-        retry_count = 0  # 独立重试计数器，避免轮次过多时退避时间过长
+        retry_count = 0
         callback_count = 0
         tool_round_num = 0
         total_rounds = 0
@@ -315,25 +244,24 @@ class LLMClient:
                     "model": self.model,
                     "messages": current_messages,
                     "tools": tools,
-                    "tool_choice": "auto",
+                    "tool_choice": tool_choice,
                 }
                 if temperature is not None:
                     create_kwargs["temperature"] = temperature
 
                 response = await asyncio.wait_for(
                     client.chat.completions.create(**create_kwargs),
-                    timeout=timeout
+                    timeout=timeout,
                 )
 
                 total_rounds += 1
                 message = response.choices[0].message
 
-                # 检查单轮工具调用数量上限
+                # 截断超限的工具调用
                 if message.tool_calls and len(message.tool_calls) > self.MAX_TOOLS_PER_ROUND:
                     logger.warning(
                         f"工具调用数量超限: {len(message.tool_calls)} > {self.MAX_TOOLS_PER_ROUND}"
                     )
-                    # 截断到上限
                     message.tool_calls = message.tool_calls[:self.MAX_TOOLS_PER_ROUND]
 
                 result = RoundResult(
@@ -360,20 +288,33 @@ class LLMClient:
                 }
                 round_records.append(round_record)
 
-                # ── Round callback (injection) ──
-                if on_round_complete is not None and callback_count < max_round_callbacks:
+                # ── L1: 内置纠正注入（仅在未达工具轮次上限时）──
+                if (
+                    tool_round_num < max_tool_rounds
+                    and not result.tool_calls
+                    and tool_choice == "required"
+                    and callback_count < max_round_callbacks
+                ):
+                    current_messages.append(dict(self._L1_CORRECTION_MESSAGE))
+                    callback_count += 1
+                    round_record["callback"] = dict(self._L1_CORRECTION_MESSAGE)
+                    continue
+
+                # ── L2: 领域回调（仅在未达工具轮次上限时）──
+                if (
+                    tool_round_num < max_tool_rounds
+                    and on_round_complete is not None
+                    and callback_count < max_round_callbacks
+                ):
                     injected = await on_round_complete(tool_round_num, result, current_messages)
                     if injected is not None:
                         current_messages.append(injected)
                         callback_count += 1
                         round_record["callback"] = injected
-                        continue  # 跳过原流程，直接进入下一轮 LLM
+                        continue
 
-                # 如果没有工具调用，直接返回内容
+                # 无工具调用 → 返回内容
                 if not message.tool_calls:
-                    content = result.content
-
-                    # 收集元数据
                     metadata = {
                         "model": self.model,
                         "tool_rounds": tool_round_num,
@@ -381,18 +322,15 @@ class LLMClient:
                         "tool_names": all_tool_names,
                         "tokens_input": response.usage.prompt_tokens if response.usage else 0,
                         "tokens_output": response.usage.completion_tokens if response.usage else 0,
-                        # Phase 3: 缓存数据收集
                         "cached_tokens": self._get_cached_tokens(response),
                         "callback_count": callback_count,
                         "round_records": round_records,
                     }
+                    return result.content, metadata
 
-                    return content, metadata
-
-                # 有工具调用，需要执行工具并继续对话
+                # ── 执行工具调用 ──
                 total_tool_calls += len(message.tool_calls)
 
-                # 将 assistant 的消息（含 tool_calls）加入上下文
                 current_messages.append({
                     "role": "assistant",
                     "content": message.content or "",
@@ -403,33 +341,30 @@ class LLMClient:
                             "function": {
                                 "name": tc.function.name,
                                 "arguments": tc.function.arguments,
-                            }
+                            },
                         }
                         for tc in message.tool_calls
-                    ]
+                    ],
                 })
 
-                # 如果没有提供 tool_executor，将错误作为工具结果返回给 LLM
                 if tool_executor is None:
                     logger.error(
                         f"工具调用失败: tool_executor is None, "
                         f"tool_names={[tc.function.name for tc in message.tool_calls]}"
                     )
-                    # 将错误作为工具结果返回给 LLM，让它生成友好回复
                     for tc in message.tool_calls:
                         current_messages.append({
                             "role": "tool",
                             "tool_call_id": tc.id,
-                            "content": "[System note: Tool execution is temporarily unavailable, please respond without using this information]"
+                            "content": "[System note: Tool execution is temporarily unavailable, please respond without using this information]",
                         })
                         round_record["tool_results"].append({
                             "tool_call_id": tc.id,
                             "content": "[System note: Tool execution is temporarily unavailable]",
                         })
                     tool_round_num += 1
-                    continue  # 继续循环，让 LLM 基于错误信息生成合适的回复
+                    continue
 
-                # 执行工具调用
                 tool_calls = [
                     {
                         "id": tc.id,
@@ -443,56 +378,73 @@ class LLMClient:
                 try:
                     tool_results = await tool_executor(tool_calls)
                 except Exception as e:
-                    # 工具执行失败，返回错误信息
                     return f"（工具执行失败: {e}）", {
                         "model": self.model,
                         "tool_rounds": tool_round_num,
+                        "total_tool_calls": total_tool_calls,
+                        "callback_count": callback_count,
+                        "tokens_input": 0,
+                        "tokens_output": 0,
+                        "cached_tokens": 0,
                         "error": str(e),
+                        "tool_names": all_tool_names,
                         "round_records": round_records,
                     }
 
-                # 将工具结果加入上下文
-                for result in tool_results:
+                for result_item in tool_results:
                     current_messages.append({
                         "role": "tool",
-                        "tool_call_id": result["tool_call_id"],
-                        "content": result["content"],
+                        "tool_call_id": result_item["tool_call_id"],
+                        "content": result_item["content"],
                     })
                     round_record["tool_results"].append({
-                        "tool_call_id": result["tool_call_id"],
-                        "content": result["content"],
+                        "tool_call_id": result_item["tool_call_id"],
+                        "content": result_item["content"],
                     })
 
                 tool_round_num += 1
-                # 继续下一轮循环，让 LLM 基于工具结果生成回复
+                if tool_round_num >= max_tool_rounds:
+                    return result.content or "", {
+                        "model": self.model,
+                        "tool_rounds": tool_round_num,
+                        "total_tool_calls": total_tool_calls,
+                        "tool_names": all_tool_names,
+                        "callback_count": callback_count,
+                        "tokens_input": response.usage.prompt_tokens if response.usage else 0,
+                        "tokens_output": response.usage.completion_tokens if response.usage else 0,
+                        "cached_tokens": self._get_cached_tokens(response),
+                        "round_records": round_records,
+                    }
                 continue
 
             except Exception as e:
                 error_msg = str(e).lower()
-                # 检查是否需要重试的错误（包含 timeout）
                 retryable = (
                     any(keyword in error_msg for keyword in _RETRYABLE_KEYWORDS)
                     or isinstance(e, asyncio.TimeoutError)
                 )
 
-                if not retryable or retry_count >= 3:  # 最多重试 3 次
+                if not retryable or retry_count >= 3:
                     raise
 
-                # timeout 与其他可重试异常共享总轮次预算
-                total_rounds += 1
                 retry_count += 1
                 retry_delay = 2 * (2 ** retry_count)
-                logger.warning(f"工具调用第 {tool_round_num + 1} 轮失败，{retry_delay}秒后重试: {e}")
+                logger.warning(
+                    f"工具调用第 {tool_round_num + 1} 轮失败，{retry_delay}秒后重试: {e}"
+                )
                 await asyncio.sleep(retry_delay)
                 continue
 
-        # 达到最大轮次仍未完成
-        return "（工具调用次数超过限制）", {
+        # 达到最大轮次
+        return "", {
             "model": self.model,
             "tool_rounds": tool_round_num,
             "total_tool_calls": total_tool_calls,
             "tool_names": all_tool_names,
             "callback_count": callback_count,
+            "tokens_input": 0,
+            "tokens_output": 0,
+            "cached_tokens": 0,
             "round_records": round_records,
         }
 

--- a/src/plugins/DicePP/module/persona/llm/collect_executor.py
+++ b/src/plugins/DicePP/module/persona/llm/collect_executor.py
@@ -1,0 +1,27 @@
+"""Collect Executor — 收集工具调用参数，不执行副作用。
+
+用于分享/事件/反应/日记/评分/观察等"只收集不执行"的场景。
+"""
+from typing import List, Dict
+
+from .client import ToolCallInfo
+
+
+class CollectExecutor:
+    """收集所有工具调用参数，不执行副作用。"""
+
+    def __init__(self):
+        self.collected: List[Dict] = []
+
+    async def __call__(self, tool_calls: List[ToolCallInfo]) -> List[Dict]:
+        results = []
+        for tc in tool_calls:
+            self.collected.append({
+                "name": tc["name"],
+                "arguments": tc["arguments"],
+            })
+            results.append({
+                "tool_call_id": tc["id"],
+                "content": '{"status": "ok"}',
+            })
+        return results

--- a/src/plugins/DicePP/module/persona/llm/router.py
+++ b/src/plugins/DicePP/module/persona/llm/router.py
@@ -355,110 +355,16 @@ class LLMRouter:
 
     async def generate(
         self,
-        messages: List[Dict[str, str]],
-        model_tier: ModelTier = ModelTier.PRIMARY,
-        timeout: Optional[int] = None,
-        temperature: Optional[float] = None,
-        user_id: Optional[str] = None,
-        group_id: Optional[str] = None,
-    ) -> str:
-        """
-        生成回复
-
-        Args:
-            messages: 消息列表
-            model_tier: 模型层级（primary/auxiliary）
-            timeout: 超时时间（覆盖默认）
-            temperature: 采样温度；None 时使用服务端默认
-            user_id: 用户ID（用于配额检查）
-            group_id: 群ID（用于配额检查）
-
-        Returns:
-            回复文本
-
-        Raises:
-            QuotaExceeded: 当配额超限时
-        """
-        tier_name, client, user_config, actual_timeout = await self._prepare_request(
-            model_tier, user_id, group_id, timeout
-        )
-
-        session_id = f"{user_id or ''}:{group_id or ''}:{uuid.uuid4().hex[:16]}"
-
-        async with self.semaphore:
-            self.stats[tier_name]["requests"] += 1
-            content, _ = await self._execute_and_trace(
-                client,
-                tier_name,
-                client.chat(
-                    messages=messages,
-                    timeout=actual_timeout,
-                    temperature=temperature,
-                ),
-                session_id=session_id,
-                user_id=user_id,
-                group_id=group_id,
-                messages=messages,
-                temperature=temperature,
-                model_tier=model_tier,
-                is_tools=False,
-            )
-            return content
-
-    async def generate_with_forced_tool(
-        self,
         messages: List[Dict],
-        tools: List[Dict],
-        tool_name: str,
-        model_tier: ModelTier = ModelTier.AUXILIARY,
-        timeout: Optional[int] = None,
-        temperature: Optional[float] = None,
-        user_id: Optional[str] = None,
-        group_id: Optional[str] = None,
-    ) -> tuple[str, dict]:
-        """
-        强制调用指定工具，只发一轮请求。
-        """
-        tier_name, client, user_config, actual_timeout = await self._prepare_request(
-            model_tier, user_id, group_id, timeout
-        )
-
-        session_id = f"{user_id or ''}:{group_id or ''}:{uuid.uuid4().hex[:16]}"
-
-        async with self.semaphore:
-            self.stats[tier_name]["requests"] += 1
-            content, metadata = await self._execute_and_trace(
-                client,
-                tier_name,
-                client.generate_with_forced_tool(
-                    messages=messages,
-                    tools=tools,
-                    tool_name=tool_name,
-                    timeout=actual_timeout,
-                    temperature=temperature,
-                ),
-                session_id=session_id,
-                user_id=user_id,
-                group_id=group_id,
-                messages=messages,
-                temperature=temperature,
-                model_tier=model_tier,
-                is_tools=True,
-            )
-            return content, metadata
-
-    # ── Phase 3: 工具调用
-    async def generate_with_tools(
-        self,
-        messages: List[Dict],
-        tools: List[Dict],
+        tools: Optional[List[Dict]] = None,
+        tool_choice: Optional[str] = None,
         tool_executor: Optional[
             Callable[[List[Dict]], Awaitable[List[Dict]]]
         ] = None,
+        max_tool_rounds: int = 5,
         model_tier: ModelTier = ModelTier.PRIMARY,
         timeout: Optional[int] = None,
         temperature: Optional[float] = None,
-        max_tool_rounds: int = 5,
         user_id: Optional[str] = None,
         group_id: Optional[str] = None,
         on_round_complete: Optional[
@@ -467,21 +373,24 @@ class LLMRouter:
         max_round_callbacks: int = 3,
     ) -> tuple[str, dict]:
         """
-        生成回复，支持工具调用（完整循环）
+        统一 LLM 生成入口，参数化控制工具调用与多轮循环。
 
         Args:
             messages: 消息列表
-            tools: 工具定义列表
-            tool_executor: 工具执行回调函数，接收 tool_calls 列表，返回 tool_results 列表
+            tools: 工具定义列表（None/空 → 纯文本路径）
+            tool_choice: None | "auto" | "required"
+            tool_executor: 工具执行回调
+            max_tool_rounds: 最多工具调用轮次
             model_tier: 模型层级
-            timeout: 超时时间
+            timeout: 超时时间（覆盖默认）
             temperature: 采样温度
-            max_tool_rounds: 最多多少轮工具调用
             user_id: 用户ID（用于配额检查）
             group_id: 群ID（用于配额检查）
+            on_round_complete: L2 领域回调
+            max_round_callbacks: L1+L2 回调注入最大次数
 
         Returns:
-            (回复文本, 元数据字典)
+            (content, metadata)
 
         Raises:
             QuotaExceeded: 当配额超限时
@@ -497,9 +406,10 @@ class LLMRouter:
             content, metadata = await self._execute_and_trace(
                 client,
                 tier_name,
-                client.chat_with_tools(
+                client.generate(
                     messages=messages,
                     tools=tools,
+                    tool_choice=tool_choice,
                     tool_executor=tool_executor,
                     max_tool_rounds=max_tool_rounds,
                     timeout=actual_timeout,
@@ -513,7 +423,7 @@ class LLMRouter:
                 messages=messages,
                 temperature=temperature,
                 model_tier=model_tier,
-                is_tools=True,
+                is_tools=bool(tools),
             )
             return content, metadata
 

--- a/src/plugins/DicePP/module/persona/tools/registry.py
+++ b/src/plugins/DicePP/module/persona/tools/registry.py
@@ -75,7 +75,7 @@ class ToolRegistry:
 
     def make_executor_for(self, *domains: str, ctx: ToolContext):
         """
-        返回闭包，作为 LLMRouter.generate_with_tools 的 tool_executor 回调。
+        返回闭包，作为 LLMRouter.generate() 的 tool_executor 回调。
 
         所有 executor 签名统一: async (args: dict, ctx: ToolContext) -> str
         ctx 在运行时注入，executor 不持有任何外部 import。

--- a/src/plugins/DicePP/module/persona/utils/json_helpers.py
+++ b/src/plugins/DicePP/module/persona/utils/json_helpers.py
@@ -14,8 +14,8 @@ r"""LLM 响应 JSON 解析的统一容错实现
 ========
 - 仅适用于 **自由文本响应**（如 chat 完成、辅助模型直出），LLM 可能添加
   ``\`\`\`json`` 围栏或前后多余空白。
-- **不适用于 tool-call 结构化输出**（``generate_with_forced_tool`` /
-  ``response_format=json``），那些路径返回的 ``arguments`` 已是合法 JSON 字符串，
+- **不适用于 tool-call 结构化输出**（``tool_choice="required"`` 多轮路径），
+  那些路径返回的 ``arguments`` 已是合法 JSON 字符串，
   应直接用 ``json.loads(content)`` 包 ``try/except json.JSONDecodeError``，
   无需 markdown 围栏处理。
 """

--- a/tests/unit/persona/test_chat_session.py
+++ b/tests/unit/persona/test_chat_session.py
@@ -41,8 +41,7 @@ def _make_session(
 
     router = MagicMock()
     router.increment_usage = AsyncMock()
-    router.generate = AsyncMock(return_value="reply")
-    router.generate_with_tools = AsyncMock(return_value=("reply", {}))
+    router.generate = AsyncMock(return_value=("reply", {}))
 
     character = MagicMock()
     character.name = "Test"
@@ -56,7 +55,6 @@ def _make_session(
     )
 
     config = ChatConfig(
-        tools_enabled=False,
         relationship_refuse_enabled=refuse_enabled,
         relationship_refuse_prob_base=0.3,
         relationship_refuse_prob_max=0.9,
@@ -119,7 +117,6 @@ async def test_first_message_uses_first_mes_without_llm():
     assert result == "你好，我是测试角色"
     # 不应调用 LLM
     assert session.router.generate.await_count == 0
-    assert session.router.generate_with_tools.await_count == 0
     # 应该已写入用户消息和 first_mes 两条
     assert session.store.add_message.await_count >= 2
 

--- a/tests/unit/persona/test_chat_session_charging.py
+++ b/tests/unit/persona/test_chat_session_charging.py
@@ -34,8 +34,7 @@ def _make_session(coordinator: LLMCallCoordinator) -> ChatSession:
 
     router = MagicMock()
     router.increment_usage = AsyncMock()
-    router.generate = AsyncMock(return_value="reply")
-    router.generate_with_tools = AsyncMock(return_value=("reply", {}))
+    router.generate = AsyncMock(return_value=("reply", {}))
 
     character = MagicMock()
     character.name = "Test"
@@ -46,7 +45,6 @@ def _make_session(coordinator: LLMCallCoordinator) -> ChatSession:
     character.get_warmth_labels = MagicMock(return_value=["a", "b", "c", "d", "e", "f"])
 
     config = ChatConfig(
-        tools_enabled=False,
         relationship_refuse_enabled=False,
         scoring_interval=999,
     )

--- a/tests/unit/persona/test_chat_session_segmented.py
+++ b/tests/unit/persona/test_chat_session_segmented.py
@@ -40,7 +40,7 @@ def mock_store():
 def mock_router():
     router = MagicMock(spec=LLMRouter)
     router.generate = AsyncMock(return_value="hello")
-    router.generate_with_tools = AsyncMock(return_value=("hello", {"tool_rounds": 0, "callback_count": 0}))
+    router.generate = AsyncMock(return_value=("hello", {"tool_rounds": 0, "callback_count": 0}))
     router.increment_usage = AsyncMock()
     return router
 
@@ -79,7 +79,6 @@ def context_builder(character):
 @pytest.fixture
 def config():
     return ChatConfig(
-        tools_enabled=True,
         tools_max_rounds=5,
         segment_target_chars=30,
         segment_max_chars=80,
@@ -135,7 +134,7 @@ class TestFlagLifecycle:
 
     @pytest.mark.asyncio
     async def test_exception_does_not_produce_sentinel(self, session, mock_router):
-        mock_router.generate_with_tools = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_router.generate = AsyncMock(side_effect=RuntimeError("boom"))
         with pytest.raises(RuntimeError):
             await session._chat_with_tools("u1", "", [{"role": "user", "content": "hi"}])
 
@@ -143,7 +142,7 @@ class TestFlagLifecycle:
 class TestReturnSemantics:
     @pytest.mark.asyncio
     async def test_chat_returns_falsy_sentinel_for_segmented(self, session):
-        # tools_enabled=True with segment_dispatcher -> falsy _SegmentedSentinel
+        # segment_dispatcher enabled → falsy _SegmentedSentinel
         result = await session.chat("u1", "", "hello")
         assert result is not None
         assert not result
@@ -151,16 +150,17 @@ class TestReturnSemantics:
         assert session.router.increment_usage.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_chat_returns_str_for_tools_disabled(self, session):
-        session.config.tools_enabled = False
+    async def test_chat_returns_falsy_for_segmented_mode(self, session):
+        """分段模式下 chat 返回 falsy sentinel"""
         result = await session.chat("u1", "", "hello")
-        assert result == "hello"
+        assert result is not None
+        assert not result
 
 
 class TestFallback:
     @pytest.mark.asyncio
     async def test_fallback_when_callbacks_exhausted(self, session, mock_router):
-        mock_router.generate_with_tools = AsyncMock(return_value=("fallback content", {
+        mock_router.generate = AsyncMock(return_value=("fallback content", {
             "tool_rounds": 0,
             "callback_count": 3,
         }))
@@ -171,7 +171,7 @@ class TestFallback:
     @pytest.mark.asyncio
     async def test_fallback_empty_content_logged(self, session, mock_router):
         from unittest.mock import patch
-        mock_router.generate_with_tools = AsyncMock(return_value=("", {
+        mock_router.generate = AsyncMock(return_value=("", {
             "tool_rounds": 0,
             "callback_count": 3,
         }))

--- a/tests/unit/persona/test_chat_with_tools.py
+++ b/tests/unit/persona/test_chat_with_tools.py
@@ -1,24 +1,12 @@
 """
-Phase 3: 工具调用集成测试
-
-测试 _chat_with_tools 完整流程
+测试 LLMClient.generate() 统一入口
 """
-
 import pytest
 import asyncio
 from typing import List, Dict, Any
 from unittest.mock import Mock, AsyncMock
 
-from plugins.DicePP.module.persona.llm.client import LLMClient, ForcedToolError, RoundResult
-from plugins.DicePP.module.persona.llm.router import LLMRouter
-
-
-class MockLLMResponse:
-    """模拟 LLM 响应"""
-
-    def __init__(self, content: str = None, tool_calls: List[Dict] = None):
-        self.content = content
-        self.tool_calls = tool_calls or []
+from plugins.DicePP.module.persona.llm.client import LLMClient, RoundResult
 
 
 class MockToolCall:
@@ -31,20 +19,18 @@ class MockToolCall:
         self.function.arguments = arguments
 
 
-class TestChatWithTools:
-    """测试 chat_with_tools 完整流程"""
+class TestGenerate:
+    """测试 generate() 统一入口"""
 
     @pytest.mark.asyncio
-    async def test_no_tool_calls(self):
-        """测试无需工具调用的普通对话"""
+    async def test_pure_text_no_tools(self):
+        """纯文本路径（tools=None）"""
         client = LLMClient(
             api_key="test_key",
             base_url="https://api.test.com/v1",
             model="gpt-4o"
         )
 
-        # Mock _get_client
-        mock_openai_client = Mock()
         mock_response = Mock()
         mock_response.choices = [Mock()]
         mock_response.choices[0].message = Mock()
@@ -55,6 +41,42 @@ class TestChatWithTools:
         mock_response.usage.completion_tokens = 20
         mock_response.usage.prompt_tokens_details = None
 
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        client._client = mock_openai_client
+
+        content, metadata = await client.generate(
+            messages=[{"role": "user", "content": "你好"}],
+        )
+
+        assert content == "你好！很高兴见到你。"
+        assert metadata["tool_rounds"] == 0
+        assert metadata["tool_names"] == []
+        assert metadata["round_records"] == []
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+        assert "tools" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_tool_calls_with_tools(self):
+        """工具路径 — LLM 直接返回内容（无 tool_calls）"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = "你好！很高兴见到你。"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = Mock()
+        mock_response.usage.prompt_tokens = 100
+        mock_response.usage.completion_tokens = 20
+        mock_response.usage.prompt_tokens_details = None
+
+        mock_openai_client = Mock()
         mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
         client._client = mock_openai_client
 
@@ -68,43 +90,42 @@ class TestChatWithTools:
             }
         }]
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=messages,
             tools=tools,
-            tool_executor=None,  # 无需工具调用
+            tool_executor=None,
             max_tool_rounds=5,
-            timeout=60
+            timeout=60,
         )
 
+        # tool_choice="required" + no tool_calls → L1 injects 3 corrections, then returns
         assert content == "你好！很高兴见到你。"
         assert metadata["tool_rounds"] == 0
-        assert metadata["total_tool_calls"] == 0
+        assert metadata["callback_count"] == 3
 
         rr = metadata["round_records"]
-        assert len(rr) == 1
-        assert rr[0]["round"] == 0
-        assert rr[0]["think"] is None
-        assert rr[0]["tool_calls"] == []
-        assert rr[0]["tool_results"] == []
-        assert rr[0]["callback"] is None
+        assert len(rr) == 4  # 3 L1 corrections + 1 final
+        for i in range(3):
+            assert rr[i]["round"] == 0
+            assert rr[i]["callback"] is not None
+            assert "[系统指令]" in rr[i]["callback"]["content"]
+        assert rr[3]["callback"] is None
 
     @pytest.mark.asyncio
     async def test_single_tool_call(self):
-        """测试单次工具调用"""
+        """单次工具调用 + 最终回复"""
         client = LLMClient(
             api_key="test_key",
             base_url="https://api.test.com/v1",
             model="gpt-4o"
         )
 
-        # Mock tool executor
         async def mock_executor(tool_calls: List[Dict]) -> List[Dict]:
             return [{
                 "tool_call_id": tc["id"],
                 "content": f"工具 {tc['name']} 执行结果"
             } for tc in tool_calls]
 
-        # 第一轮：返回 tool_calls
         mock_response1 = Mock()
         mock_response1.choices = [Mock()]
         mock_response1.choices[0].message = Mock()
@@ -117,7 +138,6 @@ class TestChatWithTools:
         mock_response1.usage.completion_tokens = 30
         mock_response1.usage.prompt_tokens_details = None
 
-        # 第二轮：返回最终结果
         mock_response2 = Mock()
         mock_response2.choices = [Mock()]
         mock_response2.choices[0].message = Mock()
@@ -147,12 +167,13 @@ class TestChatWithTools:
             }
         }]
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=messages,
             tools=tools,
             tool_executor=mock_executor,
-            max_tool_rounds=5,
-            timeout=60
+            tool_choice="auto",
+            max_tool_rounds=2,
+            timeout=60,
         )
 
         assert content == "我记得你喜欢猫！"
@@ -160,29 +181,24 @@ class TestChatWithTools:
         assert metadata["total_tool_calls"] == 1
         assert "search_memory" in metadata["tool_names"]
 
-        # round_records: 2 entries — tool call round + final round
         rr = metadata["round_records"]
         assert len(rr) == 2
         assert rr[0]["round"] == 0
-        assert rr[0]["think"] is None
-        assert rr[0]["callback"] is None
         assert rr[0]["tool_calls"] == [{"id": "tc_1", "name": "search_memory", "arguments": '{"query": "猫"}'}]
         assert rr[0]["tool_results"] == [{"tool_call_id": "tc_1", "content": "工具 search_memory 执行结果"}]
-        assert rr[1]["round"] == 1  # tool_round_num 在上轮递增
-        assert rr[1]["think"] is None
+        assert rr[1]["round"] == 1
         assert rr[1]["tool_calls"] == []
         assert rr[1]["tool_results"] == []
 
     @pytest.mark.asyncio
     async def test_tool_executor_none_graceful_fallback(self):
-        """测试 tool_executor 为 None 时优雅降级，将错误返回给 LLM 处理"""
+        """tool_executor 为 None 时优雅降级"""
         client = LLMClient(
             api_key="test_key",
             base_url="https://api.test.com/v1",
             model="gpt-4o"
         )
 
-        # 第一轮：返回 tool_calls
         mock_response1 = Mock()
         mock_response1.choices = [Mock()]
         mock_response1.choices[0].message = Mock()
@@ -192,7 +208,6 @@ class TestChatWithTools:
         ]
         mock_response1.usage = None
 
-        # 第二轮：LLM 生成最终回复（基于错误信息）
         mock_response2 = Mock()
         mock_response2.choices = [Mock()]
         mock_response2.choices[0].message = Mock()
@@ -209,32 +224,28 @@ class TestChatWithTools:
         messages = [{"role": "user", "content": "test"}]
         tools = [{"type": "function", "function": {"name": "search_memory"}}]
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=messages,
             tools=tools,
-            tool_executor=None,  # 不提供 tool_executor
-            max_tool_rounds=5,
-            timeout=60
+            tool_executor=None,
+            tool_choice="auto",
+            max_tool_rounds=2,
+            timeout=60,
         )
 
-        # 验证：LLM 被调用两次（第一次返回 tool_calls，第二次生成回复）
         assert mock_openai_client.chat.completions.create.call_count == 2
-        # 验证：返回最终内容（不是错误消息）
         assert content == "抱歉，我暂时无法搜索记忆，但我们还是聊聊吧。"
-        # 验证：元数据中包含工具调用轮次
         assert metadata["tool_rounds"] == 1
 
         rr = metadata["round_records"]
         assert len(rr) == 2
-        assert rr[0]["round"] == 0
         assert rr[0]["tool_calls"][0]["name"] == "search_memory"
         assert len(rr[0]["tool_results"]) == 1
         assert "temporarily unavailable" in rr[0]["tool_results"][0]["content"]
-        assert rr[0]["tool_results"][0]["tool_call_id"] == "tc_1"
 
     @pytest.mark.asyncio
     async def test_tool_execution_failure(self):
-        """测试工具执行失败处理"""
+        """工具执行失败处理"""
         client = LLMClient(
             api_key="test_key",
             base_url="https://api.test.com/v1",
@@ -260,12 +271,12 @@ class TestChatWithTools:
         messages = [{"role": "user", "content": "test"}]
         tools = [{"type": "function", "function": {"name": "search_memory"}}]
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=messages,
             tools=tools,
             tool_executor=failing_executor,
             max_tool_rounds=5,
-            timeout=60
+            timeout=60,
         )
 
         assert "工具执行失败" in content
@@ -273,45 +284,12 @@ class TestChatWithTools:
 
         rr = metadata["round_records"]
         assert len(rr) == 1
-        assert rr[0]["round"] == 0
         assert rr[0]["tool_calls"][0]["name"] == "search_memory"
-        assert rr[0]["tool_results"] == []  # 执行失败，无结果
-
-    @pytest.mark.asyncio
-    async def test_generate_with_forced_tool_no_tool_calls_raises(self):
-        """强制工具调用时 LLM 未返回 tool_calls，应抛出 ForcedToolError"""
-        client = LLMClient(
-            api_key="test_key",
-            base_url="https://api.test.com/v1",
-            model="gpt-4o"
-        )
-
-        mock_response = Mock()
-        mock_response.choices = [Mock()]
-        mock_response.choices[0].message = Mock()
-        mock_response.choices[0].message.content = "我没有调用工具"
-        mock_response.choices[0].message.tool_calls = None
-        mock_response.usage = Mock()
-        mock_response.usage.prompt_tokens = 50
-        mock_response.usage.completion_tokens = 10
-
-        mock_openai_client = Mock()
-        mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
-        client._client = mock_openai_client
-
-        with pytest.raises(ForcedToolError) as exc_info:
-            await client.generate_with_forced_tool(
-                messages=[{"role": "user", "content": "test"}],
-                tools=[{"type": "function", "function": {"name": "test_tool"}}],
-                tool_name="test_tool",
-            )
-
-        assert "test_tool" in str(exc_info.value)
-        assert exc_info.value.raw_content == "我没有调用工具"
+        assert rr[0]["tool_results"] == []
 
     @pytest.mark.asyncio
     async def test_max_tool_rounds_exceeded(self):
-        """测试超过最大工具调用轮次"""
+        """超过最大工具调用轮次"""
         client = LLMClient(
             api_key="test_key",
             base_url="https://api.test.com/v1",
@@ -344,37 +322,30 @@ class TestChatWithTools:
         messages = [{"role": "user", "content": "test"}]
         tools = [{"type": "function", "function": {"name": "search_memory"}}]
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=messages,
             tools=tools,
             tool_executor=mock_executor,
-            max_tool_rounds=2,  # 限制为 2 轮
-            max_round_callbacks=0,  # 禁用回调以保持原测试语义
-            timeout=60
+            max_tool_rounds=2,
+            max_round_callbacks=0,
+            timeout=60,
         )
 
-        assert "工具调用次数超过限制" in content
+        assert content == ""
         assert metadata["tool_rounds"] == 2
 
         rr = metadata["round_records"]
         assert len(rr) == 2
-        assert rr[0]["round"] == 0
-        assert rr[0]["tool_calls"][0]["name"] == "search_memory"
-        assert len(rr[0]["tool_results"]) == 1
-        assert rr[1]["round"] == 1
-        assert rr[1]["tool_calls"][0]["name"] == "search_memory"
-        assert len(rr[1]["tool_results"]) == 1
 
     @pytest.mark.asyncio
     async def test_callback_injection_appends_message_and_continues(self):
-        """回调返回 dict 时注入消息并继续循环"""
+        """L2 回调返回 dict 时注入消息并继续循环"""
         client = LLMClient(
             api_key="test_key",
             base_url="https://api.test.com/v1",
             model="gpt-4o"
         )
 
-        # Round 0: content without tool_calls -> callback injects system note
         mock_response1 = Mock()
         mock_response1.choices = [Mock()]
         mock_response1.choices[0].message = Mock()
@@ -382,7 +353,6 @@ class TestChatWithTools:
         mock_response1.choices[0].message.tool_calls = None
         mock_response1.usage = None
 
-        # Round 1 (after injection): content again -> callback returns None
         mock_response2 = Mock()
         mock_response2.choices = [Mock()]
         mock_response2.choices[0].message = Mock()
@@ -401,9 +371,10 @@ class TestChatWithTools:
                 return {"role": "system", "content": "inject"}
             return None
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=[{"role": "user", "content": "test"}],
-            tools=[],
+            tools=[{"type": "function", "function": {"name": "search_memory"}}],
+            tool_choice="auto",  # 避免 L1 触发
             on_round_complete=on_round,
             max_round_callbacks=3,
             max_tool_rounds=5,
@@ -416,17 +387,14 @@ class TestChatWithTools:
         rr = metadata["round_records"]
         assert len(rr) == 2
         assert rr[0]["callback"] == {"role": "system", "content": "inject"}
-        assert rr[0]["tool_calls"] == []
-        assert rr[0]["tool_results"] == []
         assert rr[1]["callback"] is None
 
-        # Verify injected message was appended
         second_call_messages = mock_openai_client.chat.completions.create.await_args_list[1][1]["messages"]
         assert any(m.get("content") == "inject" for m in second_call_messages)
 
     @pytest.mark.asyncio
     async def test_callback_returns_none_uses_original_flow(self):
-        """回调返回 None 时走原流程（处理 tool_calls）"""
+        """L2 回调返回 None 时走原流程"""
         client = LLMClient(
             api_key="test_key",
             base_url="https://api.test.com/v1",
@@ -452,7 +420,7 @@ class TestChatWithTools:
         async def on_round(round_num, result, messages):
             return None
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=[{"role": "user", "content": "test"}],
             tools=[{"type": "function", "function": {"name": "search_memory"}}],
             tool_executor=mock_executor,
@@ -461,8 +429,8 @@ class TestChatWithTools:
             max_tool_rounds=1,
         )
 
-        assert metadata["callback_count"] == 0  # on_round 返回 None，不递增
-        assert metadata["total_tool_calls"] > 0   # 确实走了 tool_calls 处理流程
+        assert metadata["callback_count"] == 0
+        assert metadata["total_tool_calls"] > 0
 
     @pytest.mark.asyncio
     async def test_max_round_callbacks_stops_injection(self):
@@ -486,17 +454,16 @@ class TestChatWithTools:
         async def on_round(round_num, result, messages):
             return {"role": "system", "content": "inject"}
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=[{"role": "user", "content": "test"}],
-            tools=[],
+            tools=[{"type": "function", "function": {"name": "search_memory"}}],
+            tool_choice="auto",
             on_round_complete=on_round,
             max_round_callbacks=2,
             max_tool_rounds=2,
         )
 
         assert metadata["callback_count"] == 2
-        # max_total_rounds = 2 + 2 = 4, but after 2 injections total_rounds=3
-        # then round 3 (total_rounds=4) returns "c" without injection (callback exhausted)
 
     def _make_response(self, content: str):
         mock_response = Mock()
@@ -528,27 +495,17 @@ class TestChatWithTools:
         async def on_round(round_num, result, messages):
             return {"role": "system", "content": "inject"}
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=[{"role": "user", "content": "test"}],
-            tools=[],
+            tools=[{"type": "function", "function": {"name": "search_memory"}}],
+            tool_choice="auto",
             on_round_complete=on_round,
             max_round_callbacks=1,
             max_tool_rounds=1,
         )
 
-        # max_total_rounds = 1 + 1 = 2
-        # round 0: "a" -> inject (callback_count=1, total_rounds=1)
-        # round 1: "b" -> callback exhausted, return "b" (total_rounds=2)
         assert content == "b"
         assert metadata["callback_count"] == 1
-
-    @pytest.mark.asyncio
-    async def test_generate_with_forced_tool_does_not_accept_callback(self):
-        """generate_with_forced_tool 签名不包含 callback 参数"""
-        import inspect
-        sig = inspect.signature(LLMClient.generate_with_forced_tool)
-        assert "on_round_complete" not in sig.parameters
-        assert "max_round_callbacks" not in sig.parameters
 
     @pytest.mark.asyncio
     async def test_round_records_with_think_and_multiple_tool_rounds(self):
@@ -559,7 +516,6 @@ class TestChatWithTools:
             model="gpt-4o"
         )
 
-        # Round 0: think + tool_call
         r0 = Mock()
         r0.choices = [Mock()]
         r0.choices[0].message = Mock()
@@ -569,7 +525,6 @@ class TestChatWithTools:
         ]
         r0.usage = None
 
-        # Round 1: think + tool_call (second round, different tool)
         r1 = Mock()
         r1.choices = [Mock()]
         r1.choices[0].message = Mock()
@@ -579,7 +534,6 @@ class TestChatWithTools:
         ]
         r1.usage = None
 
-        # Round 2: think + final response (no tool_calls)
         r2 = Mock()
         r2.choices = [Mock()]
         r2.choices[0].message = Mock()
@@ -599,14 +553,15 @@ class TestChatWithTools:
                 for tc in tool_calls
             ]
 
-        content, metadata = await client.chat_with_tools(
+        content, metadata = await client.generate(
             messages=[{"role": "user", "content": "test"}],
             tools=[
                 {"type": "function", "function": {"name": "search_memory"}},
                 {"type": "function", "function": {"name": "roll_dice"}},
             ],
             tool_executor=mock_executor,
-            max_tool_rounds=5,
+            max_tool_rounds=3,
+            max_round_callbacks=0,
         )
 
         assert content == "你喜欢猫！"
@@ -614,12 +569,10 @@ class TestChatWithTools:
         assert metadata["total_tool_calls"] == 2
 
         rr = metadata["round_records"]
-        assert len(rr) == 3  # 2 tool rounds + 1 final
+        assert len(rr) == 3
 
-        # Round 0: tool call
         assert rr[0]["round"] == 0
         assert rr[0]["think"] == "<think>需要查询记忆</think>"
-        assert rr[0]["callback"] is None
         assert rr[0]["tool_calls"] == [
             {"id": "tc_1", "name": "search_memory", "arguments": '{"query":"猫"}'}
         ]
@@ -627,7 +580,6 @@ class TestChatWithTools:
             {"tool_call_id": "tc_1", "content": "[search_memory] result"}
         ]
 
-        # Round 1: second tool call
         assert rr[1]["round"] == 1
         assert rr[1]["think"] == "<think>还需要掷骰</think>"
         assert rr[1]["tool_calls"] == [
@@ -637,15 +589,167 @@ class TestChatWithTools:
             {"tool_call_id": "tc_2", "content": "[roll_dice] result"}
         ]
 
-        # Round 2: final, no tool_calls, think preserved
         assert rr[2]["round"] == 2
         assert rr[2]["think"] == "<think>回答准备好了</think>"
         assert rr[2]["tool_calls"] == []
         assert rr[2]["tool_results"] == []
 
+    @pytest.mark.asyncio
+    async def test_l1_correction_injected_when_required_and_no_tool_calls(self):
+        """L1 纠正：tool_choice="required" 且空 tool_calls 时注入"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        # Round 0: no tool_calls → L1 fires (callback #1)
+        # Round 1: tool_calls → executor → tool_round_num=1
+        # Round 2: no tool_calls → tool_round=1 >= max_tool_rounds=1 → skip L1 → return
+        r0 = Mock()
+        r0.choices = [Mock()]
+        r0.choices[0].message = Mock()
+        r0.choices[0].message.content = "some text"
+        r0.choices[0].message.tool_calls = None
+        r0.usage = None
+
+        r1 = Mock()
+        r1.choices = [Mock()]
+        r1.choices[0].message = Mock()
+        r1.choices[0].message.content = ""
+        r1.choices[0].message.tool_calls = [
+            MockToolCall("tc_1", "search_memory", '{"query":"x"}')
+        ]
+        r1.usage = None
+
+        r2 = Mock()
+        r2.choices = [Mock()]
+        r2.choices[0].message = Mock()
+        r2.choices[0].message.content = "result"
+        r2.choices[0].message.tool_calls = None
+        r2.usage = None
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(
+            side_effect=[r0, r1, r2]
+        )
+        client._client = mock_openai_client
+
+        async def mock_executor(tool_calls):
+            return [{"tool_call_id": tc["id"], "content": "ok"} for tc in tool_calls]
+
+        content, metadata = await client.generate(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[{"type": "function", "function": {"name": "search_memory"}}],
+            tool_executor=mock_executor,
+            max_tool_rounds=2,
+            max_round_callbacks=1,
+        )
+
+        assert content == "result"
+        assert metadata["callback_count"] == 1
+        rr = metadata["round_records"]
+        assert len(rr) == 3
+        assert rr[0]["callback"] is not None
+        assert "[系统指令]" in rr[0]["callback"]["content"]
+
+    @pytest.mark.asyncio
+    async def test_tool_choice_defaults_to_required(self):
+        """tools 非空且未设置 tool_choice 时默认 "required" """
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = "done"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = None
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        client._client = mock_openai_client
+
+        await client.generate(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[{"type": "function", "function": {"name": "search_memory"}}],
+        )
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["tool_choice"] == "required"
+
+    @pytest.mark.asyncio
+    async def test_tool_choice_explicit_auto(self):
+        """显式设置 tool_choice="auto" 时不触发 L1"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = "done"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = None
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        client._client = mock_openai_client
+
+        content, metadata = await client.generate(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[{"type": "function", "function": {"name": "search_memory"}}],
+            tool_choice="auto",
+        )
+
+        # Auto mode — no tool_calls is fine, return content directly
+        assert content == "done"
+        assert metadata["callback_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_max_tool_rounds_is_one(self):
+        """max_tool_rounds=1 单轮退化"""
+        client = LLMClient(
+            api_key="test_key",
+            base_url="https://api.test.com/v1",
+            model="gpt-4o"
+        )
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.tool_calls = [
+            MockToolCall("tc_1", "record_event", '{"description":"test"}')
+        ]
+        mock_response.usage = None
+
+        mock_openai_client = Mock()
+        mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        client._client = mock_openai_client
+
+        async def mock_executor(tool_calls):
+            return [{"tool_call_id": tc["id"], "content": '{"status":"ok"}'} for tc in tool_calls]
+
+        content, metadata = await client.generate(
+            messages=[{"role": "user", "content": "test"}],
+            tools=[{"type": "function", "function": {"name": "record_event"}}],
+            tool_executor=mock_executor,
+            max_tool_rounds=1,
+            max_round_callbacks=0,
+        )
+
+        assert metadata["tool_rounds"] == 1
+        assert metadata["total_tool_calls"] == 1
+
 
 class TestFilterThinkTags:
-    """<think> 标签过滤（client 层模型输出归一化）"""
+    """<think> 标签过滤"""
 
     def test_filters_single_think_block(self):
         client = LLMClient(api_key="k", base_url="http://x", model="m")

--- a/tests/unit/persona/test_event_agent.py
+++ b/tests/unit/persona/test_event_agent.py
@@ -1,10 +1,7 @@
 """
 单元测试: Persona Event Agent
 
-测试 EventGenerationAgent 的三个主要方法:
-- generate_event: 生成客观生活事件
-- generate_reaction: 生成角色对事件的反应
-- generate_diary: 生成日记总结
+测试 EventGenerationAgent 的主要方法
 """
 
 import json
@@ -23,164 +20,197 @@ from plugins.DicePP.module.persona.life.event_agent import (
 from plugins.DicePP.module.persona.data.models import ModelTier
 
 
-class TestEventGenerationAgent:
-    """测试事件生成 Agent"""
+def _make_side_effect(result_args: str, tool_name: str):
+    """创建 router.generate 的 side_effect，调用 tool_executor 填充 CollectExecutor"""
+    async def side_effect(**kwargs):
+        tool_executor = kwargs.get("tool_executor")
+        if tool_executor:
+            tc = {
+                "id": "tc_1",
+                "name": tool_name,
+                "arguments": result_args,
+            }
+            await tool_executor([tc])
+        return "", {}
+    return side_effect
+
+
+class TestGenerateDiary:
+    """测试 generate_diary 方法"""
 
     @pytest.fixture
     def mock_llm_router(self):
-        """创建 Mock LLM Router"""
         router = MagicMock()
         router.generate = AsyncMock()
         return router
 
     @pytest.fixture
     def agent(self, mock_llm_router):
-        """创建 EventGenerationAgent 实例"""
         config = MagicMock()
         config.background_llm_timeout_seconds = 90
+        config.background_llm_max_tool_rounds = 3
         return EventGenerationAgent(mock_llm_router, config=config)
 
-    @pytest.fixture
-    def event_context(self):
-        """创建测试用的 EventContext"""
-        return EventContext(
-            character_name="测试角色",
-            character_description="一个温柔的AI助手",
-            world="现代日常世界",
-            scenario="居家生活",
-            recent_diaries=["今天天气不错，去公园散步了。"],
-            today_events=[{"description": "早上喝了咖啡"}],
-            permanent_state="心情愉悦",
-            current_time=datetime(2024, 1, 1, 10, 0),
+    @pytest.mark.asyncio
+    async def test_generate_diary_success(self, agent, mock_llm_router):
+        """正常生成日记"""
+        mock_llm_router.generate.side_effect = _make_side_effect(
+            '{"diary": "今天过得真充实，发生了很多有趣的事情。"}',
+            "record_diary_entry",
         )
 
-    class TestGenerateDiary:
-        """测试 generate_diary 方法"""
+        events = [
+            {"description": "早上喝咖啡", "reaction": "感觉很清醒"},
+            {"description": "下午散步", "reaction": "心情放松了许多"},
+        ]
 
-        async def test_generate_diary_success(self, agent, mock_llm_router):
-            """测试正常生成日记"""
-            mock_llm_router.generate.return_value = "  今天过得真充实，发生了很多有趣的事情。  "
+        result = await agent.generate_diary(
+            events=events,
+            character_name="测试角色",
+            character_description="一个喜欢记录生活的人",
+            yesterday_diary="昨天也很充实。",
+        )
 
-            events = [
-                {"description": "早上喝咖啡", "reaction": "感觉很清醒"},
-                {"description": "下午散步", "reaction": "心情放松了许多"},
-            ]
+        assert result == "今天过得真充实，发生了很多有趣的事情。"
+        mock_llm_router.generate.assert_called_once()
+        call_kwargs = mock_llm_router.generate.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.85
+        assert call_kwargs["timeout"] == 90
+        assert call_kwargs["model_tier"] == ModelTier.AUXILIARY
+        assert call_kwargs["tools"] is not None
 
-            result = await agent.generate_diary(
-                events=events,
-                character_name="测试角色",
-                character_description="一个喜欢记录生活的人",
-                yesterday_diary="昨天也很充实。",
-            )
+    @pytest.mark.asyncio
+    async def test_generate_diary_truncate_long(self, agent, mock_llm_router):
+        """超长日记被截断"""
+        long_diary = "今天真是漫长的一天" * 60
+        mock_llm_router.generate.side_effect = _make_side_effect(
+            f'{{"diary": "{long_diary}"}}',
+            "record_diary_entry",
+        )
 
-            assert result == "今天过得真充实，发生了很多有趣的事情。"
-            mock_llm_router.generate.assert_called_once()
-            call_kwargs = mock_llm_router.generate.call_args.kwargs
-            assert call_kwargs["temperature"] == 0.85
-            assert call_kwargs["timeout"] == 90
-            assert call_kwargs["model_tier"] == ModelTier.AUXILIARY
+        result = await agent.generate_diary(
+            events=[{"description": "事件", "reaction": "反应"}],
+            character_name="角色",
+            character_description="描述",
+        )
 
-        async def test_generate_diary_truncate_long(self, agent, mock_llm_router):
-            """测试超长日记被截断"""
-            long_diary = "今天真是漫长的一天" * 60  # 540字，超过500字
-            mock_llm_router.generate.return_value = long_diary
+        assert len(result) <= 300
+        assert result.endswith("...")
 
-            result = await agent.generate_diary(
-                events=[{"description": "事件", "reaction": "反应"}],
-                character_name="角色",
-                character_description="描述",
-            )
+    @pytest.mark.asyncio
+    async def test_generate_diary_fallback_on_exception(self, agent, mock_llm_router):
+        """异常时返回默认兜底文本"""
+        mock_llm_router.generate.side_effect = Exception("服务不可用")
 
-            assert len(result) <= 500
-            assert result.endswith("...")
+        result = await agent.generate_diary(
+            events=[{"description": "事件", "reaction": "反应"}],
+            character_name="角色",
+            character_description="描述",
+        )
 
-        async def test_generate_diary_fallback_on_exception(self, agent, mock_llm_router):
-            """测试异常时返回默认兜底文本"""
-            mock_llm_router.generate.side_effect = Exception("服务不可用")
+        assert "太累了" in result
+        assert "简单记录" in result
 
-            result = await agent.generate_diary(
-                events=[{"description": "事件", "reaction": "反应"}],
-                character_name="角色",
-                character_description="描述",
-            )
+    @pytest.mark.asyncio
+    async def test_generate_diary_no_collected(self, agent, mock_llm_router):
+        """LLM 未调用工具时返回兜底文本"""
+        mock_llm_router.generate.return_value = ("text without tool call", {})
 
-            assert "太累了" in result
-            assert "简单记录" in result
+        result = await agent.generate_diary(
+            events=[{"description": "事件", "reaction": "反应"}],
+            character_name="角色",
+            character_description="描述",
+        )
 
-        async def test_generate_diary_without_yesterday(self, agent, mock_llm_router):
-            """测试不传入昨天日记的情况"""
-            mock_llm_router.generate.return_value = "今天的日记内容"
+        assert "太累了" in result
 
-            events = [{"description": "事件1", "reaction": "反应1"}]
-            await agent.generate_diary(
-                events=events,
-                character_name="角色",
-                character_description="描述",
-                yesterday_diary=None,
-            )
+    @pytest.mark.asyncio
+    async def test_generate_diary_without_yesterday(self, agent, mock_llm_router):
+        """不传入昨天日记的情况"""
+        mock_llm_router.generate.side_effect = _make_side_effect(
+            '{"diary": "今天的日记内容"}',
+            "record_diary_entry",
+        )
 
-            call_args = mock_llm_router.generate.call_args.kwargs
-            messages = call_args["messages"]
-            user_prompt = messages[1]["content"]
-            assert "昨天的日记" not in user_prompt
-            assert "事件1" in user_prompt
-            assert "反应1" in user_prompt
+        events = [{"description": "事件1", "reaction": "反应1"}]
+        await agent.generate_diary(
+            events=events,
+            character_name="角色",
+            character_description="描述",
+            yesterday_diary=None,
+        )
 
-        async def test_generate_diary_with_yesterday(self, agent, mock_llm_router):
-            """测试传入昨天日记的情况"""
-            mock_llm_router.generate.return_value = "今天的日记内容"
+        call_args = mock_llm_router.generate.call_args.kwargs
+        messages = call_args["messages"]
+        user_prompt = messages[1]["content"]
+        assert "昨天的日记" not in user_prompt
+        assert "事件1" in user_prompt
+        assert "反应1" in user_prompt
 
-            events = [{"description": "事件1", "reaction": "反应1"}]
-            yesterday = "这是昨天的日记内容，写了很多字。"
-            await agent.generate_diary(
-                events=events,
-                character_name="角色",
-                character_description="描述",
-                yesterday_diary=yesterday,
-            )
+    @pytest.mark.asyncio
+    async def test_generate_diary_with_yesterday(self, agent, mock_llm_router):
+        """传入昨天日记的情况"""
+        mock_llm_router.generate.side_effect = _make_side_effect(
+            '{"diary": "今天的日记内容"}',
+            "record_diary_entry",
+        )
 
-            call_args = mock_llm_router.generate.call_args.kwargs
-            messages = call_args["messages"]
-            user_prompt = messages[1]["content"]
-            assert "昨天的日记" in user_prompt
-            assert yesterday[:200] in user_prompt
+        events = [{"description": "事件1", "reaction": "反应1"}]
+        yesterday = "这是昨天的日记内容，写了很多字。"
+        await agent.generate_diary(
+            events=events,
+            character_name="角色",
+            character_description="描述",
+            yesterday_diary=yesterday,
+        )
 
-        async def test_generate_diary_empty_events(self, agent, mock_llm_router):
-            """测试空事件列表"""
-            mock_llm_router.generate.return_value = "今天没什么特别的事发生。"
+        call_args = mock_llm_router.generate.call_args.kwargs
+        messages = call_args["messages"]
+        user_prompt = messages[1]["content"]
+        assert "昨天的日记" in user_prompt
+        assert yesterday[:200] in user_prompt
 
-            result = await agent.generate_diary(
-                events=[],
-                character_name="角色",
-                character_description="描述",
-            )
+    @pytest.mark.asyncio
+    async def test_generate_diary_empty_events(self, agent, mock_llm_router):
+        """空事件列表"""
+        mock_llm_router.generate.side_effect = _make_side_effect(
+            '{"diary": "今天没什么特别的事发生。"}',
+            "record_diary_entry",
+        )
 
-            assert result == "今天没什么特别的事发生。"
+        result = await agent.generate_diary(
+            events=[],
+            character_name="角色",
+            character_description="描述",
+        )
+
+        assert result == "今天没什么特别的事发生。"
 
 
 class TestGenerateEventResult:
-    """测试 generate_event_result Function Calling 路径"""
+    """测试 generate_event_result 工具路径"""
 
     @pytest.fixture
-    def mock_llm_router_forced(self):
+    def mock_llm_router(self):
         router = MagicMock()
-        router.generate_with_forced_tool = AsyncMock()
+        router.generate = AsyncMock()
         return router
 
     @pytest.fixture
-    def agent_forced(self, mock_llm_router_forced):
+    def agent(self, mock_llm_router):
         config = MagicMock()
         config.background_llm_timeout_seconds = 90
-        return EventGenerationAgent(mock_llm_router_forced, config=config)
+        config.background_llm_max_tool_rounds = 3
+        return EventGenerationAgent(mock_llm_router, config=config)
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_success(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_result_success(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"description": "窗外下雨了", "context_summary": "窗外下雨", "duration_minutes": 30}',
-            {}
+            "record_event",
         )
 
-        result = await agent_forced.generate_event_result(
+        result = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -195,7 +225,6 @@ class TestGenerateEventResult:
         assert result.description == "窗外下雨了"
         assert result.context_summary == "窗外下雨"
         assert result.duration_minutes == 30
-        # raw_response 和 system_prompt_digest 必须保存原始 LLM 输出
         assert result.raw_response != ""
         raw = json.loads(result.raw_response)
         assert raw["description"] == "窗外下雨了"
@@ -203,16 +232,15 @@ class TestGenerateEventResult:
         assert raw["duration_minutes"] == 30
         assert result.system_prompt_digest != ""
         assert "世界观设定专家" in result.system_prompt_digest
-        mock_llm_router_forced.generate_with_forced_tool.assert_called_once()
-        # B-260507-d3cc8b: 验证 timeout 默认传递到 router
-        call_kwargs = mock_llm_router_forced.generate_with_forced_tool.call_args.kwargs
+        mock_llm_router.generate.assert_called_once()
+        call_kwargs = mock_llm_router.generate.call_args.kwargs
         assert call_kwargs["timeout"] == 90
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_fallback(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.side_effect = Exception("forced tool error")
+    async def test_generate_event_result_fallback(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = Exception("forced tool error")
 
-        result = await agent_forced.generate_event_result(
+        result = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -226,22 +254,20 @@ class TestGenerateEventResult:
 
         assert "休息" in result.description
         assert result.duration_minutes == 0
-        # B-260507-d3cc8b: fallback 携带默认 delta 避免状态断层
         assert result.energy_delta == 0
         assert result.mood_delta is None
         assert result.health_delta is None
-        # R7: fallback 填充 raw_response 和 system_prompt_digest 以增强可观测性
         assert result.raw_response != ""
         assert "fallback" in result.system_prompt_digest
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_clamp_duration_max(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_result_clamp_duration_max(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"description": "测试中", "duration_minutes": 3000}',
-            {}
+            "record_event",
         )
 
-        result = await agent_forced.generate_event_result(
+        result = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -256,13 +282,13 @@ class TestGenerateEventResult:
         assert result.duration_minutes == 2880
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_clamp_duration_min(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_result_clamp_duration_min(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"description": "测试中", "duration_minutes": -10}',
-            {}
+            "record_event",
         )
 
-        result = await agent_forced.generate_event_result(
+        result = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -277,13 +303,13 @@ class TestGenerateEventResult:
         assert result.duration_minutes == 0
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_empty_description_fallback(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_result_empty_description_fallback(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"description": "", "duration_minutes": 0}',
-            {}
+            "record_event",
         )
 
-        result = await agent_forced.generate_event_result(
+        result = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -299,15 +325,15 @@ class TestGenerateEventResult:
         assert result.duration_minutes == 0
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_no_truncate_long_description(self, agent_forced, mock_llm_router_forced):
+    async def test_generate_event_result_no_truncate_long_description(self, agent, mock_llm_router):
         """description 不再硬截断，完整保留；context_summary 为空时 fallback 到 description 前 60 字"""
-        long_desc = "窗外" * 50  # 100 字
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+        long_desc = "窗外" * 50
+        mock_llm_router.generate.side_effect = _make_side_effect(
             f'{{"description": "{long_desc}", "duration_minutes": 0}}',
-            {}
+            "record_event",
         )
 
-        result = await agent_forced.generate_event_result(
+        result = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -319,17 +345,16 @@ class TestGenerateEventResult:
             )
         )
 
-        assert result.description == long_desc  # 完整保留，不截断
+        assert result.description == long_desc
         assert len(result.context_summary) == 60
         assert result.context_summary == long_desc[:60]
 
-        # description < 60 字时 fallback 保留完整文本
         short_desc = "窗外下雨了"
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+        mock_llm_router.generate.side_effect = _make_side_effect(
             f'{{"description": "{short_desc}", "duration_minutes": 0}}',
-            {}
+            "record_event",
         )
-        result2 = await agent_forced.generate_event_result(
+        result2 = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -343,14 +368,14 @@ class TestGenerateEventResult:
         assert result2.context_summary == short_desc
 
     @pytest.mark.asyncio
-    async def test_generate_event_result_empty_context(self, agent_forced, mock_llm_router_forced):
-        """空上下文（recent_diaries/today_events 均为空）时正常生成"""
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_result_empty_context(self, agent, mock_llm_router):
+        """空上下文时正常生成"""
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"description": "正在休息", "duration_minutes": 15}',
-            {}
+            "record_event",
         )
 
-        result = await agent_forced.generate_event_result(
+        result = await agent.generate_event_result(
             EventContext(
                 character_name="小雨",
                 character_description="温柔的少女",
@@ -367,28 +392,29 @@ class TestGenerateEventResult:
 
 
 class TestGenerateEventReaction:
-    """测试 generate_event_reaction Function Calling 路径"""
+    """测试 generate_event_reaction 工具路径"""
 
     @pytest.fixture
-    def mock_llm_router_forced(self):
+    def mock_llm_router(self):
         router = MagicMock()
-        router.generate_with_forced_tool = AsyncMock()
+        router.generate = AsyncMock()
         return router
 
     @pytest.fixture
-    def agent_forced(self, mock_llm_router_forced):
+    def agent(self, mock_llm_router):
         config = MagicMock()
         config.background_llm_timeout_seconds = 90
-        return EventGenerationAgent(mock_llm_router_forced, config=config)
+        config.background_llm_max_tool_rounds = 3
+        return EventGenerationAgent(mock_llm_router, config=config)
 
     @pytest.mark.asyncio
-    async def test_generate_event_reaction_success(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_reaction_success(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"reaction": "真开心~", "share_desire": 0.8}',
-            {}
+            "record_reaction",
         )
 
-        result = await agent_forced.generate_event_reaction(
+        result = await agent.generate_event_reaction(
             event="窗外下雨了",
             character_name="小雨",
             character_description="温柔的少女",
@@ -396,21 +422,19 @@ class TestGenerateEventReaction:
 
         assert result.reaction == "真开心~"
         assert result.share_desire == 0.8
-        # raw_response 必须保存原始 LLM 输出
         assert result.raw_response != ""
         raw = json.loads(result.raw_response)
         assert raw["reaction"] == "真开心~"
         assert raw["share_desire"] == 0.8
-        mock_llm_router_forced.generate_with_forced_tool.assert_called_once()
-        # B-260507-d3cc8b: 验证 timeout 默认传递到 router
-        call_kwargs = mock_llm_router_forced.generate_with_forced_tool.call_args.kwargs
+        mock_llm_router.generate.assert_called_once()
+        call_kwargs = mock_llm_router.generate.call_args.kwargs
         assert call_kwargs["timeout"] == 90
 
     @pytest.mark.asyncio
-    async def test_generate_event_reaction_fallback_required(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.side_effect = Exception("tool error")
+    async def test_generate_event_reaction_fallback_required(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = Exception("tool error")
 
-        result = await agent_forced.generate_event_reaction(
+        result = await agent.generate_event_reaction(
             event="窗外下雨了",
             character_name="小雨",
             character_description="温柔的少女",
@@ -420,10 +444,10 @@ class TestGenerateEventReaction:
         assert result.share_desire == 1.0
 
     @pytest.mark.asyncio
-    async def test_generate_event_reaction_fallback_never(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.side_effect = Exception("tool error")
+    async def test_generate_event_reaction_fallback_never(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = Exception("tool error")
 
-        result = await agent_forced.generate_event_reaction(
+        result = await agent.generate_event_reaction(
             event="窗外下雨了",
             character_name="小雨",
             character_description="温柔的少女",
@@ -433,10 +457,10 @@ class TestGenerateEventReaction:
         assert result.share_desire == 0.0
 
     @pytest.mark.asyncio
-    async def test_generate_event_reaction_fallback_optional(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.side_effect = Exception("tool error")
+    async def test_generate_event_reaction_fallback_optional(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = Exception("tool error")
 
-        result = await agent_forced.generate_event_reaction(
+        result = await agent.generate_event_reaction(
             event="窗外下雨了",
             character_name="小雨",
             character_description="温柔的少女",
@@ -446,13 +470,13 @@ class TestGenerateEventReaction:
         assert result.share_desire == 0.5
 
     @pytest.mark.asyncio
-    async def test_generate_event_reaction_clamp_share_desire_max(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_reaction_clamp_share_desire_max(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"reaction": "开心", "share_desire": 1.5}',
-            {}
+            "record_reaction",
         )
 
-        result = await agent_forced.generate_event_reaction(
+        result = await agent.generate_event_reaction(
             event="窗外下雨了",
             character_name="小雨",
             character_description="温柔的少女",
@@ -462,13 +486,13 @@ class TestGenerateEventReaction:
         assert result.share_desire == 1.0
 
     @pytest.mark.asyncio
-    async def test_generate_event_reaction_clamp_share_desire_min(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_reaction_clamp_share_desire_min(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"reaction": "开心", "share_desire": -0.3}',
-            {}
+            "record_reaction",
         )
 
-        result = await agent_forced.generate_event_reaction(
+        result = await agent.generate_event_reaction(
             event="窗外下雨了",
             character_name="小雨",
             character_description="温柔的少女",
@@ -478,13 +502,13 @@ class TestGenerateEventReaction:
         assert result.share_desire == 0.0
 
     @pytest.mark.asyncio
-    async def test_generate_event_reaction_empty_reaction_fallback(self, agent_forced, mock_llm_router_forced):
-        mock_llm_router_forced.generate_with_forced_tool.return_value = (
+    async def test_generate_event_reaction_empty_reaction_fallback(self, agent, mock_llm_router):
+        mock_llm_router.generate.side_effect = _make_side_effect(
             '{"reaction": "", "share_desire": 0.5}',
-            {}
+            "record_reaction",
         )
 
-        result = await agent_forced.generate_event_reaction(
+        result = await agent.generate_event_reaction(
             event="窗外下雨了",
             character_name="小雨",
             character_description="温柔的少女",
@@ -496,14 +520,17 @@ class TestGenerateEventReaction:
 
     @pytest.mark.asyncio
     async def test_share_message_prompt_injection(self):
-        """验证分享消息 prompt 注入状态/事件/意向（3.3.2 / 3.3.3）"""
+        """验证分享消息 prompt 注入状态/事件/意向"""
         from io import StringIO
         from loguru import logger
         from plugins.DicePP.module.persona.life.event_agent import ShareMessageContext
 
-        # 创建真实 EventGenerationAgent，mock llm_router
         mock_router = MagicMock()
-        mock_router.generate_with_forced_tool = AsyncMock(return_value=('{"message": "茶很好喝哦"}', {}))
+        mock_router.generate = AsyncMock()
+        mock_router.generate.side_effect = _make_side_effect(
+            '{"message": "茶很好喝哦"}',
+            "record_share_message",
+        )
         agent = EventGenerationAgent(llm_router=mock_router)
 
         context = ShareMessageContext(
@@ -534,7 +561,6 @@ class TestGenerateEventReaction:
 
         assert message == "茶很好喝哦"
 
-        # 验证分享消息 prompt 注入
         logs = output.getvalue()
         assert "[prompt:system_share]" in logs
         assert "[prompt:user_share]" in logs

--- a/tests/unit/persona/test_generate_share_message.py
+++ b/tests/unit/persona/test_generate_share_message.py
@@ -1,10 +1,9 @@
 """
 单元测试: generate_share_message
 
-覆盖重试逻辑、超时处理、截断逻辑、few-shot 注入。
+覆盖 CollectExecutor 收集、截断逻辑、few-shot 注入。
 """
 
-import asyncio
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
@@ -13,20 +12,33 @@ from plugins.DicePP.module.persona.life.event_agent import (
     ShareMessageContext,
 )
 from plugins.DicePP.module.persona.data.models import ModelTier
-from plugins.DicePP.module.persona.llm import ForcedToolError
 
 
 class MockConfig:
     proactive_share_max_chars = 200
-    proactive_share_max_retries = 2
     background_llm_timeout_seconds = 10
-    proactive_share_backoff_base_seconds = 2
+    background_llm_max_tool_rounds = 3
+
+
+def _make_side_effect(args_json: str, tool_name: str = "record_share_message"):
+    """创建 router.generate 的 side_effect，调用 tool_executor 填充 CollectExecutor"""
+    async def side_effect(**kwargs):
+        tool_executor = kwargs.get("tool_executor")
+        if tool_executor:
+            tc = {
+                "id": "tc_1",
+                "name": tool_name,
+                "arguments": args_json,
+            }
+            await tool_executor([tc])
+        return "", {}
+    return side_effect
 
 
 @pytest.fixture
 def mock_llm_router():
     router = MagicMock()
-    router.generate_with_forced_tool = AsyncMock()
+    router.generate = AsyncMock()
     return router
 
 
@@ -55,27 +67,26 @@ def base_context():
 @pytest.mark.asyncio
 async def test_generate_share_message_success(agent, mock_llm_router, base_context):
     """正常返回分享消息"""
-    mock_llm_router.generate_with_forced_tool.return_value = (
+    mock_llm_router.generate.side_effect = _make_side_effect(
         '{"message": "刚才在公园长椅上眯了一会儿，被鸽子踩醒了"}',
-        {},
     )
 
     result = await agent.generate_share_message(base_context)
 
     assert result == "刚才在公园长椅上眯了一会儿，被鸽子踩醒了"
-    mock_llm_router.generate_with_forced_tool.assert_called_once()
-    call_kwargs = mock_llm_router.generate_with_forced_tool.call_args.kwargs
+    mock_llm_router.generate.assert_called_once()
+    call_kwargs = mock_llm_router.generate.call_args.kwargs
     assert call_kwargs["model_tier"] == ModelTier.AUXILIARY
     assert call_kwargs["temperature"] == 0.85
-    assert "record_share_message" in call_kwargs["tool_name"]
+    assert "tools" in call_kwargs
+    assert call_kwargs["max_tool_rounds"] == 3
 
 
 @pytest.mark.asyncio
 async def test_generate_share_message_strip_quotes(agent, mock_llm_router, base_context):
     """去除消息中的引号"""
-    mock_llm_router.generate_with_forced_tool.return_value = (
+    mock_llm_router.generate.side_effect = _make_side_effect(
         '{"message": "\\"带引号的消息\\""}',
-        {},
     )
 
     result = await agent.generate_share_message(base_context)
@@ -87,9 +98,8 @@ async def test_generate_share_message_strip_quotes(agent, mock_llm_router, base_
 async def test_generate_share_message_truncate_long(agent, mock_llm_router, base_context):
     """超长消息被截断到 config.max_chars"""
     long_msg = "哈" * 300
-    mock_llm_router.generate_with_forced_tool.return_value = (
+    mock_llm_router.generate.side_effect = _make_side_effect(
         f'{{"message": "{long_msg}"}}',
-        {},
     )
 
     result = await agent.generate_share_message(base_context)
@@ -99,76 +109,35 @@ async def test_generate_share_message_truncate_long(agent, mock_llm_router, base
 
 
 @pytest.mark.asyncio
-async def test_generate_share_message_timeout_raises(agent, mock_llm_router, base_context):
-    """超时错误直接抛出，由 LLMClient 内层处理，event_agent 层不重试"""
-    mock_llm_router.generate_with_forced_tool.side_effect = asyncio.TimeoutError
-
-    with pytest.raises(asyncio.TimeoutError):
-        await agent.generate_share_message(base_context)
-
-    assert mock_llm_router.generate_with_forced_tool.call_count == 1
-    assert mock_llm_router.generate_with_forced_tool.call_args.kwargs["timeout"] == 10
-
-
-@pytest.mark.asyncio
-async def test_generate_share_message_llm_error_raises(agent, mock_llm_router, base_context):
-    """LLM 网络/API 错误直接抛出，由 LLMClient 内层处理，event_agent 层不重试"""
-    mock_llm_router.generate_with_forced_tool.side_effect = Exception("LLM 错误")
-
-    with pytest.raises(Exception, match="LLM 错误"):
-        await agent.generate_share_message(base_context)
-
-    assert mock_llm_router.generate_with_forced_tool.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_generate_share_message_json_decode_retry(agent, mock_llm_router, base_context):
-    """JSON 解析失败时 event_agent 层重试"""
-    mock_llm_router.generate_with_forced_tool.side_effect = [
-        ("invalid json", {}),
-        ('{"message": "第二次成功了"}', {}),
-    ]
+async def test_generate_share_message_llm_error_returns_none(agent, mock_llm_router, base_context):
+    """LLM 错误时返回 None"""
+    mock_llm_router.generate.side_effect = Exception("LLM 错误")
 
     result = await agent.generate_share_message(base_context)
 
-    assert result == "第二次成功了"
-    assert mock_llm_router.generate_with_forced_tool.call_count == 2
+    assert result is None
 
 
 @pytest.mark.asyncio
-async def test_generate_share_message_forced_tool_error_retry(agent, mock_llm_router, base_context):
-    """ForcedToolError 时 event_agent 层重试"""
-    mock_llm_router.generate_with_forced_tool.side_effect = [
-        ForcedToolError("模型未调用工具", raw_content="raw"),
-        ('{"message": "第二次成功了"}', {}),
-    ]
-
-    result = await agent.generate_share_message(base_context)
-
-    assert result == "第二次成功了"
-    assert mock_llm_router.generate_with_forced_tool.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_generate_share_message_forced_tool_error_exhausted(agent, mock_llm_router, base_context):
-    """ForcedToolError 耗尽重试次数后返回 None"""
-    mock_llm_router.generate_with_forced_tool.side_effect = ForcedToolError(
-        "模型未调用工具", raw_content="raw"
+async def test_generate_share_message_empty_message(agent, mock_llm_router, base_context):
+    """LLM 返回空消息时返回 None"""
+    mock_llm_router.generate.side_effect = _make_side_effect(
+        '{"message": ""}',
     )
 
     result = await agent.generate_share_message(base_context)
 
     assert result is None
-    assert mock_llm_router.generate_with_forced_tool.call_count == 3  # 1 + max_retries(2)
 
 
 @pytest.mark.asyncio
-async def test_generate_share_message_empty_message(agent, mock_llm_router, base_context):
-    """LLM 返回空消息时继续重试"""
-    mock_llm_router.generate_with_forced_tool.return_value = (
-        '{"message": ""}',
-        {},
-    )
+async def test_generate_share_message_no_collected(agent, mock_llm_router, base_context):
+    """LLM 未调用工具时返回 None"""
+    # side_effect 不调用 tool_executor → executor.collected 为空
+    async def no_tool_call(**kwargs):
+        return "text without tool", {}
+
+    mock_llm_router.generate.side_effect = no_tool_call
 
     result = await agent.generate_share_message(base_context)
 
@@ -178,34 +147,32 @@ async def test_generate_share_message_empty_message(agent, mock_llm_router, base
 @pytest.mark.asyncio
 async def test_generate_share_message_few_shot_default(agent, mock_llm_router, base_context):
     """默认 few-shot 示例被注入 prompt"""
-    mock_llm_router.generate_with_forced_tool.return_value = (
+    mock_llm_router.generate.side_effect = _make_side_effect(
         '{"message": "测试消息"}',
-        {},
     )
 
     await agent.generate_share_message(base_context)
 
-    call_kwargs = mock_llm_router.generate_with_forced_tool.call_args.kwargs
+    call_kwargs = mock_llm_router.generate.call_args.kwargs
     messages = call_kwargs["messages"]
     system_prompt = messages[0]["content"]
     assert "示例:" in system_prompt
     assert "鸽子" in system_prompt
-    assert "七七" in system_prompt  # 角色名替换
-    assert "{{character_name}}" not in system_prompt  # 占位符已被替换
+    assert "七七" in system_prompt
+    assert "{{character_name}}" not in system_prompt
 
 
 @pytest.mark.asyncio
 async def test_generate_share_message_few_shot_empty_list(agent, mock_llm_router, base_context):
     """空列表时不注入 few-shot"""
     base_context.share_message_examples = []
-    mock_llm_router.generate_with_forced_tool.return_value = (
+    mock_llm_router.generate.side_effect = _make_side_effect(
         '{"message": "测试消息"}',
-        {},
     )
 
     await agent.generate_share_message(base_context)
 
-    call_kwargs = mock_llm_router.generate_with_forced_tool.call_args.kwargs
+    call_kwargs = mock_llm_router.generate.call_args.kwargs
     messages = call_kwargs["messages"]
     system_prompt = messages[0]["content"]
     assert "示例:" not in system_prompt
@@ -217,14 +184,13 @@ async def test_generate_share_message_few_shot_custom(agent, mock_llm_router, ba
     base_context.share_message_examples = [
         "场景：下雨了\n消息：\"下雨了，记得带伞\"\n→ 好示例"
     ]
-    mock_llm_router.generate_with_forced_tool.return_value = (
+    mock_llm_router.generate.side_effect = _make_side_effect(
         '{"message": "测试消息"}',
-        {},
     )
 
     await agent.generate_share_message(base_context)
 
-    call_kwargs = mock_llm_router.generate_with_forced_tool.call_args.kwargs
+    call_kwargs = mock_llm_router.generate.call_args.kwargs
     messages = call_kwargs["messages"]
     system_prompt = messages[0]["content"]
     assert "下雨了" in system_prompt
@@ -235,9 +201,8 @@ async def test_generate_share_message_few_shot_custom(agent, mock_llm_router, ba
 async def test_generate_share_message_no_config_fallback(agent, mock_llm_router, base_context):
     """未传入 config 时使用默认值"""
     agent_no_config = EventGenerationAgent(mock_llm_router)
-    mock_llm_router.generate_with_forced_tool.return_value = (
+    mock_llm_router.generate.side_effect = _make_side_effect(
         '{"message": "默认行为"}',
-        {},
     )
 
     result = await agent_no_config.generate_share_message(base_context)

--- a/tests/unit/persona/test_phase3_features.py
+++ b/tests/unit/persona/test_phase3_features.py
@@ -204,11 +204,6 @@ class TestConfigValues:
         config = PersonaConfig()
         assert config.max_messages == 15
 
-    def test_tools_enabled(self):
-        """tools_enabled 应该为 True"""
-        config = PersonaConfig()
-        assert config.tools_enabled is True
-
     def test_relationship_refuse_enabled(self):
         """relationship_refuse_enabled 应该默认为 True"""
         config = PersonaConfig()

--- a/tests/unit/persona/test_round_messages_e2e.py
+++ b/tests/unit/persona/test_round_messages_e2e.py
@@ -41,10 +41,10 @@ async def test_round_messages_e2e():
     content, metadata = await router._execute_and_trace(
         client=client,
         tier_name="primary",
-        call_coro=client.chat_with_tools(
+        call_coro=client.generate(
             messages=[{"role": "user", "content": "hi"}],
-            tools=[],
-            max_tool_rounds=3,
+            tools=[{"type": "function", "function": {"name": "test_tool"}}],
+            max_round_callbacks=0,
         ),
         session_id="s1",
         user_id="u1",
@@ -52,7 +52,7 @@ async def test_round_messages_e2e():
         messages=[{"role": "user", "content": "hi"}],
         temperature=None,
         model_tier="primary",
-        is_tools=False,
+        is_tools=True,
     )
 
     await asyncio.sleep(0.5)

--- a/tests/unit/persona/test_scoring.py
+++ b/tests/unit/persona/test_scoring.py
@@ -1,0 +1,144 @@
+"""
+单元测试: ScoringAgent 工具路径
+
+覆盖 CollectExecutor 收集、fallback、JSON 解析失败三种路径。
+"""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from plugins.DicePP.module.persona.chat.scoring import ScoringAgent
+from plugins.DicePP.module.persona.data.models import ScoreDeltas
+
+
+def _make_side_effect(args_json: str, tool_name: str = "score_relationship"):
+    """创建 router.generate 的 side_effect，调用 tool_executor 填充 CollectExecutor"""
+    async def side_effect(**kwargs):
+        tool_executor = kwargs.get("tool_executor")
+        if tool_executor:
+            tc = {
+                "id": "tc_1",
+                "name": tool_name,
+                "arguments": args_json,
+            }
+            await tool_executor([tc])
+        return "", {}
+    return side_effect
+
+
+@pytest.fixture
+def mock_router():
+    router = MagicMock()
+    router.generate = AsyncMock()
+    return router
+
+
+@pytest.fixture
+def agent(mock_router):
+    return ScoringAgent(mock_router, timezone="Asia/Shanghai", max_tool_rounds=3)
+
+
+class TestScoringToolPath:
+    """测试 ScoringAgent 工具路径"""
+
+    @pytest.mark.asyncio
+    async def test_normal_tool_call_collection(self, agent, mock_router):
+        """正常工具调用收集 → _extract_result 解析"""
+        mock_router.generate.side_effect = _make_side_effect(
+            '{"deltas": {"intimacy": 1.5, "passion": 0, "trust": 0.5, "secureness": 0}, '
+            '"facts": {"爱好": "摄影"}}',
+        )
+
+        result = await agent.batch_analyze(
+            messages=[
+                {"role": "user", "content": "你好"},
+                {"role": "assistant", "content": "你好！"},
+            ],
+        )
+
+        assert result.deltas.intimacy == 1.5
+        assert result.deltas.passion == 0.0
+        assert result.deltas.trust == 0.5
+        assert result.facts == {"爱好": "摄影"}
+        assert result.parse_error == ""
+        mock_router.generate.assert_called_once()
+        call_kwargs = mock_router.generate.call_args.kwargs
+        assert call_kwargs["tools"] is not None
+        assert call_kwargs["tool_executor"] is not None
+
+    @pytest.mark.asyncio
+    async def test_empty_collected_fallback_to_parse_response(self, agent, mock_router):
+        """executor.collected 为空 → fallback 到 _parse_response(content)"""
+        response_json = (
+            '{"deltas": {"intimacy": -1.0, "passion": 0, "trust": 0, "secureness": 0}, '
+            '"facts": {}}'
+        )
+
+        async def no_tool_call(**kwargs):
+            return response_json, {}
+
+        mock_router.generate.side_effect = no_tool_call
+
+        result = await agent.batch_analyze(
+            messages=[
+                {"role": "user", "content": "test"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        )
+
+        assert result.deltas.intimacy == -1.0
+        assert result.parse_error == ""
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failure(self, agent, mock_router):
+        """arguments JSON 解析失败 → parse_error 非空"""
+        mock_router.generate.side_effect = _make_side_effect(
+            "not valid json{{{",
+        )
+
+        result = await agent.batch_analyze(
+            messages=[
+                {"role": "user", "content": "test"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        )
+
+        assert result.parse_error != ""
+
+    @pytest.mark.asyncio
+    async def test_llm_call_failure(self, agent, mock_router):
+        """LLM 调用异常 → 返回 parse_error"""
+        mock_router.generate.side_effect = Exception("服务不可用")
+
+        result = await agent.batch_analyze(
+            messages=[
+                {"role": "user", "content": "test"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        )
+
+        assert "LLM 调用失败" in result.parse_error
+        assert result.deltas == ScoreDeltas()
+        assert result.facts == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_collected_and_empty_content(self, agent, mock_router):
+        """collected 为空且 content 为空 → fallback 返回空结果"""
+        async def no_tool_no_content(**kwargs):
+            return "", {}
+
+        mock_router.generate.side_effect = no_tool_no_content
+
+        result = await agent.batch_analyze(
+            messages=[
+                {"role": "user", "content": "test"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        )
+
+        assert result.deltas == ScoreDeltas()
+        assert result.parse_error != ""
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/persona/test_scoring_agent.py
+++ b/tests/unit/persona/test_scoring_agent.py
@@ -134,8 +134,7 @@ class TestScoringAgentPrompt:
         assert "你好" in prompt
         assert "你好呀~" in prompt
         assert "张三" in prompt
-        assert "deltas" in prompt
-        assert "facts" in prompt
+        assert "score_relationship" in prompt
 
     def test_build_prompt_empty_profile(self):
         """测试空档案的 Prompt"""


### PR DESCRIPTION
## 概要

将 Persona 模块的 LLM 调用从三条分散路径合并为参数化控制的单一 `generate()` 入口，所有场景天然支持多轮工具调用和纠正注入。

## 改动

### 统一入口

- `client.py`: 新增 `generate()` 统一方法，`tools` 参数控制纯文本/工具路径自动分发。内置 L1 纠正注入（`tool_choice="required"` 时空 tool_calls 自动注入 `[系统指令]`），支持 L2 领域回调。`tool_round_num` 达到上限后早退终止，避免无效轮次浪费
- `router.py`: 合并 `generate()` + `generate_with_tools()` + `generate_with_forced_tool()` 为一个入口，保持 tier 选择/semaphore/trace 不变
- `collect_executor.py`: 新增 `CollectExecutor` 类，收集工具调用参数不执行副作用，后台场景共用

### 删除

- `ForcedToolError` 类（LLM 不调工具由 L1 纠正处理）
- `chat()`、`chat_with_tools()`、`generate_with_forced_tool()` 方法
- `tools_enabled=false` 分支（聊天永远走工具路径）
- `tools_enabled` 配置字段（失活且用户要求删除）

### 调用方迁移（7 处）

- 分享/事件/反应/日记/评分/观察 → 工具路径 + `CollectExecutor`
- 聊天 → `router.generate()` + `tool_choice` 按分段开关切换

### 配置

- 新增 `background_llm_max_tool_rounds`（默认 1，单工具场景首轮即停）
- 聊天复用 `tools_max_rounds`（默认 5）

## 测试

- 单元测试 501 passed（3 轮 review 闭环）
- LLM 实调验证：纯文本/工具路径/L1 纠正 3 场景通过