### PR TITLE
feat(persona): chat-driven character action — 聊天驱动的角色自主行动

### DIFF
--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -253,6 +253,16 @@ class PersonaConfig(BaseModel):
     proactive_coordinator_max_failures: int = Field(default=3, ge=0, description="coordinator 连续失败上限")
     proactive_coordinator_max_iterations: int = Field(default=5, ge=1, description="coordinator 单次 submit 最大迭代次数（防刷屏）")
 
+    # ── chat → life 行动建议
+    suggest_action_min_relationship: int = Field(
+        default=40, ge=0, le=100,
+        description="suggest_action 工具的最低关系分数阈值，低于此值的用户调用不会被评估",
+    )
+    suggest_action_evaluation_timeout: int = Field(
+        default=30, ge=5, le=120,
+        description="suggest_action 评估 LLM 的超时时间（秒）",
+    )
+
     # 已移除: scheduled_events 功能由 CharacterLife 边界事件和槽位系统覆盖
 
     # ── Phase 2: 群活跃度

--- a/src/plugins/DicePP/module/persona/character/models.py
+++ b/src/plugins/DicePP/module/persona/character/models.py
@@ -42,6 +42,12 @@ class PersonaExtensions(BaseModel):
     # - []（空列表）：不使用任何示例
     # - ["...", "..."]（非空列表）：使用自定义示例
     share_message_examples: Optional[List[str]] = Field(default=None)
+    # 睡眠期间回复语（可选，不配置则使用系统默认）
+    # 语义说明：
+    # - None（或未配置）：使用系统默认回复语
+    # - []（空列表）：显式关闭门控，睡眠中也正常回复
+    # - ["...", "..."]（非空列表）：使用自定义回复语
+    sleep_messages: Optional[List[str]] = Field(default=None)
 
     def generate_event_times(
         self,

--- a/src/plugins/DicePP/module/persona/chat/session.py
+++ b/src/plugins/DicePP/module/persona/chat/session.py
@@ -38,10 +38,13 @@ from ..game.decay import DecayCalculator
 from ..wall_clock import persona_wall_now, PERSONA_EPOCH, format_timestamp
 from ..tools.registry import ToolRegistry, ToolDomain
 from ..tools.context import ToolContext
+from ..life.protocols import SleepGate
 from ..llm.coordinator import LLMCallCoordinator
 from ..gateway.port import MessagePort
 from .segment_dispatcher import SegmentDispatcher, SegmentItem
 from .segment_state import SegmentBudgetState, SegmentLimits
+
+_DEFAULT_SLEEP_MESSAGES = ("角色正在休息，请稍后再来",)
 
 if TYPE_CHECKING:
     from core.config.pydantic_models import PersonaConfig
@@ -131,6 +134,7 @@ class ChatSession:
         segment_dispatcher: Optional[SegmentDispatcher] = None,
         query_store: Any = None,
         resolve_db: Any = None,
+        sleep_gate: Optional[SleepGate] = None,
     ):
         self.store = store
         self.router = router
@@ -145,6 +149,7 @@ class ChatSession:
         self.segment_dispatcher = segment_dispatcher
         self.query_store = query_store
         self.resolve_db = resolve_db
+        self._sleep_gate = sleep_gate
         self._pending_messages: Dict[str, deque] = {}
         self._last_messages: Dict[str, Tuple[str, float]] = {}
 
@@ -178,6 +183,17 @@ class ChatSession:
 
         try:
             is_chat_message = not message.startswith(".") or message.lower().startswith(".ai")
+
+            # 睡眠门控（仅拦截聊天消息，命令透传）
+            if is_chat_message and self._sleep_gate is not None and not await self._sleep_gate.is_awake():
+                msgs = self.character.extensions.sleep_messages
+                if msgs is None:
+                    msgs = _DEFAULT_SLEEP_MESSAGES
+                if msgs:
+                    msg = random.choice(msgs)
+                    logger.info(f"睡眠门控触发: user={user_id}, character={self.character.name}")
+                    return msg
+
             if self.config.relationship_refuse_enabled and is_chat_message:
                 if group_id:
                     history = await self.store.get_group_unified_messages(group_id, limit=1)

--- a/src/plugins/DicePP/module/persona/factory.py
+++ b/src/plugins/DicePP/module/persona/factory.py
@@ -21,6 +21,7 @@ from .exceptions import (
 from .game.decay import DecayCalculator, DecayConfig
 from .gateway.pipeline import MessagePipeline, TruncateStage
 from .gateway.port import MessagePort
+from .life.action_evaluator import ActionEvaluator
 from .life.character_life import CharacterLife, CharacterLifeConfig
 from .life.diary import DiaryGenerator, DiaryConfig
 from .life.event_agent import EventGenerationAgent
@@ -28,6 +29,7 @@ from .life.proactive_config import ProactiveConfig
 from .life.proactive_scheduler import ProactiveScheduler
 from .life.event_share_queue import EventShareTaskQueue
 from .life.simulator import LifeSimulator, LifeConfig
+from .life.protocols import SleepGate
 from .life.target import TargetSelector
 from .llm.coordinator import LLMCallCoordinator
 from .llm.router import LLMRouter
@@ -38,6 +40,7 @@ from .tools.roll_dice import ROLL_DICE_TOOL, roll_dice_executor
 from .tools.send_reply_segment import make_tool_def, send_reply_segment_executor
 from .tools.list_databases import LIST_QUERY_DATABASES_TOOL, list_query_databases_executor
 from .tools.search_query import SEARCH_QUERY_TOOL, search_query_executor
+from .tools.suggest_action import SUGGEST_ACTION_TOOL, make_suggest_action_executor
 from .chat.segment_dispatcher import SegmentDispatcher
 
 
@@ -228,6 +231,7 @@ def _build_chat(
     segment_dispatcher: Optional[SegmentDispatcher] = None,
     query_store: Any = None,
     resolve_db: Any = None,
+    sleep_gate: Optional[SleepGate] = None,
 ) -> ChatSession:
     """组装 ChatSession"""
     scoring_agent = ScoringAgent(router, timezone=config.timezone,
@@ -267,6 +271,7 @@ def _build_chat(
         segment_dispatcher=segment_dispatcher,
         query_store=query_store,
         resolve_db=resolve_db,
+        sleep_gate=sleep_gate,
     )
 
 
@@ -277,18 +282,11 @@ async def _build_life(
     coordinator: LLMCallCoordinator,
     port: MessagePort,
     decay_calculator: DecayCalculator,
-    router: LLMRouter,
+    character_life: CharacterLife,
+    event_agent: EventGenerationAgent,
+    event_share_queue: EventShareTaskQueue,
 ) -> LifeSimulator:
-    """组装 LifeSimulator 及其全部子组件"""
-    event_agent = EventGenerationAgent(router, config=config)
-    life_config = CharacterLifeConfig.from_persona(config)
-    character_life = CharacterLife(
-        config=life_config,
-        event_agent=event_agent,
-        data_store=store,
-        character=character,
-    )
-
+    """组装 LifeSimulator — 仅构造 scheduler, diary_generator 等外围组件"""
     target_selector = TargetSelector(
         data_store=store,
         bot_config=config,
@@ -311,14 +309,6 @@ async def _build_life(
     character_life.set_boundary_receiver(scheduler)
     await character_life.load_persistent_state()
     logger.info("角色生活模拟已初始化")
-
-    event_share_queue = EventShareTaskQueue(
-        data_store=store,
-        share_threshold=config.proactive_event_share_threshold,
-        max_retries=config.proactive_share_max_retries,
-        timezone=config.timezone,
-    )
-    logger.info("延迟任务队列已初始化")
 
     diary_config = DiaryConfig(
         diary_time=config.character_life_diary_time,
@@ -367,9 +357,9 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
     if not config.primary_api_key:
         raise PersonaConfigError("未配置主模型 API Key (persona_ai.primary_api_key)")
 
+    # ── Step 1: 基础设施 (store, router, port)
     store = await _build_store(bot, config)
     router = _build_router(config, store)
-
     port = _build_port(bot, store)
 
     segment_dispatcher = None
@@ -377,6 +367,49 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
         segment_dispatcher = SegmentDispatcher(
             message_port=port,
         )
+
+    # ── Step 2: event_agent (life 和 scheduler 共用)
+    event_agent = EventGenerationAgent(router, config=config)
+
+    # ── Step 3: event_share_queue (提前构造，供 character_life 和 _build_life 共用)
+    event_share_queue = EventShareTaskQueue(
+        data_store=store,
+        share_threshold=config.proactive_event_share_threshold,
+        max_retries=config.proactive_share_max_retries,
+        timezone=config.timezone,
+    )
+    logger.info("延迟任务队列已初始化")
+
+    # ── Step 4: character_life (提前构造，供 sleep_gate 和 suggest_action 引用)
+    life_config = CharacterLifeConfig.from_persona(config)
+    character_life = CharacterLife(
+        config=life_config,
+        event_agent=event_agent,
+        data_store=store,
+        character=character,
+        event_share_queue=event_share_queue,
+        share_threshold=config.proactive_event_share_threshold,
+        share_delay_min=config.proactive_event_share_delay_min,
+        share_delay_max=config.proactive_event_share_delay_max,
+    )
+
+    # ── Step 5: action_evaluator
+    action_evaluator = ActionEvaluator(
+        store=store,
+        router=router,
+        config=config,
+        timezone=config.timezone,
+    )
+    logger.info("ActionEvaluator 已初始化")
+
+    # ── Step 6: tool_registry (含 suggest_action executor)
+    suggest_action_executor = make_suggest_action_executor(
+        store=store,
+        action_evaluator=action_evaluator,
+        character_life=character_life,
+        min_relationship=config.suggest_action_min_relationship,
+        life_lock=character_life._state_lock,
+    )
 
     tool_registry = ToolRegistry()
     tool_registry.register(ToolDomain.CHAT, SEARCH_MEMORY_TOOL, search_memory_executor)
@@ -388,6 +421,7 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
     tool_registry.register(ToolDomain.CHAT, ROLL_DICE_TOOL, roll_dice_executor)
     tool_registry.register(ToolDomain.CHAT, LIST_QUERY_DATABASES_TOOL, list_query_databases_executor)
     tool_registry.register(ToolDomain.CHAT, SEARCH_QUERY_TOOL, search_query_executor)
+    tool_registry.register(ToolDomain.CHAT, SUGGEST_ACTION_TOOL, suggest_action_executor)
     if config.segment_enabled:
         tool_registry.register(
             ToolDomain.CHAT,
@@ -400,6 +434,7 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
         )
     logger.info("工具注册表与分段调度器已初始化")
 
+    # ── Step 7: coordinator, decay_calculator
     coordinator = LLMCallCoordinator(
         max_failures=config.proactive_coordinator_max_failures,
         max_iterations=config.proactive_coordinator_max_iterations,
@@ -412,6 +447,7 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
     )
     logger.info("衰减计算器已初始化")
 
+    # ── Step 8: _build_chat (注入 sleep_gate)
     async def _resolve_query_db(user_id: str, group_id: str) -> str:
         if group_id:
             row = await bot.db.group_config.get(group_id)
@@ -430,8 +466,16 @@ async def create_persona(bot: Bot) -> Optional[PersonaApp]:
         store, router, tool_registry, coordinator, character, config,
         decay_calculator, port, segment_dispatcher,
         query_store=bot.db.query, resolve_db=_resolve_query_db,
+        sleep_gate=character_life,
     )
-    life = await _build_life(store, character, config, coordinator, port, decay_calculator, router)
+
+    # ── Step 9: _build_life (注入预构造组件)
+    life = await _build_life(
+        store, character, config, coordinator, port, decay_calculator,
+        character_life=character_life,
+        event_agent=event_agent,
+        event_share_queue=event_share_queue,
+    )
 
     logger.info("Persona 模块初始化完成")
     return PersonaApp(

--- a/src/plugins/DicePP/module/persona/life/action_evaluator.py
+++ b/src/plugins/DicePP/module/persona/life/action_evaluator.py
@@ -1,0 +1,202 @@
+"""
+ActionEvaluator — 独立的 LLM 评估管线
+
+评估用户对话中产生的行动灵感是否适合角色执行。
+不依赖 CharacterLife 或 EventGenerationAgent，仅通过 store 读取上下文。
+"""
+import re
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+from nonebot.log import logger
+
+from ..data.store import PersonaDataStore
+from ..data.models import ModelTier
+from ..llm.loop import AgentLoop
+from ..tools.collecting import make_collecting_executor
+from ..tools.registry import ToolRegistry, ToolDef
+
+if TYPE_CHECKING:
+    from core.config.pydantic_models import PersonaConfig
+    from ..llm.router import LLMRouter
+
+RECORD_EVALUATION_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "record_evaluation",
+        "description": "记录行动可行性评估结果",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string",
+                    "enum": ["approved", "rejected", "deferred"],
+                    "description": "评估结论：approved=可行立即执行, rejected=不可行丢弃, deferred=可行但有进行中活动需等待",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "评估理由，30-80字，说明为何通过/拒绝/推迟",
+                },
+            },
+            "required": ["result", "reason"],
+        },
+    },
+}
+
+# 常见中文地点词匹配
+_LOCATION_RE = re.compile(
+    r"(家|学校|学院|大学|商店|便利店|超市|市场|公园|花园|酒馆|酒吧|"
+    r"咖啡厅|咖啡馆|餐厅|饭店|食堂|街道|广场|医院|诊所|药房|图书馆|"
+    r"书店|健身房|体育馆|游泳馆|电影院|剧场|商场|办公室|公司|工厂|"
+    r"车站|机场|码头|河边|海边|山上|森林|田野|寺庙|教堂)"
+)
+
+_SYSTEM_PROMPT = """你是行为可行性评估专家。根据以下信息判断角色是否可以在当前状态下执行所述行动。
+
+硬约束：
+1. 反瞬移：角色当前位置基于今日事件推断。不能从一个地点瞬间跳到另一个。
+2. 反并发：进行中活动未结束时，不能同时做另一件事。
+3. 时间合理性：深夜不适合外出活动，体力低不适合剧烈活动。
+
+你必须通过调用 record_evaluation 工具来输出结果，不要直接回复文本。"""
+
+
+class ActionEvaluator:
+    """独立的行动可行性评估器"""
+
+    def __init__(
+        self,
+        store: PersonaDataStore,
+        router: "LLMRouter",
+        config: "PersonaConfig",
+        timezone: str = "Asia/Shanghai",
+    ):
+        self._store = store
+        self._router = router
+        self._timezone = timezone
+        self._timeout = config.suggest_action_evaluation_timeout
+
+    def _get_today_str(self) -> str:
+        from ..wall_clock import persona_wall_now
+        return persona_wall_now(self._timezone).strftime("%Y-%m-%d")
+
+    @staticmethod
+    def _extract_location(today_events: List) -> str:
+        if not today_events:
+            return "unknown"
+        last_event = today_events[-1]
+        text = getattr(last_event, "description", "") or ""
+        m = _LOCATION_RE.search(text)
+        return m.group(1) if m else "unknown"
+
+    def _build_user_prompt(
+        self,
+        action_idea: str,
+        character_state,
+        location_context: str,
+        today_events: List,
+        ongoing_descriptions: List[str],
+    ) -> str:
+        now = self._now()
+        time_str = now.strftime("%H:%M")
+        energy = character_state.energy if character_state.energy is not None else 50
+        mood = character_state.mood if character_state.mood is not None else 50
+        health = character_state.health if character_state.health is not None else 50
+
+        events_lines = []
+        for e in today_events[-5:]:
+            t = getattr(e, "created_at", None)
+            ts = t.strftime("%H:%M") if t else "??:??"
+            desc = getattr(e, "description", "") or ""
+            events_lines.append(f"- [{ts}] {desc}")
+        events_text = "\n".join(events_lines) if events_lines else "无"
+
+        ongoing_text = "\n".join(f"- {d}" for d in ongoing_descriptions) if ongoing_descriptions else "无"
+
+        return (
+            f"当前时间: {time_str}\n"
+            f"角色状态: energy={energy}/100 mood={mood}/100 health={health}/100\n"
+            f"当前位置推断: {location_context}\n"
+            f"进行中活动:\n{ongoing_text}\n"
+            f"今日事件:\n{events_text}\n"
+            f"行动建议: {action_idea}"
+        )
+
+    def _now(self):
+        from ..wall_clock import persona_wall_now
+        return persona_wall_now(self._timezone)
+
+    async def evaluate(
+        self,
+        action_idea: str,
+        ongoing_descriptions: Optional[List[str]] = None,
+    ) -> Tuple[str, str]:
+        """评估行动可行性，返回 (result, reason)。"""
+        try:
+            character_state = await self._store.get_character_state()
+            if not character_state:
+                return ("rejected", "角色状态不存在")
+
+            today_str = self._get_today_str()
+            today_events = await self._store.get_daily_events(today_str)
+            location_context = self._extract_location(today_events)
+
+            user_prompt = self._build_user_prompt(
+                action_idea=action_idea,
+                character_state=character_state,
+                location_context=location_context,
+                today_events=today_events,
+                ongoing_descriptions=ongoing_descriptions or [],
+            )
+
+            return await self._call_llm(user_prompt)
+
+        except Exception:
+            logger.exception("[ActionEvaluator] 评估失败")
+            return ("rejected", "评估异常，默认拒绝")
+
+    async def _call_llm(self, user_prompt: str) -> Tuple[str, str]:
+        collected_args: list = []
+        tool_registry = ToolRegistry()
+        tool_registry.register(
+            "life",
+            ToolDef(name="record_evaluation", description="", parameters=RECORD_EVALUATION_TOOL["function"]["parameters"]),
+            make_collecting_executor(collected_args),
+        )
+
+        from ..llm.router import LLMRouter
+        hooks = self._router.make_default_hooks()
+        loop = AgentLoop(
+            provider=self._router.auxiliary_client,
+            tool_registry=tool_registry,
+            hooks=hooks,
+            max_tool_rounds=1,
+        )
+
+        try:
+            from ..llm.loop import LoopResult
+            result: LoopResult = await loop.run(
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": user_prompt},
+                ],
+                tools=[RECORD_EVALUATION_TOOL],
+                temperature=0.3,
+                timeout=self._timeout,
+            )
+        except Exception:
+            logger.exception("[ActionEvaluator] LLM 调用异常")
+            return ("rejected", "LLM 调用失败")
+
+        if not collected_args:
+            logger.warning("[ActionEvaluator] LLM 未调用 record_evaluation 工具")
+            return ("rejected", "LLM 未生成评估结果")
+
+        args = collected_args[0]
+        result_val = str(args.get("result", "rejected")).strip().lower()
+        reason = str(args.get("reason", "评估失败")).strip()
+
+        if result_val not in ("approved", "rejected", "deferred"):
+            result_val = "rejected"
+
+        logger.info(f"[ActionEvaluator] result={result_val} reason={reason[:80]}")
+        return (result_val, reason)

--- a/src/plugins/DicePP/module/persona/life/character_life.py
+++ b/src/plugins/DicePP/module/persona/life/character_life.py
@@ -4,6 +4,7 @@
 管理角色的全天生活事件生成和日记记录。
 事件触发时刻由角色卡 PersonaExtensions.generate_event_times() 决定（日内分钟槽位）。
 """
+import asyncio
 import json
 from nonebot.log import logger
 import random
@@ -18,6 +19,7 @@ from ..data.store import PersonaDataStore
 from ..data.persist_keys import PERSONA_SK_CHARACTER_LIFE
 from ..data.models import CharacterState
 from ..wall_clock import persona_wall_now
+from .event_share_queue import EventShareTaskQueue
 from .protocols import BoundaryReceiver
 
 if TYPE_CHECKING:
@@ -99,11 +101,20 @@ class CharacterLife:
         event_agent: EventGenerationAgent,
         data_store: PersonaDataStore,
         character: Character,
+        share_threshold: float,
+        *,
+        event_share_queue: Optional[EventShareTaskQueue] = None,
+        share_delay_min: int = 1,
+        share_delay_max: int = 5,
     ):
         self.config = config
         self.event_agent = event_agent
         self.data_store = data_store
         self.character = character
+        self.event_share_queue = event_share_queue
+        self._share_threshold = share_threshold
+        self._share_delay_min = share_delay_min
+        self._share_delay_max = share_delay_max
         # 当日计划槽位（自 0 点起的分钟, 槽位类型），边界槽位类型为 wake_up/good_night，日常为 system
         self._slot_minutes_today: Optional[List[Tuple[int, str]]] = None
         self._fired_slot_indices: Set[int] = set()
@@ -119,6 +130,8 @@ class CharacterLife:
         # 可选的边界接收器，用于同步波动边界和标记边界事件
         self.boundary_receiver: Optional[BoundaryReceiver] = None
         self._boundaries_loaded = False
+        # 状态读写并发锁（保护 inject_spontaneous_event 与 generate_daily_event 的 state 读写区间）
+        self._state_lock = asyncio.Lock()
 
     def update_character(self, character: Character) -> None:
         """同步新的角色卡引用"""
@@ -278,6 +291,14 @@ class CharacterLife:
         self._chain_triggered_today = bool(data.get("chain_triggered"))
         # 加载上次跨天恢复日期
         self._day_transition_recovered_date = data.get("day_transition_recovered_date")
+        # 恢复波动边界（兼容旧持久化数据）
+        js = data.get("jittered_start")
+        je = data.get("jittered_end")
+        if js is not None and je is not None:
+            self._today_jittered_start = int(js)
+            self._today_jittered_end = int(je)
+        else:
+            self._regenerate_slots_for_today()
 
     async def save_persistent_state(self) -> None:
         today = self._get_today_str()
@@ -297,6 +318,8 @@ class CharacterLife:
             ],
             "chain_triggered": self._chain_triggered_today,
             "day_transition_recovered_date": self._day_transition_recovered_date,
+            "jittered_start": self._today_jittered_start,
+            "jittered_end": self._today_jittered_end,
         }
         await self.data_store.set_setting(
             PERSONA_SK_CHARACTER_LIFE,
@@ -400,6 +423,18 @@ class CharacterLife:
             today = self._get_today_str()
             now = self.config.now()
 
+            async with self._state_lock:
+                return await self._generate_daily_event_impl(today, now, slot_type)
+
+        except Exception as e:
+            logger.exception("生成生活事件失败: {}", e)
+            return []
+
+    async def _generate_daily_event_impl(
+        self, today: str, now, slot_type: str
+    ) -> List[Dict[str, Any]]:
+        """generate_daily_event 的 state-locked 实现"""
+        try:
             # 获取角色状态，初始化旧版迁移的 None 字段，处理跨天空清意向
             character_state = await self.data_store.get_character_state()
             if character_state:
@@ -521,19 +556,8 @@ class CharacterLife:
                     character_state.intention_created_at = now
                     await self.data_store.update_character_state(character_state)
 
-                # 合并 event + reaction 的原始 LLM 输出
-                raw_parts: Dict[str, Any] = {}
-                if event_result.raw_response:
-                    try:
-                        raw_parts["event"] = json.loads(event_result.raw_response)
-                    except json.JSONDecodeError:
-                        raw_parts["event"] = event_result.raw_response
-                if reaction_result.raw_response:
-                    try:
-                        raw_parts["reaction"] = json.loads(reaction_result.raw_response)
-                    except json.JSONDecodeError:
-                        raw_parts["reaction"] = reaction_result.raw_response
-                combined_raw = json.dumps(raw_parts, ensure_ascii=False) if raw_parts else ""
+                combined_raw = CharacterLife._serialize_raw_parts(
+                    event_result.raw_response, reaction_result.raw_response)
 
                 # 保存事件到数据库
                 await self.data_store.add_daily_event(
@@ -608,7 +632,7 @@ class CharacterLife:
             return event_chain
 
         except Exception as e:
-            logger.exception("生成生活事件失败: {}", e)
+            logger.exception("生成生活事件失败 (impl): {}", e)
             return []
 
     async def _get_recent_diaries(self, days: int) -> List[str]:
@@ -642,3 +666,200 @@ class CharacterLife:
             "chain_max_depth": self.config.chain_max_depth,
             "chain_force_extend_once_prob": self.config.chain_force_extend_once_prob,
         }
+
+    # ── SleepGate ──────────────────────────────────────────────
+
+    def _slot_fired(self, slot_type: str) -> bool:
+        """检查指定类型的槽位是否已触发"""
+        if not self._slot_minutes_today:
+            return False
+        for i, (_, st) in enumerate(self._slot_minutes_today):
+            if st == slot_type and i in self._fired_slot_indices:
+                return True
+        return False
+
+    async def is_awake(self) -> bool:
+        """检查角色是否清醒（供 ChatSession 睡眠门控使用）"""
+        async with self._state_lock:
+            return self._is_awake_locked()
+
+    def _is_awake_locked(self) -> bool:
+        """is_awake 的无锁实现，调用方负责持有 _state_lock"""
+        if self._today_jittered_start is None or self._today_jittered_end is None:
+            return True
+
+        now = self.config.now()
+        now_m = now.hour * 60 + now.minute
+        start = self._today_jittered_start
+        end = self._today_jittered_end
+
+        in_window: bool
+        if end >= start:
+            in_window = start <= now_m <= end
+        else:
+            in_window = now_m >= start or now_m <= end
+
+        if not in_window:
+            return False
+
+        if self._slot_fired("good_night") and not self._slot_fired("wake_up"):
+            return False
+
+        return True
+
+    @staticmethod
+    def _serialize_raw_parts(event_raw: str, reaction_raw: str) -> str:
+        raw_parts: Dict[str, Any] = {}
+        for key, raw in [("event", event_raw), ("reaction", reaction_raw)]:
+            if raw:
+                try:
+                    raw_parts[key] = json.loads(raw)
+                except json.JSONDecodeError:
+                    raw_parts[key] = raw
+        return json.dumps(raw_parts, ensure_ascii=False) if raw_parts else ""
+
+    # ── Spontaneous Event Injection ────────────────────────────
+
+    async def _get_today_event_dicts(self) -> List[Dict[str, str]]:
+        events = await self._get_today_events()
+        result: List[Dict[str, str]] = []
+        for e in events:
+            evt_time = e.created_at.strftime("%H:%M") if e.created_at else "??:??"
+            result.append({"description": e.description, "time": evt_time})
+        return result
+
+    async def inject_spontaneous_event(self, action_description: str) -> bool:
+        """注入自发事件，绕开槽位系统。
+
+        注意：此方法不检查 is_awake()，允许在睡眠期间仍有自发事件注入。
+        调用方（suggest_action executor）如需拦截，应自行检查清醒状态。
+        """
+        async with self._state_lock:
+            try:
+                return await self._inject_spontaneous_event_impl(action_description)
+            except Exception:
+                logger.exception("[spontaneous] 注入失败")
+                return False
+
+    async def _inject_spontaneous_event_impl(self, action_description: str) -> bool:
+        character_state = await self.data_store.get_character_state()
+        if not character_state:
+            return False
+        self._migrate_legacy_state(character_state)
+
+        now = self.config.now()
+        recent_diaries = await self._get_recent_diaries(3)
+        today_event_dicts = await self._get_today_event_dicts()
+
+        ongoing = self.get_ongoing_activities()
+        ongoing_context = "\n".join(
+            f"- 进行中: {a.description}" for a in ongoing
+        ) if ongoing else ""
+        state_context = (
+            f"体力{character_state.energy}/心情{character_state.mood}/健康{character_state.health}"
+        )
+        if ongoing_context:
+            state_context += "\n" + ongoing_context
+
+        context = EventContext(
+            character_name=self.character.name,
+            character_description=self.character.description,
+            world=self.character.extensions.world,
+            scenario=f"{self.character.scenario}\n\n【当前场景：{action_description}】",
+            recent_diaries=recent_diaries,
+            today_events=list(today_event_dicts),
+            permanent_state=character_state.text + ("\n当前状态: " + state_context if state_context else ""),
+            current_time=now,
+            energy=character_state.energy,
+            mood=character_state.mood,
+            health=character_state.health,
+            current_intention=character_state.current_intention,
+            intention_created_at=character_state.intention_created_at,
+        )
+
+        event_result = await self.event_agent.generate_event_result(context)
+        ed = CharacterLife._clamp_delta(event_result.energy_delta)
+        md = CharacterLife._clamp_delta(event_result.mood_delta)
+        hd = CharacterLife._clamp_delta(event_result.health_delta)
+
+        character_state.energy = max(0, min(100, character_state.energy + ed))
+        character_state.mood = max(0, min(100, character_state.mood + md))
+        character_state.health = max(0, min(100, character_state.health + hd))
+        await self.data_store.update_character_state(character_state)
+
+        reaction_result = await self.event_agent.generate_event_reaction(
+            event=event_result.description,
+            character_name=self.character.name,
+            character_description=self.character.description,
+            share_policy="optional",
+            today_events=list(today_event_dicts),
+            energy=character_state.energy,
+            mood=character_state.mood,
+            health=character_state.health,
+        )
+
+        pending_plan = reaction_result.pending_plan
+        if pending_plan is None:
+            pass
+        elif pending_plan == "":
+            character_state.current_intention = None
+            character_state.intention_created_at = None
+            await self.data_store.update_character_state(character_state)
+        else:
+            character_state.current_intention = pending_plan
+            character_state.intention_created_at = now
+            await self.data_store.update_character_state(character_state)
+
+        combined_raw = CharacterLife._serialize_raw_parts(
+            event_result.raw_response, reaction_result.raw_response)
+
+        try:
+            await self.data_store.add_daily_event(
+                date=self._get_today_str(),
+                event_type="spontaneous",
+                description=event_result.description,
+                reaction=reaction_result.reaction,
+                share_desire=reaction_result.share_desire,
+                duration_minutes=event_result.duration_minutes,
+                system_prompt_digest=event_result.system_prompt_digest,
+                raw_response=combined_raw,
+                energy_delta=event_result.energy_delta,
+                mood_delta=event_result.mood_delta,
+                health_delta=event_result.health_delta,
+                context_summary=event_result.context_summary,
+            )
+        except Exception:
+            logger.exception("[spontaneous] persist failed")
+            return False
+
+        if event_result.duration_minutes > 0:
+            self._add_ongoing_activity(
+                description=event_result.description,
+                duration_minutes=event_result.duration_minutes,
+            )
+
+        if (
+            self.event_share_queue is not None
+            and reaction_result.share_desire >= self._share_threshold
+        ):
+            event_id = f"evt_{now.strftime('%Y%m%d%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            delay = random.randint(
+                self._share_delay_min, self._share_delay_max,
+            )
+            try:
+                await self.event_share_queue.enqueue_event_share(
+                    event_id=event_id,
+                    event_description=event_result.description,
+                    reaction=reaction_result.reaction,
+                    share_desire=reaction_result.share_desire,
+                    delay_minutes=delay,
+                )
+            except Exception:
+                logger.exception("[spontaneous] 分享入队失败")
+
+        logger.info(
+            "[spontaneous] 注入成功 desc=%s energy=%+d mood=%+d health=%+d",
+            event_result.description[:60],
+            ed, md, hd,
+        )
+        return True

--- a/src/plugins/DicePP/module/persona/life/protocols.py
+++ b/src/plugins/DicePP/module/persona/life/protocols.py
@@ -16,3 +16,9 @@ class BoundaryReceiver(Protocol):
     """窄接口：CharacterLife 向外部通知边界事件和波动边界。"""
 
     def set_jittered_boundaries(self, start: int, end: int) -> None: ...
+
+
+class SleepGate(Protocol):
+    """窄接口：CharacterLife 向 ChatSession 提供清醒状态查询。"""
+
+    async def is_awake(self) -> bool: ...

--- a/src/plugins/DicePP/module/persona/tools/suggest_action.py
+++ b/src/plugins/DicePP/module/persona/tools/suggest_action.py
@@ -1,0 +1,76 @@
+"""suggest_action 工具 — Chat LLM 将行动灵感传递给生活模拟"""
+import asyncio
+from typing import Any, Callable
+
+from nonebot.log import logger
+
+from .registry import ToolDef
+
+SUGGEST_ACTION_TOOL = ToolDef(
+    name="suggest_action",
+    description="当对话中产生了角色可能想做的行动灵感时调用此工具。"
+                "行动灵感可能来自：用户给角色的建议、角色主动提出的想法、"
+                "或聊天中自然涌现的灵光一闪。"
+                "调用后角色会在合适的时机自主决定是否执行，你不需要等待结果。",
+    parameters={
+        "type": "object",
+        "properties": {
+            "action_idea": {
+                "type": "string",
+                "description": "行动灵感的自然语言描述，如'出去散散步''做点吃的''给窗台上的植物浇水'",
+            },
+        },
+        "required": ["action_idea"],
+    },
+)
+
+
+def make_suggest_action_executor(
+    store: Any,
+    action_evaluator: Any,
+    character_life: Any,
+    min_relationship: int,
+    life_lock: asyncio.Lock,
+) -> Callable:
+    """返回 suggest_action 工具的 executor 闭包。
+
+    life_lock 用于串行化评估+注入全过程，与 tick 路径的 _state_lock 互斥，
+    保证评估阶段读取的角色状态是连贯快照。
+    """
+
+    async def executor(args: dict, ctx: Any) -> str:
+        user_id = ctx.user_id
+        action_idea = str(args.get("action_idea", "")).strip()
+        if not action_idea:
+            return "action noted"
+
+        rel = await store.get_relationship(user_id)
+        if not rel or rel.composite_score < min_relationship:
+            logger.info(
+                "[suggest_action] SKIP user=%s score=%.2f threshold=%d",
+                user_id, rel.composite_score if rel else 0, min_relationship,
+            )
+            return "action noted"
+
+        async def _evaluate_and_inject():
+            try:
+                async with life_lock:
+                    ongoing = [a.description for a in character_life.get_ongoing_activities()]
+                    result, reason = await action_evaluator.evaluate(action_idea, ongoing)
+                    logger.info(
+                        "[suggest_action] EVAL user=%s result=%s reason=%s",
+                        user_id, result, reason,
+                    )
+                    if result == "approved":
+                        injected = await character_life._inject_spontaneous_event_impl(action_idea)
+                        logger.info(
+                            "[suggest_action] INJECT user=%s success=%s", user_id, injected,
+                        )
+            except Exception:
+                logger.exception("[suggest_action] 异步评估失败")
+
+        asyncio.create_task(_evaluate_and_inject())
+        logger.info("[suggest_action] QUEUED user=%s idea=%s", user_id, action_idea[:80])
+        return "action noted"
+
+    return executor

--- a/tests/e2e/persona/test_character_lifecycle_real_llm.py
+++ b/tests/e2e/persona/test_character_lifecycle_real_llm.py
@@ -181,6 +181,7 @@ async def _run_full_day_lifecycle() -> dict:
             event_agent=agent,
             data_store=store,
             character=character,
+            share_threshold=0.4,
         )
         life.boundary_receiver = MagicMock()
         diary_generator = DiaryGenerator(

--- a/tests/integration/persona/test_character_day_simulation.py
+++ b/tests/integration/persona/test_character_day_simulation.py
@@ -148,6 +148,7 @@ def life(temp_db, mock_event_agent, character, config):
         event_agent=mock_event_agent,
         data_store=temp_db,
         character=character,
+        share_threshold=0.4,
     )
     life.boundary_receiver = MagicMock()
     return life

--- a/tests/module/persona/life/test_chat_life_integration.py
+++ b/tests/module/persona/life/test_chat_life_integration.py
@@ -1,0 +1,301 @@
+"""R9: suggest_action + SleepGate + inject_spontaneous_event 专项测试"""
+import asyncio
+from datetime import datetime
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from plugins.DicePP.module.persona.life.character_life import (
+    CharacterLife,
+    CharacterLifeConfig,
+)
+from plugins.DicePP.module.persona.character.models import Character, PersonaExtensions
+from plugins.DicePP.module.persona.data.models import CharacterState
+
+
+def _make_character(sleep_messages=None):
+    ext = PersonaExtensions(sleep_messages=sleep_messages)
+    return Character(name="TestChar", description="A test character", extensions=ext)
+
+
+def _make_cfg(**kw):
+    return CharacterLifeConfig(
+        enabled=True,
+        slot_match_window_minutes=15,
+        timezone="Asia/Shanghai",
+        min_event_interval_minutes=5,
+        chain_max_depth=1,
+        chain_force_extend_once_prob=0.0,
+        default_energy=50, default_mood=50, default_health=50,
+        recovery_energy=20, recovery_mood=10, recovery_health=5,
+        **kw,
+    )
+
+
+def _dt(hour, minute=0):
+    return datetime(2026, 5, 15, hour, minute, 0)
+
+
+class TestSleepGate:
+    """is_awake() 各场景测试"""
+
+    def _make_life(self, start=None, end=None, good_night_fired=False, wake_up_fired=False):
+        char = _make_character()
+        cfg = _make_cfg()
+        event_agent = MagicMock()
+        store = AsyncMock()
+        life = CharacterLife(config=cfg, event_agent=event_agent, data_store=store, character=char, share_threshold=0.4)
+        life._today_jittered_start = start
+        life._today_jittered_end = end
+        if good_night_fired or wake_up_fired:
+            s = start if start is not None else 480
+            e = end if end is not None else 1320
+            life._slot_minutes_today = [(s, "wake_up"), (e, "good_night")]
+            if wake_up_fired:
+                life._fired_slot_indices.add(0)
+            if good_night_fired:
+                life._fired_slot_indices.add(1)
+        return life
+
+    @pytest.mark.asyncio
+    async def test_uninitialized_returns_true(self):
+        life = self._make_life(start=None, end=None)
+        assert await life.is_awake() is True
+
+    @pytest.mark.asyncio
+    async def test_inside_window_not_fired(self):
+        life = self._make_life(start=480, end=1320)
+        life.config.now = lambda: _dt(12, 0)
+        assert await life.is_awake() is True
+
+    @pytest.mark.asyncio
+    async def test_before_window_returns_false(self):
+        life = self._make_life(start=480, end=1320)
+        life.config.now = lambda: _dt(6, 0)
+        assert await life.is_awake() is False
+
+    @pytest.mark.asyncio
+    async def test_after_window_returns_false(self):
+        life = self._make_life(start=480, end=1320)
+        life.config.now = lambda: _dt(23, 0)
+        assert await life.is_awake() is False
+
+    @pytest.mark.asyncio
+    async def test_good_night_fired_while_in_window_returns_false(self):
+        life = self._make_life(start=480, end=1320, good_night_fired=True)
+        life.config.now = lambda: _dt(22, 0)
+        assert await life.is_awake() is False
+
+    @pytest.mark.asyncio
+    async def test_cross_midnight_window(self):
+        life = self._make_life(start=1320, end=120)
+        life.config.now = lambda: _dt(23, 30)
+        assert await life.is_awake() is True
+
+    @pytest.mark.asyncio
+    async def test_cross_midnight_before_dawn_in_window(self):
+        life = self._make_life(start=1320, end=120)
+        life.config.now = lambda: _dt(1, 0)
+        assert await life.is_awake() is True
+
+    @pytest.mark.asyncio
+    async def test_cross_midnight_outside_window(self):
+        life = self._make_life(start=1320, end=120)
+        life.config.now = lambda: _dt(8, 0)
+        assert await life.is_awake() is False
+
+    @pytest.mark.asyncio
+    async def test_cross_midnight_wake_up_resets_good_night(self):
+        life = self._make_life(start=1320, end=120, good_night_fired=True, wake_up_fired=True)
+        life.config.now = lambda: _dt(1, 0)
+        assert await life.is_awake() is True
+
+class TestSleepMessagesSemantics:
+    """sleep_messages 三态语义测试"""
+
+    def test_none_uses_default(self):
+        char = _make_character(sleep_messages=None)
+        assert char.extensions.sleep_messages is None
+
+    def test_empty_list_disables_gate_but_chat_proceeds(self):
+        char = _make_character(sleep_messages=[])
+        assert char.extensions.sleep_messages == []
+
+    def test_custom_messages_no_fallback(self):
+        char = _make_character(sleep_messages=["zzz...", "不要吵我"])
+        assert len(char.extensions.sleep_messages) == 2
+        assert "zzz..." in char.extensions.sleep_messages
+
+
+class TestSuggestActionRelationshipGate:
+    """suggest_action executor 亲密度门控测试"""
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_skips(self):
+        from plugins.DicePP.module.persona.tools.suggest_action import make_suggest_action_executor
+
+        store = AsyncMock()
+        rel = MagicMock()
+        rel.composite_score = 25.0
+        store.get_relationship = AsyncMock(return_value=rel)
+        action_evaluator = AsyncMock()
+        character_life = MagicMock()
+
+        executor = make_suggest_action_executor(
+            store=store, action_evaluator=action_evaluator,
+            character_life=character_life, min_relationship=40,
+            life_lock=asyncio.Lock(),
+        )
+        ctx = MagicMock(user_id="u1")
+        result = await executor({"action_idea": "出去散步"}, ctx)
+        assert result == "action noted"
+        action_evaluator.evaluate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_above_threshold_proceeds(self):
+        from plugins.DicePP.module.persona.tools.suggest_action import make_suggest_action_executor
+
+        store = AsyncMock()
+        rel = MagicMock()
+        rel.composite_score = 55.0
+        store.get_relationship = AsyncMock(return_value=rel)
+        action_evaluator = AsyncMock()
+        character_life = MagicMock()
+        character_life.get_ongoing_activities.return_value = []
+
+        executor = make_suggest_action_executor(
+            store=store, action_evaluator=action_evaluator,
+            character_life=character_life, min_relationship=40,
+            life_lock=asyncio.Lock(),
+        )
+        ctx = MagicMock(user_id="u1")
+        result = await executor({"action_idea": "出去散步"}, ctx)
+        assert result == "action noted"
+        # fire-and-forget: executor returns immediately, evaluate runs in background
+        await asyncio.sleep(0.1)
+
+    @pytest.mark.asyncio
+    async def test_missing_relationship_skips(self):
+        from plugins.DicePP.module.persona.tools.suggest_action import make_suggest_action_executor
+
+        store = AsyncMock()
+        store.get_relationship = AsyncMock(return_value=None)
+        action_evaluator = AsyncMock()
+        character_life = MagicMock()
+
+        executor = make_suggest_action_executor(
+            store=store, action_evaluator=action_evaluator,
+            character_life=character_life, min_relationship=40,
+            life_lock=asyncio.Lock(),
+        )
+        ctx = MagicMock(user_id="u1")
+        result = await executor({"action_idea": "测试"}, ctx)
+        assert result == "action noted"
+        action_evaluator.evaluate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lock_serializes_injection(self):
+        from plugins.DicePP.module.persona.tools.suggest_action import make_suggest_action_executor
+
+        life_lock = asyncio.Lock()
+        store = AsyncMock()
+        rel = MagicMock()
+        rel.composite_score = 55.0
+        store.get_relationship = AsyncMock(return_value=rel)
+
+        call_order = []
+        async def slow_evaluate(*args, **kw):
+            call_order.append("eval")
+            await asyncio.sleep(0.05)
+            return ("approved", "ok")
+
+        action_evaluator = MagicMock()
+        action_evaluator.evaluate = slow_evaluate
+        character_life = MagicMock()
+        character_life.get_ongoing_activities.return_value = []
+        character_life._inject_spontaneous_event_impl = AsyncMock(return_value=True)
+
+        executor = make_suggest_action_executor(
+            store=store, action_evaluator=action_evaluator,
+            character_life=character_life, min_relationship=40,
+            life_lock=life_lock,
+        )
+        ctx = MagicMock(user_id="u1")
+
+        await executor({"action_idea": "task1"}, ctx)
+        await executor({"action_idea": "task2"}, ctx)
+
+        await asyncio.sleep(0.3)
+        assert len(call_order) == 2
+        assert character_life._inject_spontaneous_event_impl.call_count == 2
+
+
+class TestInjectSpontaneousEvent:
+    """inject_spontaneous_event 基础流程测试"""
+
+    def test_state_lock_exists(self):
+        char = _make_character()
+        cfg = _make_cfg()
+        event_agent = MagicMock()
+        store = AsyncMock()
+        life = CharacterLife(config=cfg, event_agent=event_agent, data_store=store, character=char, share_threshold=0.4)
+        assert hasattr(life, '_state_lock')
+        assert isinstance(life._state_lock, asyncio.Lock)
+
+    @pytest.mark.asyncio
+    async def test_inject_returns_false_on_missing_state(self):
+        char = _make_character()
+        cfg = _make_cfg()
+        event_agent = MagicMock()
+        store = AsyncMock()
+        store.get_character_state = AsyncMock(return_value=None)
+        life = CharacterLife(config=cfg, event_agent=event_agent, data_store=store, character=char, share_threshold=0.4)
+        result = await life.inject_spontaneous_event("测试行动")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_lock_serializes_concurrent_calls(self):
+        char = _make_character()
+        cfg = _make_cfg()
+        event_agent = MagicMock()
+        store = AsyncMock()
+        cs = CharacterState(energy=50, mood=50, health=50)
+        store.get_character_state = AsyncMock(return_value=cs)
+        life = CharacterLife(config=cfg, event_agent=event_agent, data_store=store, character=char, share_threshold=0.4)
+
+        call_order = []
+
+        async def fake_impl(action_description):
+            call_order.append(action_description)
+            return True
+
+        life._inject_spontaneous_event_impl = fake_impl
+
+        results = await asyncio.gather(
+            life.inject_spontaneous_event("first"),
+            life.inject_spontaneous_event("second"),
+            life.inject_spontaneous_event("third"),
+        )
+        assert results == [True, True, True]
+        assert call_order == ["first", "second", "third"]
+
+
+class TestSerializeRawParts:
+    """_serialize_raw_parts 静态方法测试"""
+
+    def test_both_valid_json(self):
+        result = CharacterLife._serialize_raw_parts(
+            '{"desc":"test event"}', '{"reaction":"test reaction"}')
+        assert '"event"' in result
+        assert '"reaction"' in result
+
+    def test_both_empty_returns_empty_string(self):
+        assert CharacterLife._serialize_raw_parts("", "") == ""
+
+    def test_one_json_one_plain(self):
+        result = CharacterLife._serialize_raw_parts('{"desc":"ok"}', "plain text reaction")
+        assert '"event"' in result
+        assert "plain text reaction" in result
+
+    def test_invalid_json_preserved_as_is(self):
+        result = CharacterLife._serialize_raw_parts("not json", "")
+        assert "not json" in result

--- a/tests/unit/persona/test_character_life.py
+++ b/tests/unit/persona/test_character_life.py
@@ -76,6 +76,7 @@ class TestCharacterLifeBasics:
             event_agent=mock_event_agent,
             data_store=mock_data_store,
             character=character,
+            share_threshold=0.4,
         )
         life.boundary_receiver = MagicMock()
         return life
@@ -245,6 +246,7 @@ class TestCharacterLifePersistence:
             event_agent=mock_event_agent,
             data_store=mock_data_store,
             character=character,
+            share_threshold=0.4,
         )
 
     @pytest.mark.asyncio
@@ -260,7 +262,7 @@ class TestCharacterLifePersistence:
             "plugins.DicePP.module.persona.life.character_life.persona_wall_now",
             lambda tz: fake_now,
         )
-        raw = '{"date": "2024-01-01", "slot_minutes": [480, 720, 960], "fired": [0]}'
+        raw = '{"date": "2024-01-01", "slot_minutes": [480, 720, 960], "fired": [0], "jittered_start": 420, "jittered_end": 1260}'
         mock_data_store.get_setting.return_value = raw
         await life.load_persistent_state()
         assert life._slot_minutes_today == [(480, "system"), (720, "system"), (960, "system")]
@@ -406,6 +408,7 @@ class TestCharacterLifeStatus:
             event_agent=MagicMock(),
             data_store=MagicMock(),
             character=char,
+            share_threshold=0.4,
         )
 
     def test_get_event_status(self, life, monkeypatch):

--- a/tests/unit/persona/test_character_life_phase1.py
+++ b/tests/unit/persona/test_character_life_phase1.py
@@ -78,6 +78,7 @@ class TestCharacterLifePhase1:
             event_agent=mock_event_agent,
             data_store=mock_data_store,
             character=character,
+            share_threshold=0.4,
         )
         life.boundary_receiver = MagicMock()
         return life

--- a/tests/unit/persona/test_character_life_phase2.py
+++ b/tests/unit/persona/test_character_life_phase2.py
@@ -89,6 +89,7 @@ class TestCharacterLifePhase2:
             event_agent=mock_event_agent,
             data_store=mock_data_store,
             character=character,
+            share_threshold=0.4,
         )
         life.boundary_receiver = MagicMock()
         return life

--- a/tests/unit/persona/test_factory_smoke.py
+++ b/tests/unit/persona/test_factory_smoke.py
@@ -55,6 +55,11 @@ def _make_bot() -> MagicMock:
     cfg.proactive_coordinator_max_failures = 3
     cfg.proactive_coordinator_max_iterations = 5
     cfg.proactive_event_share_threshold = 0.6
+    cfg.proactive_event_share_delay_min = 1
+    cfg.proactive_event_share_delay_max = 5
+    cfg.proactive_share_max_retries = 2
+    cfg.suggest_action_min_relationship = 40
+    cfg.suggest_action_evaluation_timeout = 30
     cfg.proactive_always_send_users = []
     cfg.proactive_always_send_groups = []
     cfg.group_activity_min_threshold = 0.0
@@ -70,7 +75,7 @@ def _make_bot() -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_create_persona_success_registers_three_tools(monkeypatch):
-    """create_persona 成功组装后，chat 域命中三个工具定义"""
+    """create_persona 成功组装后，chat 域命中工具定义"""
     bot = _make_bot()
 
     character = Character(
@@ -134,6 +139,7 @@ async def test_create_persona_success_registers_three_tools(monkeypatch):
     assert "search_chat_history" in names, f"缺失 search_chat_history，实际注册: {names}"
     assert "roll_dice" in names, f"缺失 roll_dice，实际注册: {names}"
     assert "send_reply_segment" in names, f"缺失 send_reply_segment，实际注册: {names}"
+    assert "suggest_action" in names, f"缺失 suggest_action，实际注册: {names}"
 
     # R6: 跨组件引用一致性
     assert app.chat is not None


### PR DESCRIPTION
## Summary

Chat LLM 可通过 suggest_action 工具向生活模拟子系统建议角色行动，由独立的 ActionEvaluator 评估可行性后注入为自发事件。同时引入 SleepGate 睡眠门控协议，角色睡眠期间聊天回复可配置拦截。

## Key Changes

- **suggest_action 工具**: Chat LLM 产出行动灵感, 经亲密度阈值过滤后进入异步评估
- **ActionEvaluator**: 独立 LLM 评估行动可行性 (approved/rejected/deferred), 含超时与地点提取
- **SleepGate 协议 + is_awake()**: 角色清醒状态查询, sleep_messages 支持三态语义 (None/[]/[...])
- **inject_spontaneous_event**: 外部事件注入角色生活, 与槽位事件共享 _state_lock 串行化
- **_serialize_raw_parts**: 消除 event/reaction 序列化代码重复
- **波动边界持久化**: 重启后恢复当天 jittered boundary, 避免睡眠门控失效

## Test Plan

- [x] 642 个 persona 相关测试全部通过
- [x] suggest_action 门控、并发串行化、亲密度过滤覆盖
- [x] 睡眠门控各场景 (窗口内/外、跨午夜、good_night/wake_up 状态)
- [x] 注入事件与槽位事件的锁竞争验证