### PR TITLE
refactor(persona): 对话历史从 system 拆出为独立 user/assistant 消息对

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -23,20 +23,6 @@
   - 方案B: 将 `recent_history` 改为"关系背景"摘要而非原始对话，从源头消除补答动机
   - 影响面: `event_agent.py` `generate_share_message` prompt、`proactive_scheduler.py` `_format_recent_history`
 
-### [B-260511-a0c5f6] system prompt 中"近期对话"占比过高，缺乏摘要压缩
-- 创建: 2026-05-11
-- 问题表现:
-  - 18:02 对话的 system prompt 实测 2821 字符，"近期对话"板块占约 70%
-  - 7 轮完整角色扮演对话（含换行、括号动作描述）全部原文注入 system prompt
-  - `max_short_term_chars=1500` 按字符截断但仍是原文，不区分信息密度
-  - LLM 需要从大量对话噪音中提取关系线索，token 利用率低
-- 工作计划:
-  - 对超过 N 轮的历史对话做摘要压缩：`"{日期} 聊了关于{主题}的内容，关系{变化}"`
-  - 或考虑将历史对话放在 `user` 消息而非 `system` 消息中，区分角色设定层和对话上下文层
-  - 短期可降低 `max_short_term_chars` 缓解，但长期需要摘要机制
-  - 影响面: `context.py` `ContextBuilder.build`、`_format_short_term`、session 截断策略
-
-
 ### [B-260512-f2d8a1] tool_choice="required" 场景缺少显式终止机制
 - 创建: 2026-05-12
 - 问题表现:
@@ -48,3 +34,68 @@
   - 作为通用终止方案，统一单工具和多工具场景
   - 影响面: `client.py:_generate_with_tools` 循环终止条件、后台 Agent prompt
   - 前置条件: 当前 `max_tool_rounds=1` 已覆盖，本条为架构扩展预留
+
+### [B-260513-a1b2c3] 统一消息存储：多源消息汇总入库 + LLM 工具检索
+- 创建: 2026-05-13
+- 问题表现:
+  - 当前消息分散存储在三套表：`messages`（私聊对话）、`group_conversations`（群聊对话）、`observation_buffer`（旁听暂存）
+  - 非对话指令（掷骰 `.r`、规则查询 `.q` 等）完全不落库，LLM 无法感知用户的指令行为
+  - 消息发送结果（成功/失败）仅在 `_persist_assistant_message` 写入后隐式成功，发送失败时无记录
+  - LLM 的 `search_chat_history` 工具只能检索 `messages` 表，不能跨群聊/私聊或查看掷骰历史
+  - 数据模型不统一（`Message` vs `GroupConversation` vs `Observation`），每加一个数据源需新增表 + 独立 API
+- 工作计划:
+
+  **1. 数据层 — 统一消息表**
+  - 新建 `unified_messages` 表：
+    ```
+    id, user_id, group_id, role, type, content, display_name,
+    sent_ok, tool_call_id, created_at
+    ```
+  - `role`: `user` / `assistant` / `system` / `tool`
+  - `type`: `chat`（对话消息）、`dice_command`（`.r 3d6` 之类）、`system_notice`（系统指令注入，如 [[系统指令]]）、`send_result`（发送状态回执）
+  - `sent_ok`: `True` / `False` / `NULL`（非 assistant 消息无意义时为 NULL）
+  - `group_id` 为空表示私聊；有值为群聊
+  - 该表替代现有的 `messages`、`group_conversations`、`observation_buffer` 三张表
+
+  **2. 采集层 — 全量消息拦截**
+  - 在 message pipeline / command 层统一 hook：所有用户消息（含掷骰指令、规则查询等）在进入具体 handler 之前先写入 `unified_messages`
+  - 消息写入时机：前置 hook（handler 执行前），`sent_ok` 初始为 NULL，发送结果后续回填
+  - 现有采集点迁移：
+    - `chat()` 中的 `store.add_message()` / `store.add_group_conversation()` → 改为写 `unified_messages`
+    - `_persist_assistant_message()` → 改为写 `unified_messages` 并回填 `sent_ok`
+    - `command.py` 中的 `_group_chat_recorder()` → 改为写 `unified_messages`
+
+  **3. 保留策略 — 滚动 + 保底**
+  - 总容量上限：每 `(user_id, group_id)` 组合保留最近 N 条（默认 1000）
+  - 保底：每个群/私聊至少保留最近 M 条（默认 50），即使超出总上限
+  - 清理触发：写入后检查，超出上限时按 `created_at` 删最旧的
+  - 独立于 LLM 上下文截断（`max_history_turns` / `max_history_tokens`），后者继续在获取时做窗口截断
+
+  **4. LLM 数据消费**
+  - 对话上下文构建（`_fetch_short_term_history` → `format_history` → `truncate_by_turns`）：
+    - 从 `unified_messages` 读取，筛选 `type=chat`（或包含 `type=chat` + `type=dice_command`，待讨论）
+    - LLM 能看到同一会话中的掷骰结果等非对话内容，但通过 `role`/`type` 区分不是 bot 发出的
+  - 工具检索（`search_chat_history`）：
+    - 扩展为跨会话查询，支持按 `type` / `user_id` / `group_id` / 时间范围筛选
+    - 返回精简摘要而非原文全文（字符上限控制）
+
+  **5. observe_group 存废**
+  - 如果保留：将现有的 `observation_buffer` 采集 path 改为从 `unified_messages` 表筛选：
+    ```sql
+    WHERE group_id = ? AND type = 'chat' AND NOT (role = 'assistant')
+          AND created_at > ? ORDER BY created_at DESC
+    ```
+    阈值逻辑（`observe_min_length` / `observe_initial_threshold` 等）不变
+  - 如果取消：直接删除 `observation_buffer` 表、`observe_group_enabled` 配置项、`command.py` 中的 `_group_chat_recorder` 旁听分支
+
+  **6. 迁移策略**
+  - 旧表数据（`messages` / `group_conversations` / `observation_buffer`）做一次性迁移到 `unified_messages`
+  - `observation_buffer` 在迁移后直接删除（无论 observe_group 是否保留，其数据均归入统一表）
+  - `messages` / `group_conversations` 保留旧表作为回滚备份，后续版本删除
+
+  **7. 配置变更**
+  - PersonaConfig 新增：
+    - `unified_message_max_total: int = 1000` — 每 `(user_id, group_id)` 总条数上限
+    - `unified_message_min_retain: int = 50` — 每 `(user_id, group_id)` 保底保留条数
+  - `observe_group_enabled` 暂保留，取决于 observe_group 存废讨论结论
+

--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -42,16 +42,16 @@ class PersonaConfig(BaseModel):
     timezone: str = "Asia/Shanghai"
 
     # ── Phase 3: 短期记忆限制
-    # 两个限制同时生效，语义如下：
     # - max_messages: 数据库中保留的消息条数上限（user + assistant 各算一条）
-    # - max_short_term_chars: 注入上下文的短期记忆字符上限（包括 user 和 assistant 的内容）
-    # 注意：这是按总字数限制，如果消息较长，实际注入的轮数可能少于 max_messages
-    # 例如：每轮 300 字（user 100 + assistant 200），1500 字只能容纳约 5 轮
-    max_short_term_chars: int = 1500  # 从 3000 改为 1500（配合工具调用）
-    max_messages: int = 15  # 从 200 改为 15（约 7-8 轮对话）
+    # - max_history_turns: 注入上下文的对话轮次上限（user/assistant 消息对）
+    # - max_history_tokens: 注入上下文的历史 token 估算上限（基于字符统计，兜底截断）
+    max_short_term_chars: int = 1500  # 已废弃：运行时不再使用，保留字段避免配置解析报错。迁移至 max_history_turns + max_history_tokens
+    max_messages: int = 15
+    max_history_turns: int = 10
+    max_history_tokens: int = 4000
 
     # ── 群聊共享历史限制（token-based 动态窗口）
-    # 群聊使用 token 估算（与 LLM 上下文窗口对齐），私聊使用字符数（max_short_term_chars）。
+    # 群聊使用 token 估算（与 LLM 上下文窗口对齐），私聊使用轮次 + token 估算双重兜底（max_history_turns + max_history_tokens）。
     # 两者计量单位不同，token 估算基于字符统计，为性能考虑不引入真实 tokenizer。
     group_max_messages: int = 40  # 群聊数据库保留条数上限
     group_max_age_minutes: int = 10  # 群聊时间窗口上限（分钟）
@@ -152,6 +152,22 @@ class PersonaConfig(BaseModel):
                     "配置项 'event_generation_timeout' / 'proactive_share_timeout_seconds' "
                     "已被重命名为 'background_llm_timeout_seconds'，当前旧字段的值将被忽略"
                     "（新字段已存在）。"
+                )
+
+        # 跨语义迁移: max_short_term_chars → max_history_turns + max_history_tokens
+        # 字符数到轮次无精确公式，启发式估算：假设每轮约 300 字符。
+        if "max_short_term_chars" in data:
+            old_val = data["max_short_term_chars"]
+            if old_val != 1500:
+                if "max_history_turns" not in data:
+                    data["max_history_turns"] = max(5, old_val // 300)
+                if "max_history_tokens" not in data:
+                    data["max_history_tokens"] = old_val
+                logger.warning(
+                    "配置项 'max_short_term_chars' 已废弃，已自动迁移至 "
+                    f"'max_history_turns'={data.get('max_history_turns')} + "
+                    f"'max_history_tokens'={data.get('max_history_tokens')}。"
+                    "转换值为估算（假设每轮约 300 字符），建议手动核实。"
                 )
 
         return data

--- a/src/plugins/DicePP/module/persona/chat/context.py
+++ b/src/plugins/DicePP/module/persona/chat/context.py
@@ -33,13 +33,15 @@ class ContextBuilder:
     def __init__(
         self,
         character: Character,
-        max_short_term_chars: int = 1500,
+        max_history_turns: int = 10,
+        max_history_tokens: int = 4000,
         timezone: str = "Asia/Shanghai",
         lore_token_budget: int = 300,
         segment_guide: Optional[SegmentGuide] = None,
     ):
         self.character = character
-        self.max_short_term_chars = max_short_term_chars
+        self.max_history_turns = max_history_turns
+        self.max_history_tokens = max_history_tokens
         self.timezone = timezone
         self.lore_token_budget = lore_token_budget
         self.segment_guide = segment_guide
@@ -50,7 +52,8 @@ class ContextBuilder:
 
     def build(
         self,
-        short_term_history: List[Dict[str, str]],
+        formatted_history: List[Dict[str, str]],
+        history_dicts: List[Dict[str, str]],
         user_profile: Optional[UserProfile] = None,
         diary_context: str = "",
         current_message: str = "",
@@ -58,11 +61,11 @@ class ContextBuilder:
     ) -> List[Dict[str, str]]:
         messages = []
 
+        # 世界书扫描仍用 raw dicts（未格式化的 content 避免时间戳/speaker 前缀干扰匹配）
+        lore_sections = self.build_lore_text(history_dicts, current_message)
+
         # 合并所有 system 内容为一条（某些提供商如 MiniMax 不支持多条 system 消息）
         system_parts = []
-
-        # 世界书扫描（按位置分类，为后续 LoreEntry.position 扩展留接口）
-        lore_sections = self.build_lore_text(short_term_history, current_message)
 
         system_prompt = self._build_system_prompt(user_profile, diary_context, warmth_label, lore_sections)
         system_parts.append(system_prompt)
@@ -71,12 +74,11 @@ class ContextBuilder:
             example = self.character.format_mes_example()
             system_parts.append(f"示例对话:\n{example}")
 
-        short_term_text = self._format_short_term(short_term_history)
-        if short_term_text:
-            system_parts.append(f"近期对话:\n{short_term_text}")
-
-        # 合并为单条 system 消息
         messages.append({"role": "system", "content": "\n\n".join(system_parts)})
+
+        # 追加格式化后的历史消息对
+        for msg in formatted_history:
+            messages.append({"role": msg["role"], "content": msg["content"]})
 
         if current_message:
             messages.append({"role": "user", "content": current_message})
@@ -85,10 +87,13 @@ class ContextBuilder:
 
     def build_lore_text(
         self,
-        short_term_history: List[Dict[str, str]],
+        history_dicts: List[Dict[str, str]],
         current_message: str,
     ) -> Dict[str, List[str]]:
         """扫描文本并返回按位置分类的世界书内容
+
+        history_dicts 的 content 字段应为原始内容（无格式化前缀），
+        世界书关键词扫描依赖纯净文本。
 
         返回结构为 {"before_char": [...], "after_char": [...]}，
         即使目前 LoreEntry 没有 position 字段，也为后续扩展留接口。
@@ -99,7 +104,7 @@ class ContextBuilder:
             return sections
 
         texts_to_scan = [current_message] if current_message is not None else []
-        for msg in short_term_history:
+        for msg in history_dicts:
             texts_to_scan.append(msg.get("content", ""))
 
         matched = self.character.search_lore_entries(texts_to_scan)
@@ -217,38 +222,123 @@ class ContextBuilder:
 
         return "\n\n".join(parts)
 
-    def _format_short_term(self, history: List[Dict[str, str]]) -> str:
-        """格式化短期记忆，根据 speaker_name 生成称呼前缀，附带时间戳"""
-        lines = []
+    def _format_private_history(self, history: List[Dict]) -> List[Dict[str, str]]:
+        """私聊历史格式化：按 role 直接映射，content 加 [HH:MM] 时间戳前缀"""
+        if not history:
+            return []
         now = persona_wall_now(self.timezone)
+        result = []
         for msg in history:
-            speaker_name = msg.get("speaker_name") or ("你" if msg["role"] == "user" else "我")
-            prefix = format_timestamp(msg.get("created_at"), now)
-            if prefix:
-                lines.append(f"[{prefix}] [{speaker_name}] {msg['content']}")
+            ts = format_timestamp(msg.get("created_at"), now)
+            prefix = f"[{ts}] " if ts else ""
+            result.append({
+                "role": msg["role"],
+                "content": f"{prefix}{msg['content']}",
+            })
+        return result
+
+    def _format_group_history(self, history: List[Dict]) -> List[Dict[str, str]]:
+        """群聊历史格式化：连续非 assistant 合并为单条 user
+
+        每行格式为 ``[HH:MM] [speaker_name] content``。
+        speaker_name 缺失时 fallback 为 ``"系统"``。
+        """
+        if not history:
+            return []
+        now = persona_wall_now(self.timezone)
+        result = []
+        buffer = []
+
+        def flush_buffer():
+            if not buffer:
+                return
+            lines = []
+            for m in buffer:
+                ts = format_timestamp(m.get("created_at"), now)
+                ts_prefix = f"[{ts}] " if ts else ""
+                speaker = m.get("speaker_name") or "系统"
+                lines.append(f"{ts_prefix}[{speaker}] {m['content']}")
+            result.append({"role": "user", "content": "\n".join(lines)})
+            buffer.clear()
+
+        for msg in history:
+            role = msg.get("role", "user")
+            if role == "assistant":
+                flush_buffer()
+                ts = format_timestamp(msg.get("created_at"), now)
+                prefix = f"[{ts}] " if ts else ""
+                result.append({
+                    "role": "assistant",
+                    "content": f"{prefix}{msg['content']}",
+                })
             else:
-                lines.append(f"[{speaker_name}] {msg['content']}")
-        return "\n".join(lines)
+                buffer.append(msg)
 
-    def truncate_by_turns(self, history: List[Dict[str, str]], max_chars: int) -> List[Dict[str, str]]:
-        """按对话轮次截断，从后往前保留完整的 user-assistant 对
+        flush_buffer()
+        return result
 
-        避免截断在对话中间，保持上下文完整性。
+    def format_history(self, history: List[Dict], is_group: bool) -> List[Dict[str, str]]:
+        """格式化历史消息统一入口，根据 is_group 派发私聊/群聊路径"""
+        if is_group:
+            return self._format_group_history(history)
+        return self._format_private_history(history)
+
+    def truncate_by_turns(
+        self, history: List[Dict[str, str]], max_turns: int, max_tokens: int
+    ) -> List[Dict[str, str]]:
+        """按轮次 + token 双重兜底从后往前截断
+
+        一轮 = 一个 user + 一个 assistant 消息对。
+        始终保留完整轮次，不拆散对。
+        末尾孤立的 user 消息保留。
+
+        输入必须已按 user/assistant 交替排列（开头可能多一个 assistant，末尾可能多一个
+        user 或 assistant）。此契约由上游格式化函数 _format_private_history /
+        _format_group_history 保证。
         """
         if not history:
             return []
 
-        # 从后往前累计
-        result = []
-        total_chars = 0
+        orphan = None
+        work = list(history)
 
-        for msg in reversed(history):
-            msg_chars = len(msg.get("content", ""))
-            # 如果超限制且已保留至少一条，停止
-            if total_chars + msg_chars > max_chars and result:
+        # 兜底：剥离开头孤立的 assistant（后续配对以 user 开头）
+        leading = None
+        if work and work[0]["role"] == "assistant":
+            leading = work.pop(0)
+
+        if work and work[-1]["role"] == "user":
+            orphan = work.pop()
+
+        # 按轮次分组 (user + assistant)
+        turns = []
+        for i in range(0, len(work) - 1, 2):
+            if work[i]["role"] == "user" and work[i + 1]["role"] == "assistant":
+                turns.append((work[i], work[i + 1]))
+
+        result = []
+        total_tokens = 0.0
+        for user_msg, assistant_msg in reversed(turns):
+            pair_cost = estimate_tokens(user_msg.get("content", "")) + estimate_tokens(
+                assistant_msg.get("content", "")
+            )
+            if len(result) // 2 >= max_turns:
                 break
-            result.insert(0, msg)  # 插入头部保持顺序
-            total_chars += msg_chars
+            if total_tokens + pair_cost > max_tokens and result:
+                break
+            result.insert(0, assistant_msg)
+            result.insert(0, user_msg)
+            total_tokens += pair_cost
+
+        if leading:
+            result.insert(0, leading)
+
+        # 兜底：末尾孤立 assistant（len(work) 奇数时最后一个元素未被 range 覆盖）
+        if len(work) % 2 == 1 and work and work[-1]["role"] == "assistant":
+            result.append(work[-1])
+
+        if orphan:
+            result.append(orphan)
 
         return result
 
@@ -266,13 +356,14 @@ class ContextBuilder:
             warmth_label=warmth_label,
             lore_sections=lore_sections or self.build_lore_text(short_term_history, ""),
         )
-        short_term_text = self._format_short_term(short_term_history)
+        # short_term_history 已由调用方格式化并截断（truncated），直接统计即可
+        formatted_chars = sum(len(msg.get("content", "")) for msg in short_term_history)
         profile_text = ""
         if user_profile and user_profile.facts:
             profile_text = "\n".join([f"- {k}: {v}" for k, v in user_profile.facts.items()])
         return {
             "system_prompt_chars": len(system_prompt),
-            "short_term_chars": len(short_term_text),
+            "short_term_chars": formatted_chars,
             "profile_chars": len(profile_text),
             "diary_chars": len(diary_context),
             "returned_message_count": 1 + len(short_term_history),

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -52,7 +52,9 @@ if TYPE_CHECKING:
 class ChatConfig:
     """对话域配置（从 PersonaConfig 中提取的子集）"""
 
-    max_short_term_chars: int = 1500
+    max_history_turns: int = 10
+    max_history_tokens: int = 4000
+    max_diary_context_chars: int = 500
     timezone: str = "Asia/Shanghai"
     lore_token_budget: int = 300
     tools_max_rounds: int = 5
@@ -77,7 +79,9 @@ class ChatConfig:
     @classmethod
     def from_persona(cls, persona: "PersonaConfig") -> "ChatConfig":
         return cls(
-            max_short_term_chars=persona.max_short_term_chars,
+            max_history_turns=persona.max_history_turns,
+            max_history_tokens=persona.max_history_tokens,
+            max_diary_context_chars=persona.max_diary_context_chars,
             timezone=persona.timezone,
             lore_token_budget=persona.lore_token_budget,
             tools_max_rounds=persona.tools_max_rounds,
@@ -708,22 +712,21 @@ class ChatSession:
         self,
         user_id: str,
         group_id: str,
-        limit: int = 15,
+        limit: Optional[int] = None,
     ) -> Tuple[List[Dict[str, str]], bool]:
         """获取并格式化近期对话历史
 
         Returns: (history_dicts, was_truncated)
         """
+        if limit is None:
+            limit = self.config.max_messages
         if not group_id:
             history = await self.store.get_recent_messages(user_id, group_id, limit=limit)
             history_dicts = [
                 {"role": msg.role, "content": msg.content, "speaker_name": "你" if msg.role == "user" else "我", "created_at": msg.created_at}
                 for msg in history
             ]
-            truncated = self.context_builder.truncate_by_turns(
-                history_dicts, self.config.max_short_term_chars
-            )
-            return truncated, len(truncated) < len(history_dicts)
+            return history_dicts, False
 
         history = await self.store.get_group_conversations(group_id, limit=None)
         return self._apply_token_window(history)
@@ -767,7 +770,9 @@ class ChatSession:
                     content = content[:-1]
 
             speaker_name = "我" if msg.role == "assistant" else (msg.display_name or "群友")
-            formatted = f"[{speaker_name}] {content}"
+            ts = format_timestamp(msg.created_at, now)
+            ts_prefix = f"[{ts}] " if ts else ""
+            formatted = f"{ts_prefix}[{speaker_name}] {content}"
             msg_cost = estimate_tokens(formatted)
 
             if total_tokens + msg_cost > budget and result:
@@ -807,7 +812,7 @@ class ChatSession:
         wall = persona_wall_now(self.config.timezone)
         today = wall.strftime("%Y-%m-%d")
         yesterday = (wall - timedelta(days=1)).strftime("%Y-%m-%d")
-        max_diary_len = self.config.max_short_term_chars  # 复用同一配置
+        max_diary_len = self.config.max_diary_context_chars
 
         events = await self.store.get_daily_events(today)
         if events:
@@ -854,6 +859,21 @@ class ChatSession:
         current_message: str,
     ) -> List[Dict[str, str]]:
         history_dicts, _ = await self._fetch_short_term_history(user_id, group_id)
+        is_group = bool(group_id)
+
+        formatted = self.context_builder.format_history(history_dicts, is_group)
+        # 群聊双层截断：_apply_token_window 在存储层按时间窗口 + token budget + max messages
+        # 做首轮过滤，truncate_by_turns 在格式化后按 max_history_turns + max_history_tokens 兜底。
+        # 当前 max_history_tokens=4000 > group_context_budget_tokens=2000，第二层通常不触发。
+        # WHY 群聊保留双层：_apply_token_window 负责群聊特有的时间窗口收敛和说话人合并，
+        # 这些逻辑超出 truncate_by_turns 通用截断的职责范围。私聊消息直接来自 DB 按时间升序，
+        # 无需首层过滤，因此仅走 truncate_by_turns 单层截断。
+        truncated = self.context_builder.truncate_by_turns(
+            formatted,
+            self.config.max_history_turns,
+            self.config.max_history_tokens,
+        )
+
         profile = await self.store.get_user_profile(user_id)
         rel = await self.store.get_relationship(user_id)
         warmth_label = self._resolve_warmth_label(user_id, rel)
@@ -861,7 +881,7 @@ class ChatSession:
         lore_sections = self._build_lore_sections(history_dicts, current_message)
 
         debug_info = self.context_builder.build_debug_info(
-            short_term_history=history_dicts,
+            short_term_history=truncated,
             user_profile=profile,
             diary_context=diary_context,
             warmth_label=warmth_label,
@@ -870,7 +890,8 @@ class ChatSession:
         logger.debug(f"context_debug: {debug_info}")
 
         return self.context_builder.build(
-            short_term_history=history_dicts,
+            formatted_history=truncated,
+            history_dicts=history_dicts,
             user_profile=profile,
             diary_context=diary_context,
             current_message=current_message,

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -232,7 +232,8 @@ def _build_chat(
 
     context_builder = ContextBuilder(
         character,
-        max_short_term_chars=config.max_short_term_chars,
+        max_history_turns=config.max_history_turns,
+        max_history_tokens=config.max_history_tokens,
         timezone=config.timezone,
         lore_token_budget=config.lore_token_budget,
         segment_guide=segment_guide,

--- a/tests/unit/persona/test_chat_session.py
+++ b/tests/unit/persona/test_chat_session.py
@@ -65,7 +65,8 @@ def _make_session(
     context_builder = MagicMock()
     context_builder.build = MagicMock(return_value=[{"role": "user", "content": "hi"}])
     context_builder.build_debug_info = MagicMock(return_value="")
-    context_builder.truncate_by_turns = MagicMock(side_effect=lambda h, _: h)
+    context_builder.format_history = MagicMock(side_effect=lambda h, is_group: h)
+    context_builder.truncate_by_turns = MagicMock(side_effect=lambda h, *a, **kw: h)
     context_builder.build_lore_text = MagicMock(return_value={})
 
     return ChatSession(

--- a/tests/unit/persona/test_chat_session_charging.py
+++ b/tests/unit/persona/test_chat_session_charging.py
@@ -53,7 +53,8 @@ def _make_session(coordinator: LLMCallCoordinator) -> ChatSession:
     context_builder = MagicMock()
     context_builder.build = MagicMock(return_value=[{"role": "user", "content": "hi"}])
     context_builder.build_debug_info = MagicMock(return_value="")
-    context_builder.truncate_by_turns = MagicMock(side_effect=lambda h, _: h)
+    context_builder.format_history = MagicMock(side_effect=lambda h, is_group: h)
+    context_builder.truncate_by_turns = MagicMock(side_effect=lambda h, *a, **kw: h)
     context_builder.build_lore_text = MagicMock(return_value={})
 
     session = ChatSession(

--- a/tests/unit/persona/test_context_builder.py
+++ b/tests/unit/persona/test_context_builder.py
@@ -1,16 +1,27 @@
 """
-单元测试: ContextBuilder 世界书集成
+单元测试: ContextBuilder 世界书集成 / 历史格式化 / 截断 / 消息组装
 """
 
 import pytest
+from datetime import datetime, timedelta
 
 from plugins.DicePP.module.persona.character.models import Character, CharacterBook, LoreEntry
 from plugins.DicePP.module.persona.data.models import UserProfile
 from plugins.DicePP.module.persona.chat.context import ContextBuilder
 
+# 今天日期，用于构造同日时间戳（format_timestamp 同日返回 HH:MM）
+_TODAY = datetime.now().replace(hour=14, minute=0, second=0, microsecond=0)
+
+
+def _dt(minute: int = 0) -> datetime:
+    return _TODAY.replace(minute=minute)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 世界书集成
+# ═══════════════════════════════════════════════════════════════════
 
 class TestContextBuilderCharacterBook:
-    """测试 ContextBuilder 中的世界书注入"""
 
     def _make_character(self, entries):
         return Character(
@@ -26,7 +37,8 @@ class TestContextBuilderCharacterBook:
         builder = ContextBuilder(char, lore_token_budget=300)
         profile = UserProfile(user_id="u1", facts={"name": "小明"})
         messages = builder.build(
-            short_term_history=[{"role": "user", "content": "墨墨今天吃了什么？"}],
+            formatted_history=[{"role": "user", "content": "墨墨今天吃了什么？"}],
+            history_dicts=[{"role": "user", "content": "墨墨今天吃了什么？"}],
             current_message="墨墨在睡觉",
             user_profile=profile,
         )
@@ -41,7 +53,8 @@ class TestContextBuilderCharacterBook:
         ])
         builder = ContextBuilder(char, lore_token_budget=300)
         messages = builder.build(
-            short_term_history=[{"role": "user", "content": "今天又在加班"}],
+            formatted_history=[{"role": "user", "content": "今天又在加班"}],
+            history_dicts=[{"role": "user", "content": "今天又在加班"}],
             current_message="好累啊",
             diary_context="今天写了日记",
         )
@@ -56,7 +69,8 @@ class TestContextBuilderCharacterBook:
         ])
         builder = ContextBuilder(char, lore_token_budget=300)
         messages = builder.build(
-            short_term_history=[],
+            formatted_history=[],
+            history_dicts=[],
             current_message="今天天气不错",
         )
         system_content = messages[0]["content"]
@@ -67,29 +81,32 @@ class TestContextBuilderCharacterBook:
         char = self._make_character([entry])
         builder = ContextBuilder(char, lore_token_budget=300)
         messages = builder.build(
-            short_term_history=[
+            formatted_history=[
+                {"role": "user", "content": "墨墨好可爱"},
+                {"role": "assistant", "content": "橘猫确实很可爱"},
+            ],
+            history_dicts=[
                 {"role": "user", "content": "墨墨好可爱"},
                 {"role": "assistant", "content": "橘猫确实很可爱"},
             ],
             current_message="墨墨在睡觉",
         )
         system_content = messages[0]["content"]
-        # 只出现一次
         assert system_content.count("苏晓的猫叫墨墨。") == 1
 
     def test_token_budget_truncation(self):
         char = self._make_character([
-            LoreEntry(keys=["a"], content="x" * 100),   # cost = 25
-            LoreEntry(keys=["b"], content="x" * 200),   # cost = 50, would exceed budget=30
+            LoreEntry(keys=["a"], content="x" * 100),
+            LoreEntry(keys=["b"], content="x" * 200),
         ])
         builder = ContextBuilder(char, lore_token_budget=30)
         messages = builder.build(
-            short_term_history=[],
+            formatted_history=[],
+            history_dicts=[],
             current_message="a and b",
         )
         system_content = messages[0]["content"]
         assert "【世界书】" in system_content
-        # 只有第一条能注入
         assert system_content.count("x" * 100) == 1
         assert "x" * 200 not in system_content
 
@@ -100,38 +117,39 @@ class TestContextBuilderCharacterBook:
         ])
         builder = ContextBuilder(char, lore_token_budget=300)
         messages = builder.build(
-            short_term_history=[],
+            formatted_history=[],
+            history_dicts=[],
             current_message="出版社和猫",
         )
         system_content = messages[0]["content"]
         assert "【世界书】\n- 出版社在中关村。\n- 苏晓的猫叫墨墨。" in system_content
 
     def test_token_budget_respects_order_priority(self):
-        """高 order 条目优先保留，即使它在列表中排在后面"""
         char = self._make_character([
-            LoreEntry(keys=["a"], content="x" * 100, order=10),   # cost = 25, low priority
-            LoreEntry(keys=["b"], content="y" * 20, order=200),   # cost = 5, high priority
+            LoreEntry(keys=["a"], content="x" * 100, order=10),
+            LoreEntry(keys=["b"], content="y" * 20, order=200),
         ])
         builder = ContextBuilder(char, lore_token_budget=10)
         messages = builder.build(
-            short_term_history=[],
+            formatted_history=[],
+            history_dicts=[],
             current_message="a and b",
         )
         system_content = messages[0]["content"]
         assert "【世界书】" in system_content
-        # 高优先级的短条目应被保留，低优先级的长条目应被截断
         assert "y" * 20 in system_content
         assert "x" * 100 not in system_content
 
     def test_budget_fits_all_entries(self):
         char = self._make_character([
-            LoreEntry(keys=["a"], content="x" * 20),   # cost = 5
-            LoreEntry(keys=["b"], content="x" * 40),   # cost = 10
-            LoreEntry(keys=["c"], content="x" * 60),   # cost = 15
+            LoreEntry(keys=["a"], content="x" * 20),
+            LoreEntry(keys=["b"], content="x" * 40),
+            LoreEntry(keys=["c"], content="x" * 60),
         ])
         builder = ContextBuilder(char, lore_token_budget=50)
         messages = builder.build(
-            short_term_history=[],
+            formatted_history=[],
+            history_dicts=[],
             current_message="a b c",
         )
         system_content = messages[0]["content"]
@@ -139,95 +157,380 @@ class TestContextBuilderCharacterBook:
         assert "x" * 40 in system_content
         assert "x" * 60 in system_content
 
+    def test_lore_uses_history_dicts_for_scanning(self):
+        """世界书扫描用 history_dicts（原始 content），不受格式化前缀干扰"""
+        char = self._make_character([
+            LoreEntry(keys=["墨墨"], content="苏晓的猫叫墨墨。"),
+        ])
+        builder = ContextBuilder(char, lore_token_budget=300)
+        messages = builder.build(
+            formatted_history=[{"role": "user", "content": "[14:30] 墨墨今天吃了什么？"}],
+            history_dicts=[{"role": "user", "content": "墨墨今天吃了什么？"}],
+            current_message="墨墨在睡觉",
+        )
+        system_content = messages[0]["content"]
+        assert "苏晓的猫叫墨墨。" in system_content
 
-class TestContextBuilderSpeakerPrefix:
-    """测试 _format_short_term 称呼前缀 (fix-persona-group-history-context)"""
+
+# ═══════════════════════════════════════════════════════════════════
+# 6.1 私聊格式化 _format_private_history
+# ═══════════════════════════════════════════════════════════════════
+
+class TestFormatPrivateHistory:
 
     def _make_character(self):
-        return Character(
-            name="苏晓",
-            description="一个温柔的AI伴侣",
-        )
+        return Character(name="苏晓", description="一个温柔的AI伴侣")
 
-    def test_private_chat_speaker_prefix(self):
-        """8.5: 私聊 formatting 使用 [你] 和 [我]"""
-        char = self._make_character()
-        builder = ContextBuilder(char)
+    def test_role_direct_mapping(self):
+        builder = ContextBuilder(self._make_character())
         history = [
-            {"role": "user", "content": "你好", "speaker_name": "你"},
-            {"role": "assistant", "content": "你好呀", "speaker_name": "我"},
+            {"role": "user", "content": "你好", "created_at": _dt(30)},
+            {"role": "assistant", "content": "你好呀", "created_at": _dt(31)},
         ]
-        text = builder._format_short_term(history)
-        assert "[你] 你好" in text
-        assert "[我] 你好呀" in text
+        result = builder._format_private_history(history)
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
 
-    def test_group_chat_speaker_prefix(self):
-        """8.5: 群聊 formatting 使用 [display_name]"""
-        char = self._make_character()
-        builder = ContextBuilder(char)
+    def test_timestamp_prefix(self):
+        builder = ContextBuilder(self._make_character())
         history = [
-            {"role": "user", "content": "大家好", "speaker_name": "小明"},
-            {"role": "user", "content": "嗨", "speaker_name": "小红"},
-            {"role": "assistant", "content": "你们好", "speaker_name": "我"},
+            {"role": "user", "content": "你好", "created_at": _dt(30)},
         ]
-        text = builder._format_short_term(history)
-        assert "[小明] 大家好" in text
-        assert "[小红] 嗨" in text
-        assert "[我] 你们好" in text
+        result = builder._format_private_history(history)
+        assert result[0]["content"].startswith("[14:30] ")
 
-    def test_group_chat_fallback_speaker_name(self):
-        """8.5: 群聊 display_name 缺失时回退到 [群友]"""
-        char = self._make_character()
-        builder = ContextBuilder(char)
-        history = [
-            {"role": "user", "content": "test", "speaker_name": "群友"},
-        ]
-        text = builder._format_short_term(history)
-        assert "[群友] test" in text
+    def test_empty_list(self):
+        builder = ContextBuilder(self._make_character())
+        result = builder._format_private_history([])
+        assert result == []
 
-    def test_build_skips_truncate_when_disabled(self):
-        """7.2: build 信任传入的 short_term_history，不做额外截断"""
-        char = self._make_character()
-        builder = ContextBuilder(char, max_short_term_chars=10)
+
+# ═══════════════════════════════════════════════════════════════════
+# 6.2 群聊格式化 _format_group_history
+# ═══════════════════════════════════════════════════════════════════
+
+class TestFormatGroupHistory:
+
+    def _make_character(self):
+        return Character(name="苏晓", description="一个温柔的AI伴侣")
+
+    def test_merge_consecutive_non_assistant(self):
+        builder = ContextBuilder(self._make_character())
         history = [
-            {"role": "user", "content": "这是一段非常长的群聊消息内容", "speaker_name": "小明"},
-            {"role": "assistant", "content": "回复", "speaker_name": "我"},
+            {"role": "user", "content": "你好", "speaker_name": "A",
+             "created_at": _dt(30)},
+            {"role": "user", "content": "嗨", "speaker_name": "B",
+             "created_at": _dt(31)},
+            {"role": "assistant", "content": "你们好呀",
+             "created_at": _dt(31)},
         ]
+        result = builder._format_group_history(history)
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert "[A] 你好" in result[0]["content"]
+        assert "[B] 嗨" in result[0]["content"]
+        assert result[1]["role"] == "assistant"
+        assert "你们好呀" in result[1]["content"]
+
+    def test_mixed_speakers_order(self):
+        """A, B, assistant, A → merged(A+B), assistant, user(A)"""
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "msg1", "speaker_name": "A",
+             "created_at": _dt(30)},
+            {"role": "user", "content": "msg2", "speaker_name": "B",
+             "created_at": _dt(31)},
+            {"role": "assistant", "content": "reply",
+             "created_at": _dt(32)},
+            {"role": "user", "content": "msg3", "speaker_name": "A",
+             "created_at": _dt(33)},
+        ]
+        result = builder._format_group_history(history)
+        assert len(result) == 3
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[2]["role"] == "user"
+        assert "msg1" in result[0]["content"] and "msg2" in result[0]["content"]
+        assert "reply" in result[1]["content"]
+        assert "msg3" in result[2]["content"]
+
+    def test_consecutive_assistants_not_merged(self):
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "assistant", "content": "reply1",
+             "created_at": _dt(30)},
+            {"role": "assistant", "content": "reply2",
+             "created_at": _dt(31)},
+        ]
+        result = builder._format_group_history(history)
+        assert len(result) == 2
+        assert result[0]["role"] == "assistant"
+        assert result[1]["role"] == "assistant"
+
+    def test_speaker_name_fallback_to_system(self):
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "test",
+             "created_at": _dt(30)},
+        ]
+        result = builder._format_group_history(history)
+        assert "[系统] test" in result[0]["content"]
+
+    def test_empty_list(self):
+        builder = ContextBuilder(self._make_character())
+        result = builder._format_group_history([])
+        assert result == []
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6.3 轮次 + token 双重截断 truncate_by_turns
+# ═══════════════════════════════════════════════════════════════════
+
+class TestTruncateByTurns:
+
+    def _make_character(self):
+        return Character(name="苏晓", description="一个温柔的AI伴侣")
+
+    def test_truncate_by_max_turns(self):
+        """12 轮，max_turns=10 → 保留最近 10 轮"""
+        builder = ContextBuilder(self._make_character())
+        history = []
+        for i in range(12):
+            history.append({"role": "user", "content": f"u{i}"})
+            history.append({"role": "assistant", "content": f"a{i}"})
+        result = builder.truncate_by_turns(history, max_turns=10, max_tokens=10000)
+        assert len(result) == 20
+        assert result[0]["content"] == "u2"
+        assert result[-1]["content"] == "a11"
+
+    def test_truncate_by_token_budget(self):
+        """token 预算超过时触发兜底"""
+        builder = ContextBuilder(self._make_character())
+        history = []
+        for i in range(8):
+            history.append({"role": "user", "content": "x" * 100})
+            history.append({"role": "assistant", "content": "y" * 100})
+        result = builder.truncate_by_turns(history, max_turns=10, max_tokens=200)
+        assert len(result) >= 2
+        assert len(result) <= 16
+
+    def test_both_limits_token_wins(self):
+        """token 早于 turns 触发截断"""
+        builder = ContextBuilder(self._make_character())
+        history = []
+        for i in range(12):
+            history.append({"role": "user", "content": "x" * 100})
+            history.append({"role": "assistant", "content": "y" * 100})
+        result = builder.truncate_by_turns(history, max_turns=10, max_tokens=150)
+        assert len(result) < 20
+
+    def test_full_turns_preserved(self):
+        """不拆散 user/assistant 对"""
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+        result = builder.truncate_by_turns(history, max_turns=1, max_tokens=10000)
+        assert len(result) == 2
+        assert result[0]["role"] == "user" and result[0]["content"] == "u2"
+        assert result[1]["role"] == "assistant" and result[1]["content"] == "a2"
+
+    def test_orphan_user_preserved(self):
+        """末尾孤立 user 保留"""
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+        ]
+        result = builder.truncate_by_turns(history, max_turns=2, max_tokens=10000)
+        assert result[-1]["role"] == "user"
+        assert result[-1]["content"] == "u2"
+
+    def test_empty_history(self):
+        builder = ContextBuilder(self._make_character())
+        result = builder.truncate_by_turns([], max_turns=10, max_tokens=4000)
+        assert result == []
+
+    def test_leading_assistant_stripped_and_preserved(self):
+        """R1: 历史以 assistant 开头时剥离并在截断后 prepend"""
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "assistant", "content": "leading_a"},
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+        ]
+        result = builder.truncate_by_turns(history, max_turns=2, max_tokens=10000)
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "leading_a"
+        assert len(result) == 3
+
+    def test_trailing_orphan_assistant_preserved(self):
+        """R1: work 长度奇数时末尾孤立 assistant 被兜底保留"""
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "assistant", "content": "orphan_a"},
+        ]
+        result = builder.truncate_by_turns(history, max_turns=5, max_tokens=10000)
+        assert result[-1]["role"] == "assistant"
+        assert result[-1]["content"] == "orphan_a"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6.4 build() 消息列表结构
+# ═══════════════════════════════════════════════════════════════════
+
+class TestBuildMessageStructure:
+
+    def _make_character(self):
+        return Character(name="苏晓", description="一个温柔的AI伴侣")
+
+    def test_system_message_first(self):
+        builder = ContextBuilder(self._make_character())
         messages = builder.build(
-            short_term_history=history,
+            formatted_history=[],
+            history_dicts=[],
+            current_message="你好",
+        )
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "你好"
+
+    def test_no_short_term_text_in_system(self):
+        """system 消息中不含"近期对话"文本块"""
+        builder = ContextBuilder(self._make_character())
+        messages = builder.build(
+            formatted_history=[
+                {"role": "user", "content": "[14:30] 你好"},
+                {"role": "assistant", "content": "[14:31] 你好呀"},
+            ],
+            history_dicts=[
+                {"role": "user", "content": "你好"},
+                {"role": "assistant", "content": "你好呀"},
+            ],
             current_message="新消息",
         )
         system_content = messages[0]["content"]
-        # 传入的历史完整保留
-        assert "这是一段非常长的群聊消息内容" in system_content
+        assert "近期对话" not in system_content
 
-    def test_build_keeps_truncated_history(self):
-        """传入已截断的历史，build 不做额外处理"""
-        char = self._make_character()
-        builder = ContextBuilder(char, max_short_term_chars=10)
-        history = [
-            {"role": "user", "content": "很长很长的私聊消息内容在这里", "speaker_name": "你"},
-            {"role": "assistant", "content": "回复", "speaker_name": "我"},
-        ]
-        # 模拟 orchestrator 层预先截断
-        truncated = builder.truncate_by_turns(history, max_chars=10)
+    def test_formatted_history_appended_after_system(self):
+        """格式化历史以独立消息对追加在 system 之后"""
+        builder = ContextBuilder(self._make_character())
         messages = builder.build(
-            short_term_history=truncated,
+            formatted_history=[
+                {"role": "user", "content": "[14:30] 你好"},
+                {"role": "assistant", "content": "[14:31] 你好呀"},
+            ],
+            history_dicts=[
+                {"role": "user", "content": "你好"},
+                {"role": "assistant", "content": "你好呀"},
+            ],
             current_message="新消息",
         )
-        system_content = messages[0]["content"]
-        # 截断后的历史被正确格式化
-        assert "[你]" in system_content or "[我]" in system_content
+        assert len(messages) == 4
+        assert messages[0]["role"] == "system"
+        assert messages[1] == {"role": "user", "content": "[14:30] 你好"}
+        assert messages[2] == {"role": "assistant", "content": "[14:31] 你好呀"}
+        assert messages[3] == {"role": "user", "content": "新消息"}
 
+    def test_current_message_no_timestamp(self):
+        """当前消息不含时间戳前缀"""
+        builder = ContextBuilder(self._make_character())
+        messages = builder.build(
+            formatted_history=[],
+            history_dicts=[],
+            current_message="你好",
+        )
+        assert messages[-1]["content"] == "你好"
+        assert not messages[-1]["content"].startswith("[")
+
+    def test_empty_history_only_system_and_current(self):
+        builder = ContextBuilder(self._make_character())
+        messages = builder.build(
+            formatted_history=[],
+            history_dicts=[],
+            current_message="你好",
+        )
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# format_history 统一入口
+# ═══════════════════════════════════════════════════════════════════
+
+class TestFormatHistory:
+
+    def _make_character(self):
+        return Character(name="苏晓", description="一个温柔的AI伴侣")
+
+    def test_is_group_false_dispatches_private(self):
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "hi", "created_at": _dt(30)},
+        ]
+        result = builder.format_history(history, is_group=False)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert result[0]["content"].startswith("[14:30]")
+
+    def test_is_group_true_dispatches_group(self):
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "hi", "speaker_name": "A",
+             "created_at": _dt(30)},
+        ]
+        result = builder.format_history(history, is_group=True)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert "[A]" in result[0]["content"]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# R2: build_debug_info is_group 显式传入
+# ═══════════════════════════════════════════════════════════════════
+
+class TestBuildDebugInfo:
+
+    def _make_character(self):
+        return Character(name="苏晓", description="一个温柔的AI伴侣")
+
+    def test_short_term_chars_reflects_formatted_content(self):
+        """传入已格式化的 truncated，short_term_chars 直接统计 content 长度"""
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "[14:30] hi"},
+            {"role": "assistant", "content": "[14:31] hello"},
+        ]
+        info = builder.build_debug_info(short_term_history=history)
+        assert info["short_term_chars"] == len("[14:30] hi") + len("[14:31] hello")
+
+    def test_returned_message_count_includes_all_messages(self):
+        builder = ContextBuilder(self._make_character())
+        history = [
+            {"role": "user", "content": "[14:30] hi"},
+        ]
+        info = builder.build_debug_info(short_term_history=history)
+        assert info["returned_message_count"] == 2  # 1 history + 1 current
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 分段回复引导
+# ═══════════════════════════════════════════════════════════════════
 
 class TestContextBuilderSegmentGuide:
-    """测试分段回复引导文本注入"""
 
     def _make_character(self):
-        return Character(
-            name="苏晓",
-            description="一个温柔的AI伴侣",
-        )
+        return Character(name="苏晓", description="一个温柔的AI伴侣")
 
     def test_segment_guide_injected_with_defaults(self):
         char = self._make_character()
@@ -238,13 +541,13 @@ class TestContextBuilderSegmentGuide:
                 enabled=True, target_chars=30, max_chars=80, soft_limit=100, hard_limit=120
             ),
         )
-        messages = builder.build(short_term_history=[], current_message="hi")
+        messages = builder.build(formatted_history=[], history_dicts=[], current_message="hi")
         system = messages[0]["content"]
         assert "send_reply_segment" in system
-        assert "30" in system  # target_chars
-        assert "80" in system  # max_chars
-        assert "100" in system  # soft_limit
-        assert "120" in system  # hard_limit
+        assert "30" in system
+        assert "80" in system
+        assert "100" in system
+        assert "120" in system
         assert "delay_before" in system
         assert "【系统消息说明】" in system
         assert "[系统指令]" in system
@@ -259,7 +562,7 @@ class TestContextBuilderSegmentGuide:
                 enabled=True, target_chars=50, max_chars=100, soft_limit=200, hard_limit=250
             ),
         )
-        messages = builder.build(short_term_history=[], current_message="hi")
+        messages = builder.build(formatted_history=[], history_dicts=[], current_message="hi")
         system = messages[0]["content"]
         assert "50" in system
         assert "100" in system
@@ -275,7 +578,7 @@ class TestContextBuilderSegmentGuide:
                 enabled=True, target_chars=30, max_chars=80, soft_limit=100, hard_limit=120
             ),
         )
-        messages = builder.build(short_term_history=[], current_message="hi")
+        messages = builder.build(formatted_history=[], history_dicts=[], current_message="hi")
         system = messages[0]["content"]
         name_idx = system.index("苏晓")
         guide_idx = system.index("【回复规则】")
@@ -285,9 +588,92 @@ class TestContextBuilderSegmentGuide:
     def test_segment_guide_disabled_when_segment_enabled_false(self):
         char = self._make_character()
         builder = ContextBuilder(char, segment_guide=None)
-        messages = builder.build(short_term_history=[], current_message="hi")
+        messages = builder.build(formatted_history=[], history_dicts=[], current_message="hi")
         system = messages[0]["content"]
         assert "【回复规则】" not in system
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6.6 配置迁移兼容性
+# ═══════════════════════════════════════════════════════════════════
+
+class TestConfigMigration:
+
+    def test_old_field_defaults_ok(self):
+        """仅含 max_short_term_chars 无新字段时，模型加载不报错且新字段取默认值"""
+        from plugins.DicePP.core.config.pydantic_models import PersonaConfig
+        from plugins.DicePP.module.persona.chat.session import ChatConfig
+        pc = PersonaConfig(max_short_term_chars=1500)
+        assert pc.max_history_turns == 10
+        assert pc.max_history_tokens == 4000
+        cc = ChatConfig.from_persona(pc)
+        assert cc.max_history_turns == 10
+        assert cc.max_history_tokens == 4000
+        assert cc.max_diary_context_chars == 500
+
+    def test_new_fields_assembled_correctly(self):
+        """ChatConfig.from_persona() 装配新字段正确"""
+        from plugins.DicePP.core.config.pydantic_models import PersonaConfig
+        from plugins.DicePP.module.persona.chat.session import ChatConfig
+        pc = PersonaConfig(
+            max_history_turns=7,
+            max_history_tokens=3000,
+            max_diary_context_chars=600,
+        )
+        cc = ChatConfig.from_persona(pc)
+        assert cc.max_history_turns == 7
+        assert cc.max_history_tokens == 3000
+        assert cc.max_diary_context_chars == 600
+
+    def test_old_field_migrated_when_new_fields_absent(self):
+        """R3: 仅设旧字段时自动迁移到新字段"""
+        from plugins.DicePP.core.config.pydantic_models import PersonaConfig
+        pc = PersonaConfig(max_short_term_chars=3000)
+        assert pc.max_history_turns == max(5, 3000 // 300)
+        assert pc.max_history_tokens == 3000
+
+    def test_old_field_ignored_when_new_fields_present(self):
+        """R3: 新旧字段同时设置时，新字段优先"""
+        from plugins.DicePP.core.config.pydantic_models import PersonaConfig
+        pc = PersonaConfig(
+            max_short_term_chars=500,
+            max_history_turns=15,
+            max_history_tokens=8000,
+        )
+        assert pc.max_history_turns == 15
+        assert pc.max_history_tokens == 8000
+
+    def test_both_fields_set_new_wins(self):
+        """新旧字段都设置时，新字段生效"""
+        from plugins.DicePP.core.config.pydantic_models import PersonaConfig
+        from plugins.DicePP.module.persona.chat.session import ChatConfig
+        pc = PersonaConfig(
+            max_short_term_chars=200,
+            max_history_turns=12,
+            max_history_tokens=5000,
+        )
+        cc = ChatConfig.from_persona(pc)
+        assert cc.max_history_turns == 12
+        assert cc.max_history_tokens == 5000
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6.7 Diary 截断独立配置
+# ═══════════════════════════════════════════════════════════════════
+
+class TestDiaryContextConfig:
+
+    def test_diary_uses_max_diary_context_chars(self):
+        """_build_diary_context 使用 max_diary_context_chars 而非 max_short_term_chars"""
+        from plugins.DicePP.core.config.pydantic_models import PersonaConfig
+        from plugins.DicePP.module.persona.chat.session import ChatConfig
+        pc = PersonaConfig(
+            max_short_term_chars=999,
+            max_diary_context_chars=300,
+        )
+        cc = ChatConfig.from_persona(pc)
+        assert cc.max_diary_context_chars == 300
+        assert cc.max_diary_context_chars != 999
 
 
 if __name__ == "__main__":

--- a/tests/unit/persona/test_phase7a.py
+++ b/tests/unit/persona/test_phase7a.py
@@ -62,9 +62,9 @@ def test_latency_percentiles_per_tier():
 
 def test_build_debug_info():
     char = Character(name="Test", system_prompt="You are a test character.")
-    builder = ContextBuilder(char, max_short_term_chars=100)
+    builder = ContextBuilder(char, max_history_turns=10, max_history_tokens=100)
     info = builder.build_debug_info(
-        short_term_history=[{"role": "user", "content": "hi", "speaker_name": "你"}],
+        short_term_history=[{"role": "user", "content": "hi"}],
         diary_context="今天下雨了",
     )
     assert info["system_prompt_chars"] > 0


### PR DESCRIPTION
## Summary
- 对话历史从 system prompt 文本块拆出，改为独立的 user/assistant 轮次消息对
- system 消息只保留角色设定层（世界书、时间、性格、关系、facts、diary、示例对话）
- 群聊中连续非 assistant 发言合并为单条 user 消息，`[HH:MM] [speaker]` 格式
- 截断策略从字符数切换为 `max_history_turns` + `max_history_tokens` 双重兜底
- `max_short_term_chars` 配置废弃，PersonaConfig 自动迁移旧值到新字段
- diary 截断配置从复用 `max_short_term_chars` 改为独立 `max_diary_context_chars`

## Test plan
- [x] `uv run pytest tests/unit/` 543 passed
- [x] 39 个新测试覆盖格式化/截断/组装/配置迁移