### PR TITLE
feat(persona): 提取查询搜索逻辑到 QueryStore，新增 search_query/list_databases 工具

### DIFF
--- a/src/plugins/DicePP/core/data/query_store.py
+++ b/src/plugins/DicePP/core/data/query_store.py
@@ -1,7 +1,7 @@
 import os
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import aiosqlite
 
@@ -47,6 +47,10 @@ def regexp_normalize(string: str) -> str:
         else:
             new_string += char
     return new_string
+
+
+class QueryStoreError(RuntimeError):
+    """查询数据库操作异常"""
 
 
 class QueryStore:
@@ -354,4 +358,303 @@ class QueryStore:
             )
         await (await self._get_conn(db_name)).commit()
         return True
+
+    # ── 共享搜索逻辑 ──────────────────────────────────────────
+
+    @staticmethod
+    def _generate_search_sql_regexp(
+        command_list: List[str],
+        prefix: str = "名称",
+    ) -> Tuple[str, List[str]]:
+        result: List[str] = []
+        for command in command_list:
+            if command.startswith("-") and len(command) > 1:
+                result.append(f"^(?!.*{regexp_normalize(command[1:])})")
+            elif command.startswith("=") and len(command) > 1:
+                result.append(f"^{regexp_normalize(command[1:])}$")
+            elif len(command) > 0:
+                result.append(regexp_normalize(command))
+
+        pattern = "|".join(result)
+        return f"{prefix} regexp ?", [pattern]
+
+    @staticmethod
+    def _generate_search_sql_in(
+        command_list: List[str],
+        prefix: str = "来源",
+    ) -> Tuple[str, List[str]]:
+        words: List[str] = []
+        anti_words: List[str] = []
+        for command in command_list:
+            if command.startswith("-") and len(command) > 1:
+                anti_words.append(command[1:])
+            elif command.startswith("=") and len(command) > 1:
+                words.append(command[1:])
+            elif len(command) > 0:
+                words.append(command)
+
+        clauses: List[str] = []
+        params: List[str] = []
+
+        if words:
+            placeholders = ",".join(["?"] * len(words))
+            clauses.append(f"{prefix} in ({placeholders})")
+            params.extend(words)
+
+        if anti_words:
+            placeholders = ",".join(["?"] * len(anti_words))
+            clauses.append(f"{prefix} not in ({placeholders})")
+            params.extend(anti_words)
+
+        if not clauses:
+            return "1=0", []
+
+        if len(clauses) == 1:
+            return clauses[0], params
+
+        return f"({clauses[0]} OR {clauses[1]})", params
+
+    @staticmethod
+    def _generate_search_conditions(
+        condition_list: Dict[tuple, List[List[str]]],
+    ) -> Tuple[str, List[Any]]:
+        sql_fragments: List[str] = []
+        params: List[Any] = []
+
+        for key_list in condition_list.keys():
+            cmd_groups = condition_list[key_list]
+            if len(cmd_groups) == 0:
+                continue
+
+            key_sql_parts: List[str] = []
+            key_params: List[Any] = []
+
+            if "全部" in key_list:
+                for command in cmd_groups:
+                    sql_part, part_params = QueryStore._generate_search_sql_regexp(
+                        command, "名称||英文||来源||分类||标签||内容"
+                    )
+                    key_sql_parts.append(sql_part)
+                    key_params.extend(part_params)
+            elif key_list == ("分类",):
+                for command in cmd_groups:
+                    sql_part, part_params = QueryStore._generate_search_sql_in(command, "分类")
+                    key_sql_parts.append(sql_part)
+                    key_params.extend(part_params)
+            else:
+                for command in cmd_groups:
+                    sql_part, part_params = QueryStore._generate_search_sql_regexp(
+                        command, "||".join(key_list)
+                    )
+                    key_sql_parts.append(sql_part)
+                    key_params.extend(part_params)
+
+            if len(key_sql_parts) != 0:
+                sql_fragments.append("(" + " AND ".join(key_sql_parts) + ")")
+                params.extend(key_params)
+
+        return " AND ".join(sql_fragments), params
+
+    async def _search_single_db(
+        self,
+        db_name: str,
+        query_tokens: List[str],
+        fulltext: bool,
+        limit: int,
+        offset: int,
+    ) -> List[Dict[str, str]]:
+        """在单个数据库中执行搜索，返回 dict 列表（含 redirect 解析与去重）。"""
+        sql_search_command_prefix: str = "Select * From data Where "
+        sql_redirect_command_prefix: str = "Select * From redirect Where "
+
+        condition_list: Dict[tuple, List[List[str]]] = {}
+        complete_name: str = ""
+        complete_name_en: str = ""
+        can_single_query: bool = True
+
+        for query_command in query_tokens:
+            cmd_target = ["名称", "英文"]
+            if query_command[0] == "#":
+                cmd_target = ["来源", "分类", "标签"]
+                query_command = query_command[1:]
+                can_single_query = False
+            elif query_command[0] == "&":
+                cmd_target = ["分类"]
+                query_command = query_command[1:]
+                can_single_query = False
+            elif fulltext:
+                cmd_target = ["全部"]
+                can_single_query = False
+
+            command_list = [command for command in query_command.split("/")]
+            if not any(command_list):
+                continue
+
+            if tuple(cmd_target) not in condition_list.keys():
+                condition_list[tuple(cmd_target)] = []
+            condition_list[tuple(cmd_target)].append(command_list)
+
+            if len(command_list) == 1:
+                if "名称" in cmd_target:
+                    complete_name += command_list[0]
+                if "英文" in cmd_target:
+                    if complete_name_en != "":
+                        complete_name_en += " " + command_list[0]
+                    else:
+                        complete_name_en += command_list[0]
+            else:
+                complete_name = ""
+                complete_name_en = ""
+
+        # 防止空查询
+        condition_size = 0
+        for key_list in condition_list.keys():
+            condition_size += len(condition_list[key_list])
+        if condition_size == 0:
+            return []
+
+        # 主查询（SQL 层 LIMIT 减少 I/O）
+        sql_condition, params = self._generate_search_conditions(condition_list)
+        sql_limit = limit * 2  # 预留余量给 redirect 追加结果
+        rows = await self.fetchall(
+            db_name,
+            sql_search_command_prefix + sql_condition + f" LIMIT {sql_limit}",
+            params,
+        )
+        results: List[Dict[str, str]] = []
+        for _data in rows:
+            results.append({
+                "name": _data[0], "name_en": _data[1], "source": _data[2],
+                "catalogue": _data[3], "tag": _data[4], "content": _data[5],
+                "redirect_by": "",
+            })
+
+        # 处理重定向
+        redirect_condition_list: Dict[tuple, List[List[str]]] = {
+            ("名称",): []
+        }
+        sql_condition_list: Dict[tuple, List[List[str]]] = {
+            ("名称",): []
+        }
+        for key_list in condition_list.keys():
+            if "全部" in key_list or "名称" in key_list:
+                redirect_condition_list[("名称",)] += condition_list[key_list]
+            else:
+                sql_condition_list[key_list] = condition_list[key_list]
+
+        if len(redirect_condition_list[("名称",)]) != 0:
+            redirect_result: List[List[str]] = []
+            sql_condition, params = self._generate_search_conditions(redirect_condition_list)
+            redirect_rows = await self.fetchall(
+                db_name,
+                sql_redirect_command_prefix + sql_condition,
+                params,
+            )
+            for _data in redirect_rows:
+                redirect_result.append([_data[0], _data[1]])
+
+            for _redirect in redirect_result:
+                sql_condition_list[("名称",)] = [[_redirect[1]]]
+                sql_condition, params = self._generate_search_conditions(sql_condition_list)
+                redirected_rows = await self.fetchall(
+                    db_name,
+                    sql_search_command_prefix + sql_condition,
+                    params,
+                )
+                for _data in redirected_rows:
+                    results.append({
+                        "name": _data[0], "name_en": _data[1], "source": _data[2],
+                        "catalogue": _data[3], "tag": _data[4], "content": _data[5],
+                        "redirect_by": _redirect[0],
+                    })
+
+        # 去重 + 精确匹配优先
+        dupe_list: Set[str] = set()
+        new_results: List[Dict[str, str]] = []
+        found_equal: bool = False
+        for r in results:
+            hash_word = r["name"] + "#" + r["source"] + "#" + r["catalogue"]
+            if can_single_query:
+                if complete_name != "" and r["name"] == complete_name:
+                    if not found_equal:
+                        dupe_list.clear()
+                        new_results.clear()
+                    found_equal = True
+                    if hash_word not in dupe_list:
+                        dupe_list.add(hash_word)
+                        new_results.append(r)
+                elif complete_name_en != "" and r["name"].lower() == complete_name_en:
+                    if not found_equal:
+                        dupe_list.clear()
+                        new_results.clear()
+                    found_equal = True
+                    if hash_word not in dupe_list:
+                        dupe_list.add(hash_word)
+                        new_results.append(r)
+            if not found_equal:
+                if hash_word not in dupe_list:
+                    dupe_list.add(hash_word)
+                    new_results.append(r)
+
+        return new_results[offset:offset + limit]
+
+    async def search(
+        self,
+        databases: List[str],
+        query_tokens: List[str],
+        fulltext: bool = False,
+        limit: int = 5,
+        offset: int = 0,
+        max_total: int = 1000,
+    ) -> dict:
+        """搜索多个资料库，返回 dict。
+
+        Returns:
+            {"results": [...], "total": int}
+
+        Raises:
+            QueryStoreError: total > max_total 或数据库未加载
+        """
+        if not query_tokens:
+            return {"results": [], "total": 0}
+
+        if not databases:
+            return {"results": [], "total": 0}
+
+        for db in databases:
+            if not self.has_database(db):
+                raise QueryStoreError(f"数据库未加载: {db}")
+
+        # 主库搜索
+        all_results = await self._search_single_db(
+            databases[0], query_tokens, fulltext, max_total + 1, 0,
+        )
+
+        # 私设库合并（私设覆盖同名主库条目）
+        for hb_db in databases[1:]:
+            hb_results = await self._search_single_db(
+                hb_db, query_tokens, fulltext, max_total + 1, 0,
+            )
+            for hb in hb_results[::-1]:
+                for main in all_results[::-1]:
+                    if hb["name"] == main["name"]:
+                        all_results.remove(main)
+                if hb["content"].strip():
+                    all_results.append(hb)
+
+        total = len(all_results)
+        if total > max_total:
+            raise QueryStoreError(f"result count {total} exceeds max_total={max_total}")
+
+        return {"results": all_results[offset:offset + limit], "total": total}
+
+    async def get_database_info(self, db_name: str) -> Optional[dict]:
+        """获取资料库元数据，未加载则返回 None。"""
+        if not self.has_database(db_name):
+            return None
+        row = await self.fetchone(db_name, "SELECT COUNT(*) FROM data")
+        rows = row[0] if row else 0
+        cat_rows = await self.fetchall(db_name, "SELECT DISTINCT 分类 FROM data")
+        categories = [r[0] for r in cat_rows if r[0]]
+        return {"name": db_name, "rows": rows, "categories": categories}
 

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -129,6 +129,8 @@ class ChatSession:
         decay_calculator: Optional[DecayCalculator] = None,
         port: Optional[MessagePort] = None,
         segment_dispatcher: Optional[SegmentDispatcher] = None,
+        query_store: Any = None,
+        resolve_db: Any = None,
     ):
         self.store = store
         self.router = router
@@ -141,6 +143,8 @@ class ChatSession:
         self.decay_calculator = decay_calculator
         self.port = port
         self.segment_dispatcher = segment_dispatcher
+        self.query_store = query_store
+        self.resolve_db = resolve_db
         self._pending_messages: Dict[str, deque] = {}
         self._last_messages: Dict[str, Tuple[str, float]] = {}
 
@@ -386,6 +390,7 @@ class ChatSession:
             user_id=user_id, group_id=group_id, store=self.store,
             send=self.port, segment_dispatcher=self.segment_dispatcher,
             segment_state=segment_state,
+            query=self.query_store, resolve_db=self.resolve_db,
         )
 
         # 组装 Hooks（通过 Router 工厂方法避免重复构造逻辑）

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -36,6 +36,8 @@ from .tools.search_memory import SEARCH_MEMORY_TOOL, search_memory_executor
 from .tools.search_history import SEARCH_HISTORY_TOOL, make_search_history_executor
 from .tools.roll_dice import ROLL_DICE_TOOL, roll_dice_executor
 from .tools.send_reply_segment import make_tool_def, send_reply_segment_executor
+from .tools.list_databases import LIST_QUERY_DATABASES_TOOL, list_query_databases_executor
+from .tools.search_query import SEARCH_QUERY_TOOL, search_query_executor
 from .chat.segment_dispatcher import SegmentDispatcher
 
 
@@ -224,6 +226,8 @@ def _build_chat(
     decay_calculator: DecayCalculator,
     port: MessagePort,
     segment_dispatcher: Optional[SegmentDispatcher] = None,
+    query_store: Any = None,
+    resolve_db: Any = None,
 ) -> ChatSession:
     """组装 ChatSession"""
     scoring_agent = ScoringAgent(router, timezone=config.timezone,
@@ -261,6 +265,8 @@ def _build_chat(
         decay_calculator=decay_calculator,
         port=port,
         segment_dispatcher=segment_dispatcher,
+        query_store=query_store,
+        resolve_db=resolve_db,
     )
 
 
@@ -380,6 +386,8 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
         make_search_history_executor(config.search_chat_history_max_chars),
     )
     tool_registry.register(ToolDomain.CHAT, ROLL_DICE_TOOL, roll_dice_executor)
+    tool_registry.register(ToolDomain.CHAT, LIST_QUERY_DATABASES_TOOL, list_query_databases_executor)
+    tool_registry.register(ToolDomain.CHAT, SEARCH_QUERY_TOOL, search_query_executor)
     if config.segment_enabled:
         tool_registry.register(
             ToolDomain.CHAT,
@@ -404,8 +412,24 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
     )
     logger.info("衰减计算器已初始化")
 
+    async def _resolve_query_db(user_id: str, group_id: str) -> str:
+        if group_id:
+            row = await bot.db.group_config.get(group_id)
+            if row and row.data:
+                return row.data.get("query_database", bot.config.mode.default)
+            return bot.config.mode.default
+        else:
+            row = await bot.db.user_stat.get(user_id)
+            if row and row.data:
+                db = row.data.get("query_database")
+                if db:
+                    return db
+            return bot.config.query.private_database
+
     chat = _build_chat(
-        store, router, tool_registry, coordinator, character, config, decay_calculator, port, segment_dispatcher
+        store, router, tool_registry, coordinator, character, config,
+        decay_calculator, port, segment_dispatcher,
+        query_store=bot.db.query, resolve_db=_resolve_query_db,
     )
     life = await _build_life(store, character, config, coordinator, port, decay_calculator, router)
 

--- a/src/plugins/DicePP/module/persona/tools/context.py
+++ b/src/plugins/DicePP/module/persona/tools/context.py
@@ -27,8 +27,10 @@ class ToolContext:
     """工具执行上下文 — 运行时注入的依赖"""
 
     user_id: str
-    group_id: str
+    group_id: str              # 私聊时为 ""
     store: Any = None
     send: Optional[SendPort] = None
     segment_dispatcher: Optional[Any] = None
     segment_state: Optional[Any] = None
+    query: Any = None          # QueryStore 实例
+    resolve_db: Any = None     # Callable[[str, str], Awaitable[str]]

--- a/src/plugins/DicePP/module/persona/tools/list_databases.py
+++ b/src/plugins/DicePP/module/persona/tools/list_databases.py
@@ -1,0 +1,36 @@
+"""列出可搜索的规则资料库"""
+import json
+from .context import ToolContext
+from .registry import ToolDef
+
+LIST_QUERY_DATABASES_TOOL = ToolDef(
+    name="list_query_databases",
+    description="列出所有可搜索的规则资料库，包括库名、条目数、主要分类等",
+    parameters={
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+)
+
+
+async def list_query_databases_executor(args: dict, ctx: ToolContext) -> str:
+    if ctx.query is None:
+        return "规则资料库查询功能不可用"
+
+    db_names = ctx.query.list_databases()
+    databases = []
+    for name in db_names:
+        info = await ctx.query.get_database_info(name)
+        if info is None:
+            continue
+        databases.append(info)
+
+    try:
+        default = await ctx.resolve_db(ctx.user_id, ctx.group_id)
+        if default and not ctx.query.has_database(default):
+            default = None
+    except Exception:
+        default = None
+
+    return json.dumps({"databases": databases, "default": default}, ensure_ascii=False)

--- a/src/plugins/DicePP/module/persona/tools/search_query.py
+++ b/src/plugins/DicePP/module/persona/tools/search_query.py
@@ -1,0 +1,163 @@
+"""搜索规则资料库工具"""
+import json
+from core.data.query_store import QueryStoreError
+from module.query.query_utils import command_split
+from .context import ToolContext
+from .registry import ToolDef
+
+SEARCH_QUERY_TOOL = ToolDef(
+    name="search_query",
+    description=(
+        "搜索 TRPG 规则资料库。提供 keyword（关键词）进行名称匹配，"
+        "可选 tags（标签过滤）、category（分类过滤）、source（来源过滤）。"
+        "也可直接使用 query 字符串（支持 #标签 &分类 /OR 语法）作为 fallback。"
+        "搜索结果仅返回摘要信息，如需查看单条的完整内容，"
+        "请保持参数不变，传入对应 detail_index 获取。"
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "keyword": {
+                "type": "string",
+                "description": "搜索关键词，匹配名称/英文名。如 '火球术'",
+            },
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "标签过滤，如 ['法师', '3环']。多标签为 AND，单个标签内 '/' 分隔为 OR",
+            },
+            "category": {
+                "type": "string",
+                "description": "分类过滤，如 '法术'、'生物'",
+            },
+            "source": {
+                "type": "string",
+                "description": "来源过滤（通过 #标签匹配，同时搜索来源/分类/标签字段），如 'PHB'",
+            },
+            "query": {
+                "type": "string",
+                "description": "fallback 原始查询字符串，支持 #标签 &分类 /OR 语法。传入时忽略 keyword/tags/category/source",
+            },
+            "database": {
+                "type": "string",
+                "description": "要搜索的资料库名称。不填使用当前对话默认库。可先调用 list_query_databases 查看可选库。注意：群聊中会自动追加当前群的房规数据库，同名条目以房规为准",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "返回结果数量上限（1-10）",
+                "default": 5,
+                "minimum": 1,
+                "maximum": 10,
+            },
+            "fulltext": {
+                "type": "boolean",
+                "description": "是否同时搜索内容正文。默认 false 只搜标题/标签",
+                "default": False,
+            },
+            "detail_index": {
+                "type": "integer",
+                "description": "获取之前搜索结果中第 N 条的完整内容。使用此参数时请保持其他参数不变",
+            },
+        },
+        "required": [],
+    },
+)
+
+
+def _build_query(args: dict) -> str:
+    """将结构化参数组装为 command_split() 兼容的查询字符串"""
+    query = args.get("query")
+    if query:
+        return query
+    parts = [args.get("keyword", "")]
+    tags = args.get("tags") or []
+    for t in tags:
+        parts.append(f"#{t}")
+    category = args.get("category")
+    if category:
+        parts.append(f"&{category}")
+    source = args.get("source")
+    if source:
+        parts.append(f"#{source}")
+    return " ".join(p for p in parts if p)
+
+
+async def search_query_executor(args: dict, ctx: ToolContext) -> str:
+    if ctx.query is None:
+        return "规则资料库查询功能不可用"
+
+    try:
+        db = args.get("database") or await ctx.resolve_db(ctx.user_id, ctx.group_id)
+    except Exception:
+        return "无法确定默认资料库，请指定 database 参数"
+
+    if not ctx.query.has_database(db):
+        available = ctx.query.list_databases()
+        return f"资料库 '{db}' 未加载。当前可用: {', '.join(available)}"
+
+    databases = [db]
+
+    if ctx.group_id:
+        hb_db = f"HB{ctx.group_id}"
+        if ctx.query.has_database(hb_db):
+            databases.append(hb_db)
+
+    raw_query = _build_query(args)
+    tokens = command_split(raw_query)
+    if not tokens:
+        return "查询关键词为空，请输入有效的搜索关键词"
+
+    detail_index = args.get("detail_index")
+    if detail_index is not None:
+        try:
+            detail_index = int(detail_index)
+        except (TypeError, ValueError):
+            return "detail_index 参数必须为整数"
+
+    limit = args.get("limit", 5)
+    if detail_index is not None:
+        limit = max(limit, detail_index + 1)
+
+    try:
+        result = await ctx.query.search(
+            databases=databases, query_tokens=tokens,
+            fulltext=args.get("fulltext", False),
+            limit=limit,
+        )
+    except QueryStoreError as e:
+        return (
+            f"搜索结果过多（超过1000条），请缩小搜索范围："
+            f"使用更具体的关键词，或添加 tags、category 过滤条件。"
+            f"原始错误: {e}"
+        )
+
+    if detail_index is not None:
+        if detail_index >= len(result["results"]):
+            return f"索引 {detail_index} 超出结果范围（共 {len(result['results'])} 条）"
+        item = result["results"][detail_index]
+        return json.dumps({
+            "name": item["name"],
+            "name_en": item["name_en"],
+            "source": item["source"],
+            "catalogue": item["catalogue"],
+            "tag": item["tag"],
+            "content": item["content"],
+            "redirect_by": item.get("redirect_by", ""),
+        }, ensure_ascii=False)
+
+    # 摘要模式
+    summary = []
+    for i, item in enumerate(result["results"]):
+        content = item["content"] or ""
+        snippet = content[:150] + "..." if len(content) > 150 else content
+        summary.append({
+            "index": i,
+            "name": item["name"],
+            "source": item["source"],
+            "catalogue": item["catalogue"],
+            "snippet": snippet,
+        })
+    return json.dumps({
+        "results": summary,
+        "total": result["total"],
+    }, ensure_ascii=False)

--- a/src/plugins/DicePP/module/query/query_command.py
+++ b/src/plugins/DicePP/module/query/query_command.py
@@ -19,8 +19,9 @@ from core.data.query_store import (
     QUERY_DATA_FIELD_LIST,
     QUERY_REDIRECT_FIELD,
     QUERY_REDIRECT_FIELD_LIST,
-    regexp_normalize,
+    QueryStoreError,
 )
+from .query_utils import command_split
 from utils.time import get_current_date_raw
 from utils.data import yield_deduplicate
 
@@ -523,9 +524,9 @@ class QueryCommand(UserCommandBase):
         if meta.group_id:
             port = GroupMessagePort(meta.group_id)
             row = await self.bot.db.group_config.get(meta.group_id)
-            database = "DND5E"
+            database = self.bot.config.mode.default
             if row and row.data:
-                database = row.data.get("query_database", "DND5E")
+                database = row.data.get("query_database", self.bot.config.mode.default)
         else:
             port = PrivateMessagePort(meta.user_id)
             # 私聊优先使用用户私设的 query_database（支持私聊切换模式），回退到全局私聊默认
@@ -993,39 +994,8 @@ class QueryCommand(UserCommandBase):
                                                        page_total=poss_result_num // page_item_num + 1)
         return feedback
     
-    def command_split(self,keywords: str) -> List[str]:
-        """
-        处理一遍指令，将更加规范的文本传递给查询
-        """
-        result_list: List[str] = []
-        collect_words: str = ""
-        prefix: str = ""
-        fine_mode: bool = False
-        for key in keywords:
-            if not fine_mode and collect_words == "" and key == "\"":
-                fine_mode = True
-            elif fine_mode and key == "\"":
-                fine_mode = False
-                if collect_words != "":
-                    result_list.append(prefix + collect_words)
-                    prefix = ""
-            elif not fine_mode and key in ["#","&"]:
-                if collect_words.strip():
-                    result_list.append(prefix + collect_words.strip())
-                collect_words = ""
-                prefix = key
-            elif not fine_mode and key in [" "]:
-                if collect_words.strip():
-                    result_list.append(prefix + collect_words.strip())
-                collect_words = ""
-                prefix = ""
-            else:
-                collect_words += key
-        if fine_mode:
-            result_list.append(prefix + collect_words)
-        elif collect_words.strip():
-            result_list.append(prefix + collect_words.strip())
-        return result_list
+    def command_split(self, keywords: str) -> List[str]:
+        return command_split(keywords)
     
     async def query_item(
         self,
@@ -1034,190 +1004,50 @@ class QueryCommand(UserCommandBase):
         query_keywords: str,
         search_mode: int = 0,
     ) -> List[QueryData]:
-        """
-        查询的实际处理,会同时处理普通数据库与房规数据库
-        """
         poss_result: List[QueryData] = []
-        # 如果库不存在直接撤
         if not self.bot.db.query.has_database(database):
             return poss_result
-        # 分割关键字，这里不检测超出，因为全部由数据库决定
-        query_command_list:List[str] = []
+        query_command_list: List[str] = []
         if len(query_keywords) > 0:
             query_command_list = self.command_split(query_keywords)
             if len(query_command_list) == 0:
                 return poss_result
         else:
             return poss_result
-        # 找到搜索候选
-        poss_result = await self.search_item(database, query_command_list, search_mode)
-        # 找到私设候选（如果开的话）
-        if homebrew_database != "":
-            homebrew_result = await self.search_item(homebrew_database, query_command_list, search_mode)
-            for homebrew in homebrew_result[::-1]:
-                if len(poss_result) > 0:
-                    for poss in poss_result[::-1]:
-                        if homebrew.data_name == poss.data_name:
-                            poss_result.remove(poss)
-                if len(homebrew.data_content.strip()) == 0:
-                    homebrew_result.remove(homebrew)
-            poss_result = poss_result + homebrew_result
-        
+        poss_result = await self.search_item(
+            database, query_command_list, search_mode, homebrew_database,
+        )
         return poss_result
 
-    async def search_item(self, database: str, query_command_list: List[str], search_mode: int = 0) -> List[QueryData]:
-        """
-        搜索合规的对象
-        """
-        sql_search_command_prefix: str = "Select * From data Where " #查询指令前缀
-        sql_redirect_command_prefix: str = "Select * From redirect Where " #查询指令前缀
-        sql_command_suffix: str = "" #" COLLATE NOCASE" #查询指令后缀
-        # 统一通过异步 store 访问 query db
-        query_result: List[QueryData] = []
-        result_length: int = 0
-        use_redirect: bool = True
-        # 分割指令
-        # 获取查询指令列表
-        complete_name: str = ""
-        complete_name_en: str = ""
-        can_single_query: bool = True
-        condition_type: List[str] = ["名称","英文","来源","分类","标签","内容","全部"]
-        condition_list: Dict[str, List[List[str]]] = {}
-        # 预处理指令
-        for query_command in query_command_list:
-            # 确认指令对象
-            cmd_target = ["名称","英文"]
-            if query_command[0]  == "#":
-                cmd_target = ["来源","分类","标签"]
-                query_command = query_command[1:]
-                can_single_query = False
-            elif query_command[0]  == "&":
-                cmd_target = ["分类"]
-                query_command = query_command[1:]
-                can_single_query = False
-                '''
-            elif "=" in query_command:
-                left_word, right_word = query_command.split("=")
-                can_single_query = False
-                if len(left_word) != 0 and len(right_word) != 0:
-                    new_cmd_target = []
-                    for word in left_word.split("/"):
-                        if word not in condition_type:
-                            new_cmd_target.append(word)
-                        else:
-                            break
-                    if len(new_cmd_target) != 0:
-                        cmd_target = new_cmd_target
-                        query_command = right_word
-                '''
-            elif search_mode == 1:
-                cmd_target = ["全部"]
-                can_single_query = False
-            command_list = [command for command in query_command.split("/")]
-            if len(command_list) == 0:
-                continue
-            # 添加条件指令
-            if tuple(cmd_target) not in condition_list.keys():
-                condition_list[tuple(cmd_target)] = []
-            condition_list[tuple(cmd_target)].append(command_list)
-            if len(command_list) == 1:
-                if "名称" in cmd_target:
-                    complete_name += command_list[0]
-                if "英文" in cmd_target:
-                    if complete_name_en != "":
-                        complete_name_en += " " + command_list[0]
-                    else:
-                        complete_name_en += command_list[0]
-            else:
-                complete_name = ""
-                complete_name_en = ""
-        # 防止空查询
-        condition_size = 0
-        for key_list in condition_list.keys():
-            condition_size += len(condition_list[key_list])
-        if condition_size == 0:
-            return []
-        # 正常查询
-        sql_condition, params = self.generate_search_conditions(condition_list)
-        #print(sql_condition)
-        rows = await self.bot.db.query.fetchall(
-            database,
-            sql_search_command_prefix + sql_condition + sql_command_suffix,
-            params,
-        )
-        for _data in rows:
-            query_result.append(QueryData(_data, database=database))
-            result_length += 1
-            if result_length > MAX_QUERY_ITEM_NUM:
-                raise QueryError("匹配条目过多，无法查询")
-        # 处理重定向
-        if use_redirect:
-            redirect_condition_list: Dict[tuple, List[List[str]]] = {
-                ("名称",) : []
-            }
-            sql_condition_list: Dict[tuple, List[List[str]]] = {
-                ("名称",) : []
-            }
-            for key_list in condition_list.keys():
-                if "全部" in key_list or "名称" in key_list:
-                    redirect_condition_list[("名称",)] += condition_list[key_list]
-                else:
-                    sql_condition_list[key_list] = condition_list[key_list]
-            if len(redirect_condition_list[("名称",)]) != 0:
-                redirect_result: List[List[str]] = []
-                sql_condition, params = self.generate_search_conditions(redirect_condition_list)
-                redirect_rows = await self.bot.db.query.fetchall(
-                    database,
-                    sql_redirect_command_prefix + sql_condition + sql_command_suffix,
-                    params,
-                )
-                for _data in redirect_rows:
-                    redirect_result.append([_data[0],_data[1]])
-                if len(redirect_condition_list) > 0:
-                    for _redirect in redirect_result:
-                        sql_condition_list[("名称",)] = [[_redirect[1]]]
-                        sql_condition, params = self.generate_search_conditions(sql_condition_list)
-                        redirected_rows = await self.bot.db.query.fetchall(
-                            database,
-                            sql_search_command_prefix + sql_condition + sql_command_suffix,
-                            params,
-                        )
-                        for _data in redirected_rows:
-                            query_result.append(QueryData(_data,_redirect[0],database))
-                            result_length += 1
-                            if result_length > MAX_QUERY_ITEM_NUM:
-                                raise QueryError("匹配条目过多，无法查询")
-        # 去除重复的条目，并寻找直接确认者,或者同名确认者
-        dupe_list: List[str] = []
-        new_query_result: List[QueryData] = []
-        found_equal: bool = False
-        for query_data in query_result:
-            if can_single_query:
-                if complete_name != "" and query_data.original_data[0] == complete_name:
-                    if not found_equal:
-                        dupe_list.clear()
-                        new_query_result.clear()
-                    found_equal = True
-                    if query_data.hash_word not in dupe_list:
-                        dupe_list.append(query_data.hash_word)
-                        new_query_result.append(query_data)
-                elif complete_name_en != "" and query_data.original_data[0].lower() == complete_name_en:
-                    if not found_equal:
-                        dupe_list.clear()
-                        new_query_result.clear()
-                    found_equal = True
-                    if query_data.hash_word not in dupe_list:
-                        dupe_list.append(query_data.hash_word)
-                        new_query_result.append(query_data)
-            if not found_equal:
-                if query_data.hash_word not in dupe_list:
-                    dupe_list.append(query_data.hash_word)
-                    new_query_result.append(query_data)
-        # 生成额外数据供使用
-        for query_data in query_result:
-            query_data.data_extend()
-        # 查询结束
-        return new_query_result
+    async def search_item(
+        self, database: str, query_command_list: List[str],
+        search_mode: int = 0, homebrew_database: str = "",
+    ) -> List[QueryData]:
+        """搜索合规的对象（适配层：调用 QueryStore.search() + dict→QueryData）。"""
+        databases = [database]
+        if homebrew_database:
+            databases.append(homebrew_database)
+
+        try:
+            result = await self.bot.db.query.search(
+                databases=databases,
+                query_tokens=query_command_list,
+                fulltext=(search_mode == 1),
+                limit=MAX_QUERY_ITEM_NUM,
+            )
+        except QueryStoreError:
+            raise QueryError("匹配条目过多，无法查询")
+
+        results: List[QueryData] = []
+        for r in result["results"]:
+            qd = QueryData(
+                [r["name"], r["name_en"], r["source"], r["catalogue"], r["tag"], r["content"]],
+                redirect_by=r.get("redirect_by", ""),
+                database=database,
+            )
+            qd.data_extend()
+            results.append(qd)
+        return results
 
     async def query_feedback(
         self,
@@ -1274,109 +1104,6 @@ class QueryCommand(UserCommandBase):
             self.record_dict[port] = QueryRecord(sub_query_items, database, get_current_date_raw(), len(sub_query_items))
         item.data_content = "\n".join(item_lines)
         return self.format_item_feedback(item)
-
-    def generate_search_conditions(
-        self,
-        condition_list: Dict[tuple, List[List[str]]],
-    ) -> Tuple[str, List[Any]]:
-        """
-        将多维条件构造成：
-        - 可执行的 SQL 片段（含占位符）
-        - 对应的 params 列表
-        """
-        sql_fragments: List[str] = []
-        params: List[Any] = []
-
-        for key_list in condition_list.keys():
-            cmd_groups = condition_list[key_list]
-            if len(cmd_groups) == 0:
-                continue
-
-            key_sql_parts: List[str] = []
-            key_params: List[Any] = []
-
-            if "全部" in key_list:
-                for command in cmd_groups:
-                    sql_part, part_params = self.generate_search_sql_regexp(
-                        command, "名称||英文||来源||分类||标签||内容"
-                    )
-                    key_sql_parts.append(sql_part)
-                    key_params.extend(part_params)
-            elif key_list == ["分类"]:
-                for command in cmd_groups:
-                    sql_part, part_params = self.generate_search_sql_in(command, "分类")
-                    key_sql_parts.append(sql_part)
-                    key_params.extend(part_params)
-            else:
-                for command in cmd_groups:
-                    sql_part, part_params = self.generate_search_sql_regexp(
-                        command, "||".join(key_list)
-                    )
-                    key_sql_parts.append(sql_part)
-                    key_params.extend(part_params)
-
-            if len(key_sql_parts) != 0:
-                sql_fragments.append("(" + " AND ".join(key_sql_parts) + ")")
-                params.extend(key_params)
-
-        return " AND ".join(sql_fragments), params
-    
-    def generate_search_sql_regexp(
-        self,
-        command_list: List[str],
-        prefix: str = "名称",
-    ) -> Tuple[str, List[str]]:
-        # 生成正则表达式的 condition（params 化）
-        result: List[str] = []
-        for command in command_list:
-            if command.startswith("-") and len(command) > 1:
-                result.append(f"^(?!.*{regexp_normalize(command[1:])})")
-            elif command.startswith("=") and len(command) > 1:
-                result.append(f"^{regexp_normalize(command[1:])}$")
-            elif len(command) > 0:
-                result.append(regexp_normalize(command))
-
-        pattern = "|".join(result)
-        return f"{prefix} regexp ?", [pattern]
-    
-    def generate_search_sql_in(
-        self,
-        command_list: List[str],
-        prefix: str = "来源",
-    ) -> Tuple[str, List[str]]:
-        # 生成列表检测 condition（params 化）
-        words: List[str] = []
-        anti_words: List[str] = []
-        for command in command_list:
-            if command.startswith("-") and len(command) > 1:
-                anti_words.append(command[1:])
-            elif command.startswith("=") and len(command) > 1:
-                words.append(command[1:])
-            elif len(command) > 0:
-                words.append(command)
-
-        clauses: List[str] = []
-        params: List[str] = []
-
-        if words:
-            placeholders = ",".join(["?"] * len(words))
-            clauses.append(f"{prefix} in ({placeholders})")
-            params.extend(words)
-
-        if anti_words:
-            placeholders = ",".join(["?"] * len(anti_words))
-            clauses.append(f"{prefix} not in ({placeholders})")
-            params.extend(anti_words)
-
-        if not clauses:
-            # 理论上不会发生：search_item 会保证至少有一个有效 token
-            return "1=0", []
-
-        if len(clauses) == 1:
-            return clauses[0], params
-
-        # words + anti_words：保持旧语义的 OR（满足 in 或不在 anti 集）
-        return f"({clauses[0]} OR {clauses[1]})", params
 
     def format_item_feedback(self, item: QueryData) -> str:
         # 最基本的单条目返回文本

--- a/src/plugins/DicePP/module/query/query_utils.py
+++ b/src/plugins/DicePP/module/query/query_utils.py
@@ -1,0 +1,49 @@
+"""查询工具函数 — 供 QueryCommand 和 persona 工具共享。
+
+契约:
+- command_split("") / command_split("  ") → 返回 []；command_split("# / &") → 返回 ["/"]（`/` 非特殊前缀，作为普通 token 收集）
+- 此模块为独立函数集合，零依赖。
+修改时需同时通过 tests/module/query/ (.查询路径) 和 persona 工具测试验证。
+"""
+from typing import List
+
+
+def command_split(keywords: str) -> List[str]:
+    """将用户输入的查询文本解析为 token 列表。
+
+    支持:
+    - 空格分隔的关键词
+    - # 前缀的标签/来源搜索
+    - & 前缀的分类搜索
+    - 双引号精确匹配
+    - / 分隔的 OR 关键词
+    """
+    result_list: List[str] = []
+    collect_words: str = ""
+    prefix: str = ""
+    fine_mode: bool = False
+    for key in keywords:
+        if not fine_mode and collect_words == "" and key == "\"":
+            fine_mode = True
+        elif fine_mode and key == "\"":
+            fine_mode = False
+            if collect_words != "":
+                result_list.append(prefix + collect_words)
+                prefix = ""
+        elif not fine_mode and key in ["#", "&"]:
+            if collect_words.strip():
+                result_list.append(prefix + collect_words.strip())
+            collect_words = ""
+            prefix = key
+        elif not fine_mode and key in [" "]:
+            if collect_words.strip():
+                result_list.append(prefix + collect_words.strip())
+            collect_words = ""
+            prefix = ""
+        else:
+            collect_words += key
+    if fine_mode:
+        result_list.append(prefix + collect_words)
+    elif collect_words.strip():
+        result_list.append(prefix + collect_words.strip())
+    return result_list

--- a/src/plugins/DicePP/shell/bot_runner.py
+++ b/src/plugins/DicePP/shell/bot_runner.py
@@ -158,6 +158,7 @@ class BotRunner:
         msg: str,
         group_id: str = "",
         dice_sequence: Optional[List[int]] = None,
+        to_me: bool = False,
     ) -> Dict[str, Any]:
         """发送消息到 Bot
 
@@ -191,7 +192,7 @@ class BotRunner:
                 raw_msg=msg,
                 sender=MessageSender(user_id, nickname),
                 group_id=group_id,
-                to_me=False,
+                to_me=to_me,
             )
 
             # 处理消息

--- a/src/plugins/DicePP/shell/main.py
+++ b/src/plugins/DicePP/shell/main.py
@@ -75,6 +75,7 @@ def cmd_send(args) -> None:
                 msg=args.msg,
                 group_id=group_id,
                 dice_sequence=dice_seq,
+                to_me=getattr(args, "to_me", False),
             )
         finally:
             await runner.stop()
@@ -148,6 +149,7 @@ def main() -> None:
     send_parser.add_argument("--msg", required=True, help="Message content")
     send_parser.add_argument("--private", action="store_true", help="Send as private message")
     send_parser.add_argument("--dice", help="Dice sequence, e.g., '20,18,15,8'")
+    send_parser.add_argument("--to-me", action="store_true", dest="to_me", help="Mark message as @bot trigger")
     send_parser.add_argument("--json", action="store_true", help="Output in JSON format")
     send_parser.set_defaults(func=cmd_send)
 

--- a/tests/module/persona/tools/test_list_databases.py
+++ b/tests/module/persona/tools/test_list_databases.py
@@ -1,0 +1,63 @@
+import pytest
+import json
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_list_databases_returns_info(fresh_bot, tmp_path):
+    """list_query_databases — 返回数据库列表和默认库"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.list_databases import (
+        LIST_QUERY_DATABASES_TOOL,
+        list_query_databases_executor,
+    )
+    from module.persona.tools.context import ToolContext
+
+    # 创建测试数据库
+    db_name = "LISTDBTEST"
+    db_path = str(tmp_path / f"{db_name}.db")
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("测试条目", "TestEntry", "PHB", "法术", "通用", "内容"),
+            commit=True,
+        )
+
+        async def _resolve_db(user_id, group_id):
+            return db_name
+
+        ctx = ToolContext(
+            user_id="test_user", group_id="",
+            query=bot.db.query, resolve_db=_resolve_db,
+        )
+        result = await list_query_databases_executor({}, ctx)
+        data = json.loads(result)
+
+        assert "databases" in data
+        assert data["default"] == db_name
+        # 找到我们创建的库
+        found = [d for d in data["databases"] if d["name"] == db_name]
+        assert len(found) == 1
+        assert found[0]["rows"] == 1
+        assert "法术" in found[0]["categories"]
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_list_databases_query_unavailable(fresh_bot):
+    """list_query_databases — query 不可用时的降级"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.list_databases import list_query_databases_executor
+    from module.persona.tools.context import ToolContext
+
+    ctx = ToolContext(user_id="test_user", group_id="")
+    result = await list_query_databases_executor({}, ctx)
+    assert "不可用" in result

--- a/tests/module/persona/tools/test_search_query.py
+++ b/tests/module/persona/tools/test_search_query.py
@@ -1,0 +1,227 @@
+import pytest
+import json
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_search_query_summary_mode(fresh_bot, tmp_path):
+    """search_query — 摘要模式返回 snippet"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.search_query import (
+        SEARCH_QUERY_TOOL,
+        search_query_executor,
+    )
+    from module.persona.tools.context import ToolContext
+
+    db_name = "SQSTEST"
+    db_path = str(tmp_path / f"{db_name}.db")
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        long_content = "这是一个非常长的内容" * 20  # ~200字
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能 3环", long_content),
+            commit=True,
+        )
+
+        async def _resolve_db(user_id, group_id):
+            return db_name
+
+        ctx = ToolContext(
+            user_id="test_user", group_id="",
+            query=bot.db.query, resolve_db=_resolve_db,
+        )
+        result = await search_query_executor({"keyword": "火球术"}, ctx)
+        data = json.loads(result)
+
+        assert "results" in data
+        assert data["total"] == 1
+        item = data["results"][0]
+        assert item["name"] == "火球术"
+        assert item["source"] == "PHB"
+        assert item["catalogue"] == "法术"
+        assert "snippet" in item
+        # snippet 应被截断到 150 字以内
+        assert len(item["snippet"]) <= 153  # 150 + "..."
+        assert "content" not in item  # 摘要模式不含完整内容
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_query_detail_mode(fresh_bot, tmp_path):
+    """search_query — 详情模式返回完整 content"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.search_query import search_query_executor
+    from module.persona.tools.context import ToolContext
+
+    db_name = "SQDETAIL"
+    db_path = str(tmp_path / f"{db_name}.db")
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能 3环", "完整火球术描述内容"),
+            commit=True,
+        )
+
+        async def _resolve_db(user_id, group_id):
+            return db_name
+
+        ctx = ToolContext(
+            user_id="test_user", group_id="",
+            query=bot.db.query, resolve_db=_resolve_db,
+        )
+        result = await search_query_executor(
+            {"keyword": "火球术", "detail_index": 0}, ctx,
+        )
+        data = json.loads(result)
+
+        assert data["name"] == "火球术"
+        assert data["content"] == "完整火球术描述内容"
+        assert "snippet" not in data
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_query_database_not_found(fresh_bot):
+    """search_query — 数据库不存在时的降级"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.search_query import search_query_executor
+    from module.persona.tools.context import ToolContext
+
+    async def _resolve_db(user_id, group_id):
+        return "NONEXIST_DB"
+
+    ctx = ToolContext(
+        user_id="test_user", group_id="",
+        query=bot.db.query, resolve_db=_resolve_db,
+    )
+    result = await search_query_executor({"keyword": "火球术"}, ctx)
+    assert "未加载" in result
+
+
+@pytest.mark.asyncio
+async def test_search_query_empty_keyword(fresh_bot, tmp_path):
+    """search_query — 空关键词降级"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.search_query import search_query_executor
+    from module.persona.tools.context import ToolContext
+
+    db_name = "SQEMPTY"
+    db_path = str(tmp_path / f"{db_name}.db")
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        async def _resolve_db(user_id, group_id):
+            return db_name
+
+        ctx = ToolContext(
+            user_id="test_user", group_id="",
+            query=bot.db.query, resolve_db=_resolve_db,
+        )
+        # keyword 只是纯特殊字符
+        result = await search_query_executor({"keyword": "# &"}, ctx)
+        assert "为空" in result or "关键词" in result
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_query_query_unavailable(fresh_bot):
+    """search_query — query 不可用时的降级"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.search_query import search_query_executor
+    from module.persona.tools.context import ToolContext
+
+    ctx = ToolContext(user_id="test_user", group_id="")
+    result = await search_query_executor({"keyword": "火球术"}, ctx)
+    assert "不可用" in result
+
+
+@pytest.mark.asyncio
+async def test_search_query_detail_index_out_of_range(fresh_bot, tmp_path):
+    """search_query — detail_index 越界降级"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.search_query import search_query_executor
+    from module.persona.tools.context import ToolContext
+
+    db_name = "SQINDEX"
+    db_path = str(tmp_path / f"{db_name}.db")
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能", "内容"),
+            commit=True,
+        )
+
+        async def _resolve_db(user_id, group_id):
+            return db_name
+
+        ctx = ToolContext(
+            user_id="test_user", group_id="",
+            query=bot.db.query, resolve_db=_resolve_db,
+        )
+        result = await search_query_executor(
+            {"keyword": "火球术", "detail_index": 99}, ctx,
+        )
+        assert "超出" in result
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_query_build_query_fallback(fresh_bot, tmp_path):
+    """search_query — query fallback 忽略结构化参数"""
+    bot, _proxy = fresh_bot
+
+    from module.persona.tools.search_query import search_query_executor
+    from module.persona.tools.context import ToolContext
+
+    db_name = "SQFALLBACK"
+    db_path = str(tmp_path / f"{db_name}.db")
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能", "内容"),
+            commit=True,
+        )
+
+        async def _resolve_db(user_id, group_id):
+            return db_name
+
+        ctx = ToolContext(
+            user_id="test_user", group_id="",
+            query=bot.db.query, resolve_db=_resolve_db,
+        )
+        # query 参数存在时应忽略 keyword
+        result = await search_query_executor(
+            {"keyword": "不存在的词条", "query": "火球术"}, ctx,
+        )
+        data = json.loads(result)
+        assert data["total"] == 1
+    finally:
+        await bot.db.query.disconnect_database(db_name)

--- a/tests/module/query/test_query_store_search.py
+++ b/tests/module/query/test_query_store_search.py
@@ -1,0 +1,385 @@
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_search_basic_keyword(fresh_bot, tmp_path):
+    """QueryStore.search() — 基本关键词搜索"""
+    bot, _proxy = fresh_bot
+
+    db_name = "SEARCHTEST"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能 3环", "火球术是3环塑能法术..."),
+            commit=True,
+        )
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火箭术", "Fire Arrow", "PHB", "法术", "塑能 2环", "火箭术是2环塑能法术..."),
+            commit=True,
+        )
+
+        result = await bot.db.query.search(
+            databases=[db_name],
+            query_tokens=["火球术"],
+        )
+        assert len(result["results"]) == 1
+        assert result["results"][0]["name"] == "火球术"
+        assert result["results"][0]["content"] == "火球术是3环塑能法术..."
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_fulltext(fresh_bot, tmp_path):
+    """QueryStore.search() — fulltext 正文搜索"""
+    bot, _proxy = fresh_bot
+
+    db_name = "SEARCHFULL"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能", "3环塑能法术，造成8d6火焰伤害"),
+            commit=True,
+        )
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("寒冰锥", "Cone of Cold", "PHB", "法术", "塑能", "5环塑能法术，造成8d8寒冷伤害"),
+            commit=True,
+        )
+
+        # fulltext=False 搜 "火焰" 不命中内容（只搜名称/英文）
+        result_name = await bot.db.query.search(
+            databases=[db_name],
+            query_tokens=["火焰"],
+            fulltext=False,
+        )
+        assert len(result_name["results"]) == 0
+
+        # fulltext=True 搜 "火焰" 命中内容
+        result_full = await bot.db.query.search(
+            databases=[db_name],
+            query_tokens=["火焰"],
+            fulltext=True,
+        )
+        assert len(result_full["results"]) == 1
+        assert result_full["results"][0]["name"] == "火球术"
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_redirect_resolution(fresh_bot, tmp_path):
+    """QueryStore.search() — redirect 解析（搜索词命中 redirect 表而非 data 表）"""
+    bot, _proxy = fresh_bot
+
+    db_name = "SEARCHREDIR"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能", "完整内容"),
+            commit=True,
+        )
+        # 别名与真实名称不重叠，确保只有 redirect 能命中
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO redirect VALUES(?,?)",
+            ("大火球", "火球术"),
+            commit=True,
+        )
+
+        result = await bot.db.query.search(
+            databases=[db_name],
+            query_tokens=["大火球"],
+        )
+        assert len(result["results"]) == 1
+        assert result["results"][0]["name"] == "火球术"
+        assert result["results"][0]["redirect_by"] == "大火球"
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_dedup(fresh_bot, tmp_path):
+    """QueryStore.search() — 去重（hash_word 相同只保留一条）"""
+    bot, _proxy = fresh_bot
+
+    db_name = "SEARCHDEDUP"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能", "内容A"),
+            commit=True,
+        )
+        # 同名+同来源+同分类 = 同 hash_word
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能 3环", "内容B"),
+            commit=True,
+        )
+
+        result = await bot.db.query.search(
+            databases=[db_name],
+            query_tokens=["火球术"],
+        )
+        assert len(result["results"]) == 1
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_max_total_exceeded(fresh_bot, tmp_path):
+    """QueryStore.search() — 超限抛 QueryStoreError"""
+    bot, _proxy = fresh_bot
+
+    from core.data.query_store import QueryStoreError
+
+    db_name = "SEARCHMAX"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        # 插入 5 条，设 max_total=3
+        for i in range(5):
+            await bot.db.query.execute(
+                db_name,
+                "INSERT INTO data VALUES(?,?,?,?,?,?)",
+                (f"条目{i}", f"Entry{i}", "PHB", "法术", "通用", f"内容{i}"),
+                commit=True,
+            )
+        with pytest.raises(QueryStoreError):
+            await bot.db.query.search(
+                databases=[db_name],
+                query_tokens=["条目"],
+                max_total=3,
+            )
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_get_database_info(fresh_bot, tmp_path):
+    """QueryStore.get_database_info() — 返回库元数据"""
+    bot, _proxy = fresh_bot
+
+    db_name = "INFOTEST"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能", "内容"),
+            commit=True,
+        )
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("长剑", "Longsword", "PHB", "武器", "军用", "内容"),
+            commit=True,
+        )
+
+        info = await bot.db.query.get_database_info(db_name)
+        assert info["name"] == db_name
+        assert info["rows"] == 2
+        assert "法术" in info["categories"]
+        assert "武器" in info["categories"]
+
+        # 未加载库返回 None
+        assert await bot.db.query.get_database_info("NONEXIST") is None
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_empty_tokens(fresh_bot):
+    """QueryStore.search() — 空 token 列表直接返回空"""
+    bot, _proxy = fresh_bot
+
+    result = await bot.db.query.search(
+        databases=["DND5E混合"],
+        query_tokens=[],
+    )
+    assert result == {"results": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_search_tag_prefix(fresh_bot, tmp_path):
+    """QueryStore.search() — #标签前缀过滤"""
+    bot, _proxy = fresh_bot
+
+    db_name = "TAGTEST"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能 3环", "内容"),
+            commit=True,
+        )
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("治疗伤口", "Cure Wounds", "PHB", "法术", "治愈 1环", "内容"),
+            commit=True,
+        )
+
+        # #塑能 应只命中火球术
+        result = await bot.db.query.search(
+            databases=[db_name],
+            query_tokens=["#塑能"],
+        )
+        assert len(result["results"]) == 1
+        assert result["results"][0]["name"] == "火球术"
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_category_prefix(fresh_bot, tmp_path):
+    """QueryStore.search() — &分类前缀过滤"""
+    bot, _proxy = fresh_bot
+
+    db_name = "CATTEST"
+    db_path = str(tmp_path / f"{db_name}.db")
+
+    await bot.db.query.create_empty_database(db_path)
+    await bot.db.query.connect_path(db_path)
+
+    try:
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能", "内容"),
+            commit=True,
+        )
+        await bot.db.query.execute(
+            db_name,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("长剑", "Longsword", "PHB", "武器", "军用", "内容"),
+            commit=True,
+        )
+
+        # &法术 应只命中火球术
+        result = await bot.db.query.search(
+            databases=[db_name],
+            query_tokens=["&法术"],
+        )
+        assert len(result["results"]) == 1
+        assert result["results"][0]["name"] == "火球术"
+    finally:
+        await bot.db.query.disconnect_database(db_name)
+
+
+@pytest.mark.asyncio
+async def test_search_homebrew_merge(fresh_bot, tmp_path):
+    """QueryStore.search() — HB 私设库合并（同名覆盖 + 空内容丢弃）"""
+    bot, _proxy = fresh_bot
+
+    main_db = "HBMAIN"
+    hb_db = "HBTEST"
+
+    main_path = str(tmp_path / f"{main_db}.db")
+    hb_path = str(tmp_path / f"{hb_db}.db")
+
+    await bot.db.query.create_empty_database(main_path)
+    await bot.db.query.connect_path(main_path)
+    await bot.db.query.create_empty_database(hb_path)
+    await bot.db.query.connect_path(hb_path)
+
+    try:
+        # 主库条目
+        await bot.db.query.execute(
+            main_db,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "塑能 3环", "主库火球术描述"),
+            commit=True,
+        )
+        await bot.db.query.execute(
+            main_db,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("寒冰锥", "Cone of Cold", "PHB", "法术", "塑能 5环", "主库寒冰锥描述"),
+            commit=True,
+        )
+
+        # HB 库：同名覆盖火球术 + 空内容条目
+        await bot.db.query.execute(
+            hb_db,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("火球术", "Fireball", "PHB", "法术", "私设 3环", "私设火球术描述"),
+            commit=True,
+        )
+        # 空内容条目 — 应被丢弃
+        await bot.db.query.execute(
+            hb_db,
+            "INSERT INTO data VALUES(?,?,?,?,?,?)",
+            ("空条目", "Empty", "PHB", "法术", "私设", ""),
+            commit=True,
+        )
+
+        result = await bot.db.query.search(
+            databases=[main_db, hb_db],
+            query_tokens=["火球术"],
+        )
+        assert len(result["results"]) == 1
+        assert result["results"][0]["content"] == "私设火球术描述"
+
+        # 空内容 HB 条目不应出现
+        result_all = await bot.db.query.search(
+            databases=[main_db, hb_db],
+            query_tokens=["空条目"],
+        )
+        assert len(result_all["results"]) == 0
+    finally:
+        await bot.db.query.disconnect_database(main_db)
+        await bot.db.query.disconnect_database(hb_db)
+
+
+@pytest.mark.asyncio
+async def test_search_empty_databases(fresh_bot):
+    """QueryStore.search() — 空 databases 列表返回空"""
+    bot, _proxy = fresh_bot
+
+    result = await bot.db.query.search(
+        databases=[],
+        query_tokens=["火球术"],
+    )
+    assert result == {"results": [], "total": 0}


### PR DESCRIPTION
## Summary
- 将搜索逻辑（SQL 生成、redirect 解析、去重、多库合并）从 QueryCommand 提取到 QueryStore.search()
- command_split() 提取为 query_utils.py 独立函数
- 新增两个 Persona AI CHAT 域工具：search_query（关键词/全文双模式）和 list_query_databases
- 群聊默认库回退改为读 bot.config.mode.default，消除硬编码
- dicepp-shell 新增 --to-me 参数支持 @bot 触发测试

## Test plan
- [x] 现有 query 模块 17 个测试无回归
- [x] 新增 QueryStore.search/get_database_info 11 个测试
- [x] 新增 search_query 工具 7 个测试
- [x] 新增 list_query_databases 工具 2 个测试
- [x] 现有 persona tools 14 个测试无回归
- [x] dicepp-shell 交互式验收：LLM 成功调用 search_query 和 list_query_databases