### PR TITLE
feat(persona): 新增每日综合日报生成器，自动收集运营统计与 Persona 数据并分段发送给 Master

### DIFF
--- a/docs/dicepp/persona/config-example.md
+++ b/docs/dicepp/persona/config-example.md
@@ -11,6 +11,8 @@
 | 配置项 | 类型 | 示例 / 默认 | 说明 |
 |--------|------|-------------|------|
 | `enabled` | bool | `true` | 是否启用 Persona 模块 |
+| `daily_report_enabled` | bool | `true` | 是否启用每日综合日报（含 LLM 开场白与运营统计），每日 tick_daily 时发送给 Master |
+| `daily_report_voice_enabled` | bool | `true` | 日报是否使用 LLM 角色口吻开场白，关闭则用纯模板 |
 | `character_name` | string | `default` | 角色卡文件名（不含路径），对应 `character_path` 下 yaml |
 | `character_path` | string | `./content/characters` | 角色卡目录 |
 | `timezone` | string | `Asia/Shanghai` | **IANA 时区名**（`ZoneInfo`）；勿写 `UTC+8` 等。见 `global.json` 内 `_comment_timezone` |

--- a/src/plugins/DicePP/core/bot/dicebot.py
+++ b/src/plugins/DicePP/core/bot/dicebot.py
@@ -382,14 +382,14 @@ class Bot:
             except (AttributeError, TypeError, KeyError, RuntimeError):
                 dice_log(str(self.handle_exception(f"Tick Daily: {command.readable_name} CODE111")[0]))
         # 给Master发送每日更新通知（Persona 日报启用时跳过）
-        # 检查 persona command 实例的实际运行状态，而非 config 静态值：
+        # 检查 PersonaCommand 实例的实际运行状态，而非 config 静态值：
         # config.enabled=True 但 PersonaApp 初始化失败时，实例 enabled=False，
         # 此处应与实例状态同步，避免日报和旧通知双双缺失。
-        persona_running = False
-        for command in self.command_dict.values():
-            if hasattr(command, "enabled") and command.enabled:
-                persona_running = True
-                break
+        from plugins.DicePP.module.persona.command import PersonaCommand
+        persona_running = any(
+            isinstance(cmd, PersonaCommand) and cmd.enabled
+            for cmd in self.command_dict.values()
+        )
         if not (persona_running and self.config.persona_ai.daily_report_enabled):
             from core.localization import LOC_DAILY_UPDATE
             feedback = self.loc_helper.format_loc_text(LOC_DAILY_UPDATE)

--- a/src/plugins/DicePP/core/bot/dicebot.py
+++ b/src/plugins/DicePP/core/bot/dicebot.py
@@ -381,11 +381,20 @@ class Bot:
                 bot_commands += daily_result
             except (AttributeError, TypeError, KeyError, RuntimeError):
                 dice_log(str(self.handle_exception(f"Tick Daily: {command.readable_name} CODE111")[0]))
-        # 给Master发送每日更新通知
-        from core.localization import LOC_DAILY_UPDATE
-        feedback = self.loc_helper.format_loc_text(LOC_DAILY_UPDATE)
-        if feedback and feedback != "$":
-            await self.send_msg_to_master(feedback)
+        # 给Master发送每日更新通知（Persona 日报启用时跳过）
+        # 检查 persona command 实例的实际运行状态，而非 config 静态值：
+        # config.enabled=True 但 PersonaApp 初始化失败时，实例 enabled=False，
+        # 此处应与实例状态同步，避免日报和旧通知双双缺失。
+        persona_running = False
+        for command in self.command_dict.values():
+            if hasattr(command, "enabled") and command.enabled:
+                persona_running = True
+                break
+        if not (persona_running and self.config.persona_ai.daily_report_enabled):
+            from core.localization import LOC_DAILY_UPDATE
+            feedback = self.loc_helper.format_loc_text(LOC_DAILY_UPDATE)
+            if feedback and feedback != "$":
+                await self.send_msg_to_master(feedback)
 
         # 日志文件自动清理 (超过24小时的log文件删除)
         try:

--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -54,6 +54,8 @@ class ProviderConfig(BaseModel):
 
 class PersonaConfig(BaseModel):
     enabled: bool = False
+    daily_report_enabled: bool = True
+    daily_report_voice_enabled: bool = True
     character_name: str = "default"
     character_path: str = "./content/characters"
 

--- a/src/plugins/DicePP/core/message_types.py
+++ b/src/plugins/DicePP/core/message_types.py
@@ -10,6 +10,7 @@ class MessageType(StrEnum):
     CHAT = "chat"
     COMMAND = "command"
     SYSTEM_NOTICE = "system_notice"
+    SYSTEM_LOG = "system_log"
 
     @classmethod
     def from_str(cls: Type[T], value: str) -> T:

--- a/src/plugins/DicePP/module/persona/admin.py
+++ b/src/plugins/DicePP/module/persona/admin.py
@@ -12,6 +12,7 @@ from core.bot import Bot
 
 from .factory import PersonaApp
 from .data.store import PersonaDataStore
+from .report.daily_report import DailyReportGenerator
 from .wall_clock import persona_wall_now
 from .game.decay import STAGE_FLOORS
 
@@ -25,6 +26,7 @@ class AdminDispatcher:
         app: Optional[PersonaApp] = None,
         data_store: Optional[PersonaDataStore] = None,
         init_error: Optional[str] = None,
+        report_generator: Optional[DailyReportGenerator] = None,
     ):
         self.bot = bot
         self.app = app
@@ -32,6 +34,7 @@ class AdminDispatcher:
         self.init_error = init_error
         self.config = bot.config.persona_ai if bot else None
         self._whitelist_confirm_pending: Dict[str, float] = {}
+        self._report_generator = report_generator
 
     def _is_admin(self, user_id: str) -> bool:
         return user_id in self.bot.config.admin or user_id in self.bot.config.master
@@ -42,13 +45,16 @@ class AdminDispatcher:
         """分发 admin 子命令"""
         if not self._is_admin(user_id):
             return "权限不足"
-        if not self.data_store:
-            return "模块未初始化"
         if not args:
             return self._help_text()
+        subcmd = args[0]
+        # snapshot 不依赖 PersonaApp 和 data_store，独立可用
+        if subcmd == "snapshot":
+            return await self._admin_snapshot(user_id, group_id, args)
+        if not self.data_store:
+            return "模块未初始化"
         if self.app is None:
             return "模块未初始化"
-        subcmd = args[0]
         handler = getattr(self, f"_admin_{subcmd}", None)
         if handler is None and subcmd in ("trace", "stats", "errors"):
             handler = getattr(self, f"_handle_admin_{subcmd}", None)
@@ -84,7 +90,8 @@ class AdminDispatcher:
             ".ai admin diary - 查看今天的事件和日记\n"
             ".ai admin probe reset <provider>/<model> - 重置 exhausted 模型\n"
             ".ai admin pause - 暂停主动消息\n"
-            ".ai admin resume - 恢复主动消息"
+            ".ai admin resume - 恢复主动消息\n"
+            ".ai admin snapshot - 查看当前运营快照"
         )
 
     # ── admin 子命令 ──────────────────────────────────────────
@@ -361,6 +368,14 @@ class AdminDispatcher:
             self.app.resume_scheduler()
             return "已恢复主动消息发送"
         return "调度器未初始化"
+
+    async def _admin_snapshot(self, user_id: str, group_id: str, args: List[str]) -> str:
+        if not self._report_generator:
+            return "日报生成器未初始化"
+        success = await self._report_generator.send_snapshot_to(user_id, group_id)
+        if not success:
+            return "快照发送失败"
+        return ""
 
     async def _admin_probe(self, user_id: str, group_id: str, args: List[str]) -> str:
         if not self._is_admin(user_id):

--- a/src/plugins/DicePP/module/persona/command.py
+++ b/src/plugins/DicePP/module/persona/command.py
@@ -25,6 +25,9 @@ from .llm.router import QuotaExceeded
 from .data.store import PersonaDataStore
 from .data.models import MessageType
 from .admin import AdminDispatcher
+from .report.daily_report import DailyReportGenerator
+from .gateway.port import MessagePort
+from .gateway.pipeline import MessagePipeline, TruncateStage
 
 
 @custom_user_command("PersonaAI", priority=DPP_COMMAND_PRIORITY_DEFAULT, flag=DPP_COMMAND_FLAG_FUN)
@@ -46,6 +49,8 @@ class PersonaCommand(UserCommandBase):
         self._async_tick_daily_task: Optional[asyncio.Task] = None
         # 管理员子命令分发器（在 delay_init 后由外部补齐）
         self._admin_handlers: Dict[str, Callable] = {}
+        # 日报生成器（生命周期独立于 PersonaApp）
+        self.report_generator: Optional[DailyReportGenerator] = None
 
     def _require_app(self) -> Optional[str]:
         """检查 app 和 data_store 是否已初始化，返回错误信息或 None"""
@@ -60,6 +65,7 @@ class PersonaCommand(UserCommandBase):
             app=self.app,
             data_store=self.data_store,
             init_error=self.init_error,
+            report_generator=self.report_generator,
         )
 
     def delay_init(self) -> List[str]:
@@ -70,6 +76,16 @@ class PersonaCommand(UserCommandBase):
 
         if not self.enabled:
             return ["Persona AI 模块已禁用"]
+
+        # 创建日报生成器（独立于 PersonaApp，app 初始为 None）
+        pipeline = MessagePipeline()
+        pipeline.add(TruncateStage(2000))
+        report_port = MessagePort(self.bot, pipeline=pipeline)
+        self.report_generator = DailyReportGenerator(
+            bot=self.bot,
+            port=report_port,
+            config=config,
+        )
 
         # 注册异步初始化任务
         async def init_persona():
@@ -84,6 +100,9 @@ class PersonaCommand(UserCommandBase):
                 return []
             if self.app:
                 self.data_store = self.app.store
+                # 注入 app 引用到日报生成器
+                if self.report_generator:
+                    self.report_generator.set_app(self.app)
                 # 注册消息发送后跨模块通知 hook（先注销旧 hook 再注册，防止热重载后重复）
                 if hasattr(self, "_post_send_hook_unregister"):
                     self._post_send_hook_unregister()
@@ -160,7 +179,7 @@ class PersonaCommand(UserCommandBase):
             return
         try:
             msg_type = MessageType.from_str(type)
-            if type not in (MessageType.CHAT.value, MessageType.COMMAND.value, MessageType.SYSTEM_NOTICE.value):
+            if type not in (MessageType.CHAT.value, MessageType.COMMAND.value, MessageType.SYSTEM_NOTICE.value, MessageType.SYSTEM_LOG.value):
                 dice_log(f"[Persona] 未知 message_type='{type}'，fallback 到 CHAT")
             await self.data_store.add_message_stream(
                 user_id=user_id,
@@ -317,7 +336,8 @@ class PersonaCommand(UserCommandBase):
         # 处理 admin 命令
         if cmd == "admin" or hint == "admin":
             response = await self._handle_admin(user_id, group_id, args)
-            await self._send(user_id, group_id, response)
+            if response:
+                await self._send(user_id, group_id, response)
             return []
 
         # 处理 profile 命令
@@ -713,6 +733,8 @@ class PersonaCommand(UserCommandBase):
                 diary = await self.app.tick_daily()
                 if diary:
                     dice_log(f"[Persona] 生成日记: {len(diary)} 字")
+                if self.report_generator and self.config.daily_report_enabled:
+                    await self.report_generator.generate_and_send(diary)
 
             # 清理已完成的任务
             dt = self._async_tick_daily_task
@@ -735,6 +757,8 @@ class PersonaCommand(UserCommandBase):
             diary = loop.run_until_complete(self.app.tick_daily())
             if diary:
                 dice_log(f"[Persona] 生成日记: {len(diary)} 字")
+            if self.report_generator and self.config.daily_report_enabled:
+                loop.run_until_complete(self.report_generator.generate_and_send(diary))
             return []
         except Exception as e:
             dice_log(f"[Persona] tick_daily 失败: {e}")

--- a/src/plugins/DicePP/module/persona/command.py
+++ b/src/plugins/DicePP/module/persona/command.py
@@ -754,11 +754,7 @@ class PersonaCommand(UserCommandBase):
                     self._async_tick_daily_task = asyncio.create_task(_run_daily())
                 return []
 
-            diary = loop.run_until_complete(self.app.tick_daily())
-            if diary:
-                dice_log(f"[Persona] 生成日记: {len(diary)} 字")
-            if self.report_generator and self.config.daily_report_enabled:
-                loop.run_until_complete(self.report_generator.generate_and_send(diary))
+            # unreachable: get_running_loop() 成功时 loop.is_running() 必为 True
             return []
         except Exception as e:
             dice_log(f"[Persona] tick_daily 失败: {e}")

--- a/src/plugins/DicePP/module/persona/data/store.py
+++ b/src/plugins/DicePP/module/persona/data/store.py
@@ -42,6 +42,9 @@ class PersonaDataStore:
     _PRUNE_INTERVAL_WRITES = 50
     _PRUNE_INTERVAL_SECONDS = 300
 
+    # SYSTEM_LOG 过滤条件，用于所有面向外部的 message_stream 查询
+    _EXCLUDE_SYSTEM_LOG = "type != 'system_log'"
+
     def __init__(
         self,
         db_connection: aiosqlite.Connection,
@@ -134,10 +137,11 @@ class PersonaDataStore:
     ) -> List[UnifiedMessage]:
         """获取最近消息（按 user_id + group_id），时间升序返回"""
         async with self.db.execute(
-            """
+            f"""
             SELECT id, user_id, group_id, role, type, content, display_name, created_at
             FROM message_stream
             WHERE user_id = ? AND group_id = ?
+              AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
             ORDER BY created_at DESC
             LIMIT ?
             """,
@@ -152,9 +156,9 @@ class PersonaDataStore:
         group_id 非空时查群聊，为空时查私聊。
         """
         async with self.db.execute(
-            """
+            f"""
             SELECT created_at FROM message_stream
-            WHERE user_id = ? AND group_id = ?
+            WHERE user_id = ? AND group_id = ? AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
             ORDER BY created_at ASC
             LIMIT 1
             """,
@@ -168,7 +172,7 @@ class PersonaDataStore:
     async def count_messages(self, user_id: str, group_id: str = "") -> int:
         """统计用户消息数量（使用 SELECT COUNT(*) 避免全量加载）"""
         async with self.db.execute(
-            "SELECT COUNT(*) FROM message_stream WHERE user_id = ? AND group_id = ?",
+            f"SELECT COUNT(*) FROM message_stream WHERE user_id = ? AND group_id = ? AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}",
             (user_id, group_id),
         ) as cursor:
             row = await cursor.fetchone()
@@ -181,18 +185,18 @@ class PersonaDataStore:
     ) -> List[UnifiedMessage]:
         """获取群聊最近消息，时间升序返回"""
         if limit is None:
-            sql = """
+            sql = f"""
             SELECT id, user_id, group_id, role, type, content, display_name, created_at
             FROM message_stream
-            WHERE group_id = ? AND group_id != ''
+            WHERE group_id = ? AND group_id != '' AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
             ORDER BY created_at DESC
             """
             params = (group_id,)
         else:
-            sql = """
+            sql = f"""
             SELECT id, user_id, group_id, role, type, content, display_name, created_at
             FROM message_stream
-            WHERE group_id = ? AND group_id != ''
+            WHERE group_id = ? AND group_id != '' AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
             ORDER BY created_at DESC
             LIMIT ?
             """
@@ -222,7 +226,7 @@ class PersonaDataStore:
         if (start_time is None) != (end_time is None):
             raise ValueError("start_time 和 end_time 必须同时提供或同时省略")
 
-        conditions = ["group_id = ?", "group_id != ''"]
+        conditions = ["group_id = ?", "group_id != ''", PersonaDataStore._EXCLUDE_SYSTEM_LOG]
         params: List[Any] = [group_id]
 
         if keyword:
@@ -261,19 +265,80 @@ class PersonaDataStore:
             rows = await cursor.fetchall()
             return [self._row_to_message(r) for r in reversed(list(rows))]
 
+    async def get_daily_message_stats(self, date: str) -> Dict[str, int]:
+        """获取某日 bot 主动发送消息统计（排除 SYSTEM_LOG）"""
+        async with self.db.execute(
+            f"""
+            SELECT COUNT(*) as sent,
+                   COUNT(DISTINCT user_id) as covered
+            FROM message_stream
+            WHERE role = 'assistant' AND date(created_at) = ?
+              AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
+            """,
+            (date,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return {"sent": row[0] if row else 0, "covered": row[1] if row else 0}
+
+    async def get_daily_interactive_users(self, date: str) -> tuple:
+        """获取某日互动用户统计：当日数、历史数、新增数"""
+        async with self.db.execute(
+            f"""
+            SELECT COUNT(DISTINCT user_id)
+            FROM message_stream
+            WHERE role = 'user' AND date(created_at) = ?
+              AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
+            """,
+            (date,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            yesterday_users = row[0] if row else 0
+
+        async with self.db.execute(
+            f"""
+            SELECT COUNT(DISTINCT user_id)
+            FROM message_stream
+            WHERE role = 'user' AND date(created_at) < ?
+              AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
+            """,
+            (date,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            before_users = row[0] if row else 0
+
+        async with self.db.execute(
+            f"""
+            SELECT COUNT(DISTINCT user_id)
+            FROM message_stream
+            WHERE role = 'user' AND date(created_at) = ?
+              AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
+              AND user_id NOT IN (
+                SELECT DISTINCT user_id FROM message_stream
+                WHERE role = 'user' AND date(created_at) < ?
+                  AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
+              )
+            """,
+            (date, date),
+        ) as cursor:
+            row = await cursor.fetchone()
+            new_users = row[0] if row else 0
+
+        return (yesterday_users, before_users, new_users)
+
     async def _prune_message_stream_private(self, user_id: str) -> None:
         """私聊按 user_id 维度保留最近 N 条"""
         async with self.db.execute(
-            "SELECT COUNT(*) FROM message_stream WHERE user_id = ? AND group_id = ''",
+            f"SELECT COUNT(*) FROM message_stream WHERE user_id = ? AND group_id = '' AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}",
             (user_id,),
         ) as cursor:
             row = await cursor.fetchone()
             if row and row[0] <= self._message_stream_max_per_group:
                 return
         await self.db.execute(
-            """
+            f"""
             DELETE FROM message_stream
             WHERE user_id = ? AND group_id = ''
+              AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
               AND id NOT IN (
                 SELECT id FROM message_stream
                 WHERE user_id = ? AND group_id = ''
@@ -288,16 +353,17 @@ class PersonaDataStore:
     async def _prune_message_stream_group(self, group_id: str) -> None:
         """群聊按 group_id 维度保留最近 N 条"""
         async with self.db.execute(
-            "SELECT COUNT(*) FROM message_stream WHERE group_id = ? AND group_id != ''",
+            f"SELECT COUNT(*) FROM message_stream WHERE group_id = ? AND group_id != '' AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}",
             (group_id,),
         ) as cursor:
             row = await cursor.fetchone()
             if row and row[0] <= self._message_stream_max_per_group:
                 return
         await self.db.execute(
-            """
+            f"""
             DELETE FROM message_stream
             WHERE group_id = ? AND group_id != ''
+              AND {PersonaDataStore._EXCLUDE_SYSTEM_LOG}
               AND id NOT IN (
                 SELECT id FROM message_stream
                 WHERE group_id = ? AND group_id != ''
@@ -333,6 +399,14 @@ class PersonaDataStore:
             await self._prune_message_stream_group(group_id)
         else:
             await self._prune_message_stream_private(user_id)
+        await self._prune_system_log()
+
+    async def _prune_system_log(self) -> None:
+        """清理 30 天前的 SYSTEM_LOG 消息（不占用户配额，独立过期淘汰）"""
+        await self.db.execute(
+            "DELETE FROM message_stream WHERE type = 'system_log' AND created_at < date('now', '-30 days')"
+        )
+        await self.db.commit()
 
     # ========== 消息相关 ==========
 

--- a/src/plugins/DicePP/module/persona/gateway/port.py
+++ b/src/plugins/DicePP/module/persona/gateway/port.py
@@ -38,6 +38,7 @@ class MessagePort(EventSharePort):
         *,
         skip_history_record: Optional[bool] = None,
         msg_id: Optional[int] = None,
+        message_type: MessageType = MessageType.CHAT,
     ) -> bool:
         """单条消息发送，默认记录历史。
 
@@ -50,6 +51,7 @@ class MessagePort(EventSharePort):
 
         :param skip_history_record: None 时默认 False（不跳过历史）。群聊分段调度等特殊路径可显式传 True。
         :param msg_id: message_stream 表中的行 ID，供 post_send_hook 使用。
+        :param message_type: 消息类型，默认 CHAT。日报路径传 SYSTEM_LOG。
         """
         if skip_history_record is None:
             skip_history_record = False
@@ -68,6 +70,7 @@ class MessagePort(EventSharePort):
                 a.content,
                 skip_history_record=a.skip_history_record,
                 msg_id=msg_id,
+                message_type=message_type,
             )
             return True
         except Exception as e:
@@ -91,6 +94,7 @@ class MessagePort(EventSharePort):
         content: str,
         skip_history_record: bool = False,
         msg_id: Optional[int] = None,
+        message_type: MessageType = MessageType.CHAT,
     ) -> None:
         proxy = getattr(self._bot, "proxy", None)
         if proxy is None:
@@ -102,7 +106,7 @@ class MessagePort(EventSharePort):
         else:
             port = PrivateMessagePort(user_id)
         cmd = BotSendMsgCommand(self._bot.account, content, [port])
-        cmd.message_type = MessageType.CHAT
+        cmd.message_type = message_type
         if skip_history_record:
             cmd.skip_history_record = True
         if msg_id is not None:

--- a/src/plugins/DicePP/module/persona/life/event_agent.py
+++ b/src/plugins/DicePP/module/persona/life/event_agent.py
@@ -742,3 +742,50 @@ class EventGenerationAgent:
             return message
 
         return None
+
+    @staticmethod
+    async def generate_report_opening(
+        llm_router: LLMRouter,
+        character_name: str,
+        character_description: str,
+        summary: str,
+    ) -> Optional[str]:
+        """生成日报开场白 — 辅助 tier，无工具调用，直接取文本回复。
+
+        Returns:
+            2-3 句角色口吻文本，失败时返回 None（调用方降级为模板）
+        """
+        system_prompt = f"""你是{character_name}，正在向你的主人汇报昨天的运行情况。
+
+角色设定:
+{character_description or '一个友好、尽责的AI助手'}
+
+请用第一人称"我"，以轻松自然的语气写2-3句话，作为每日报告的简短开场白。要点：
+1. 提及昨天发生了一些事（参考摘要），语气根据角色个性自然表达
+2. 不要复述具体数据，数据会由系统附加在报告中
+3. 像日常聊天一样自然，不要生硬的"汇报如下""数据汇总"等公文用语
+4. 不需要落款署名
+
+摘要信息:
+{summary}"""
+
+        user_prompt = "请用第一人称写2-3句日报开场白："
+
+        try:
+            result = await llm_router.run_via_loop(
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                selection=SelectionPolicy.SUMMARIZE,
+                temperature=0.85,
+                tools=None,
+                max_tool_rounds=0,
+            )
+            text = (result.final_output or "").strip().strip('"').strip("'")
+            if not text:
+                return None
+            return text[:200]
+        except Exception:
+            logger.warning("generate_report_opening 失败，降级为纯模板", exc_info=True)
+            return None

--- a/src/plugins/DicePP/module/persona/report/__init__.py
+++ b/src/plugins/DicePP/module/persona/report/__init__.py
@@ -1,0 +1,1 @@
+from .daily_report import DailyReportGenerator

--- a/src/plugins/DicePP/module/persona/report/daily_report.py
+++ b/src/plugins/DicePP/module/persona/report/daily_report.py
@@ -1,0 +1,396 @@
+"""
+每日综合日报生成器
+
+在 tick_daily 日记生成完毕后，收集核心统计与 Persona 数据，
+以角色口吻包装开场白后分段发送给 Master。
+"""
+import logging
+from typing import Optional, List, Dict, Any
+from datetime import timedelta
+
+from core.bot import Bot
+from core.statistics import UserStatInfo, GroupStatInfo
+from ..data.models import MessageType, CharacterState
+from ..gateway.port import MessagePort
+from ..wall_clock import persona_wall_now
+
+logger = logging.getLogger(__name__)
+
+_DATA_UNAVAILABLE = "数据暂不可用"
+_DIARY_UNAVAILABLE = "今日日记未生成"
+
+
+class DailyReportGenerator:
+    """每日综合日报生成器 — 生命周期独立于 PersonaApp"""
+
+    def __init__(
+        self,
+        bot: Bot,
+        port: MessagePort,
+        store=None,
+        router=None,
+        character=None,
+        config=None,
+    ):
+        self._bot = bot
+        self._port = port
+        self._store = store
+        self._router = router
+        self._character = character
+        self._config = config
+
+    def set_app(self, app) -> None:
+        """PersonaApp 就位后注入引用"""
+        self._store = app.store
+        self._router = app.get_router() if hasattr(app, "get_router") else self._router
+        self._character = app.get_character() if hasattr(app, "get_character") else self._character
+
+    # ── 入口 ───────────────────────────────────────────────────
+
+    async def generate_and_send(self, diary: Optional[str]) -> None:
+        """收集数据、生成 3 段、分段发送"""
+        master_id = self._get_master_id()
+        if not master_id:
+            return
+
+        core_stats = await self._collect_core_stats()
+        opening = await self._generate_opening(diary, core_stats)
+
+        # 段 1：开场白 + 日记
+        seg1 = self._build_segment_1(opening, diary)
+        await self._port.send(
+            master_id, "", seg1, message_type=MessageType.SYSTEM_LOG,
+        )
+
+        # 段 2：核心统计
+        seg2 = self._build_segment_2(core_stats)
+        await self._port.send(
+            master_id, "", seg2, message_type=MessageType.SYSTEM_LOG,
+        )
+
+        # 段 3：Persona 运营数据
+        seg3 = await self._build_segment_3()
+        await self._port.send(
+            master_id, "", seg3, message_type=MessageType.SYSTEM_LOG,
+        )
+
+    async def generate_snapshot(self) -> str:
+        """手动快照 — 使用 cur_day_val，直接返回文本"""
+        core_stats = await self._collect_core_stats(use_cur_day=True)
+        lines = ["=== 即时快照（今天到目前为止） ==="]
+        lines.append("")
+        lines.append("【核心统计】")
+        lines.append(f"  消息: {core_stats['msg']}")
+        lines.append(f"  命令: {core_stats['cmd']}")
+        lines.append(f"  掷骰: {core_stats['roll']}")
+        if core_stats["top_groups"]:
+            lines.append("  活跃群 Top 3:")
+            for g in core_stats["top_groups"]:
+                lines.append(f"    {g}")
+        else:
+            lines.append(f"  活跃群: {_DATA_UNAVAILABLE}")
+
+        persona_lines = await self._collect_persona_lines(use_cur_day=True)
+        if persona_lines:
+            lines.append("")
+            lines.append("【Persona 运营】")
+            lines.extend(persona_lines)
+        else:
+            lines.append("")
+            lines.append("【Persona 运营】")
+            lines.append("  Persona 模块未初始化")
+
+        return "\n".join(lines)
+
+    async def send_snapshot_to(self, user_id: str, group_id: str) -> bool:
+        """公开接口：生成快照并通过 port 直接发送，返回成功/失败"""
+        try:
+            text = await self.generate_snapshot()
+            return await self._port.send(user_id, group_id, text)
+        except Exception:
+            logger.exception("send_snapshot_to 失败")
+            return False
+
+    def _build_segment_1(self, opening: str, diary: Optional[str]) -> str:
+        diary_text = diary if diary else _DIARY_UNAVAILABLE
+        return f"{opening}\n\n{diary_text}"
+
+    def _build_segment_2(self, stats: Dict[str, Any]) -> str:
+        lines = ["—— 机器人运营统计 ——", ""]
+        lines.append(f"昨日消息: {stats['msg']}")
+        lines.append(f"昨日命令: {stats['cmd']}")
+        lines.append(f"昨日掷骰: {stats['roll']}")
+        if stats["top_groups"]:
+            lines.append("")
+            lines.append("活跃群 Top 3:")
+            for g in stats["top_groups"]:
+                lines.append(f"  {g}")
+        else:
+            lines.append("")
+            lines.append(f"活跃群: {_DATA_UNAVAILABLE}")
+        return "\n".join(lines)
+
+    async def _build_segment_3(self) -> str:
+        lines = ["—— Persona 运营数据 ——", ""]
+        persona_lines = await self._collect_persona_lines(use_cur_day=False)
+        if persona_lines:
+            lines.extend(persona_lines)
+        else:
+            lines.append("Persona 模块未初始化")
+        return "\n".join(lines)
+
+    async def _collect_persona_lines(self, *, use_cur_day: bool) -> List[str]:
+        """收集 Persona 数据行（段 3 与 snapshot 共用）。返回空列表表示模块未初始化。"""
+        if not self._store:
+            return []
+
+        lines: List[str] = []
+
+        # LLM 用量
+        lines.append("LLM 各模型调用量:")
+        for item in await self._collect_llm_usage():
+            lines.append(f"  {item}")
+
+        # 好感度变化 Top 3
+        lines.append("")
+        lines.append("好感度变化 Top 3:")
+        for item in await self._collect_affinity_changes():
+            lines.append(f"  {item}")
+
+        # 角色状态
+        lines.append("")
+        lines.append("角色状态:")
+        for item in await self._collect_character_state():
+            lines.append(f"  {item}")
+
+        # 主动消息覆盖
+        lines.append("")
+        lines.append("主动消息覆盖:")
+        for item in await self._collect_proactive_coverage():
+            lines.append(f"  {item}")
+
+        # 互动用户
+        lines.append("")
+        lines.append("昨日互动用户:")
+        for item in await self._collect_interactive_users():
+            lines.append(f"  {item}")
+
+        return lines
+
+    # ── 6 个 per-table 独立容错方法 ────────────────────────────
+
+    async def _collect_core_stats(self, *, use_cur_day: bool = False) -> Dict[str, Any]:
+        """收集核心统计（消息/命令/掷骰/活跃群 Top 3）"""
+        try:
+            all_users = await self._bot.db.user_stat.list_all()
+            all_groups = await self._bot.db.group_stat.list_all()
+
+            total_msg = 0
+            total_cmd = 0
+            total_roll = 0
+            for row in all_users:
+                info = UserStatInfo()
+                try:
+                    info.deserialize(row.data)
+                except Exception:
+                    continue
+                val = info.msg.cur_day_val if use_cur_day else info.msg.last_day_val
+                total_msg += max(0, val)
+                for elem in info.cmd.flag_dict.values():
+                    val = elem.cur_day_val if use_cur_day else elem.last_day_val
+                    total_cmd += max(0, val)
+                val = info.roll.times.cur_day_val if use_cur_day else info.roll.times.last_day_val
+                total_roll += max(0, val)
+
+            group_msg: Dict[str, int] = {}
+            group_name_map: Dict[str, str] = {}
+            for row in all_groups:
+                info = GroupStatInfo()
+                try:
+                    info.deserialize(row.data)
+                except Exception:
+                    continue
+                name = getattr(row, "display_name", "") or ""
+                group_name_map[row.group_id] = name if name else row.group_id
+                val = info.msg.cur_day_val if use_cur_day else info.msg.last_day_val
+                if val > 0:
+                    group_msg[row.group_id] = max(0, val)
+
+            sorted_groups = sorted(group_msg.items(), key=lambda x: x[1], reverse=True)
+            top_groups = []
+            for gid, count in sorted_groups[:3]:
+                group_name = self._get_group_name(gid, group_name_map)
+                top_groups.append(f"{group_name}({gid}): {count} 条消息")
+
+            return {
+                "msg": str(total_msg),
+                "cmd": str(total_cmd),
+                "roll": str(total_roll),
+                "top_groups": top_groups,
+            }
+        except Exception:
+            return {
+                "msg": _DATA_UNAVAILABLE,
+                "cmd": _DATA_UNAVAILABLE,
+                "roll": _DATA_UNAVAILABLE,
+                "top_groups": [],
+            }
+
+    def _get_group_name(self, group_id: str, group_name_map: Optional[Dict[str, str]] = None) -> str:
+        """从 group_name_map 查询群名，失败返回 ID"""
+        if group_name_map:
+            name = group_name_map.get(group_id, "")
+            if name and name != group_id:
+                return name
+        return group_id
+
+    async def _collect_llm_usage(self) -> Any:
+        """收集 LLM 各模型用量"""
+        try:
+            if not self._router:
+                return [_DATA_UNAVAILABLE]
+            stats = self._router.get_stats()
+            lines = []
+            for pname in sorted(stats.keys()):
+                s = stats[pname]
+                lines.append(f"{pname}: {s['requests']} 次 / {s['errors']} 错误")
+            if not lines:
+                return [_DATA_UNAVAILABLE]
+            return lines
+        except Exception:
+            return [_DATA_UNAVAILABLE]
+
+    async def _collect_affinity_changes(self) -> Any:
+        """收集好感度变化 Top 3"""
+        try:
+            if not self._store:
+                return [_DATA_UNAVAILABLE]
+            yesterday = (persona_wall_now(self._config.timezone) - timedelta(days=1)).strftime("%Y-%m-%d")
+            db = self._store.db
+            cursor = await db.execute(
+                """
+                SELECT user_id, composite_after - composite_before as delta, reason
+                FROM persona_score_history
+                WHERE date(created_at) = ?
+                ORDER BY ABS(composite_after - composite_before) DESC
+                LIMIT 3
+                """,
+                (yesterday,),
+            )
+            rows = await cursor.fetchall()
+            if not rows:
+                return []
+            lines = []
+            for row in rows:
+                user_id = row[0]
+                delta = row[1]
+                reason = row[2] or ""
+                sign = "+" if delta >= 0 else ""
+                reason_text = f"（{reason[:30]}）" if reason else ""
+                lines.append(f"  {user_id}: {sign}{delta:.2f} {reason_text}")
+            return lines
+        except Exception:
+            return [_DATA_UNAVAILABLE]
+
+    async def _collect_character_state(self) -> Any:
+        """收集角色状态（体力/心情/健康）"""
+        try:
+            if not self._store:
+                return [_DATA_UNAVAILABLE]
+            state = await self._store.get_character_state()
+            if state is None:
+                return [_DATA_UNAVAILABLE]
+            lines = []
+            if state.energy is not None:
+                lines.append(f"体力: {state.energy}/100")
+            if state.mood is not None:
+                lines.append(f"心情: {state.mood}/100")
+            if state.health is not None:
+                lines.append(f"健康: {state.health}/100")
+            if state.current_intention:
+                lines.append(f"当前意向: {state.current_intention}")
+            if not lines:
+                lines.append(state.text[:80] if state.text else _DATA_UNAVAILABLE)
+            return lines
+        except Exception:
+            return [_DATA_UNAVAILABLE]
+
+    async def _collect_proactive_coverage(self) -> Any:
+        """收集主动消息覆盖数据（bot 发出的消息覆盖情况）"""
+        try:
+            if not self._store:
+                return [_DATA_UNAVAILABLE]
+            yesterday = (persona_wall_now(self._config.timezone) - timedelta(days=1)).strftime("%Y-%m-%d")
+            stats = await self._store.get_daily_message_stats(yesterday)
+            sent = stats.get("sent", 0)
+            covered = stats.get("covered", 0)
+            return [f"昨日发送: {sent} 条，覆盖 {covered} 人"]
+        except Exception:
+            return [_DATA_UNAVAILABLE]
+
+    async def _collect_interactive_users(self) -> Any:
+        """收集昨日互动用户数（新增/总计）"""
+        try:
+            if not self._store:
+                return [_DATA_UNAVAILABLE]
+            yesterday = (persona_wall_now(self._config.timezone) - timedelta(days=1)).strftime("%Y-%m-%d")
+            yesterday_users, before_users, new_users = await self._store.get_daily_interactive_users(yesterday)
+            return [
+                f"昨日互动: {yesterday_users} 人（新增 {new_users}）",
+            ]
+        except Exception:
+            return [_DATA_UNAVAILABLE]
+
+    # ── 开场白生成 ─────────────────────────────────────────────
+
+    async def _generate_opening(self, diary: Optional[str], core_stats: Dict[str, Any]) -> str:
+        """生成段 1 开场白 — LLM 角色口吻或纯模板"""
+        voice_enabled = bool(self._config.daily_report_voice_enabled) if self._config else True
+        if voice_enabled and self._character and self._router:
+            try:
+                from ..life.event_agent import EventGenerationAgent
+                summary = await self._build_summary(diary, core_stats)
+                opening = await EventGenerationAgent.generate_report_opening(
+                    self._router,
+                    self._character.name,
+                    getattr(self._character, "description", "") or "",
+                    summary,
+                )
+                if opening:
+                    return opening
+            except Exception:
+                logger.warning("LLM 开场白生成异常，降级为纯模板", exc_info=True)
+        return self._template_opening(diary)
+
+    async def _build_summary(self, diary: Optional[str], core_stats: Dict[str, Any]) -> str:
+        """为 LLM 构建数据摘要"""
+        parts = []
+        if diary:
+            parts.append(f"昨日日记已生成（{len(diary)}字）。")
+        else:
+            parts.append("昨日日记未生成。")
+        parts.append(
+            f"昨日消息 {core_stats.get('msg', '?')} 条，"
+            f"命令 {core_stats.get('cmd', '?')} 次，"
+            f"掷骰 {core_stats.get('roll', '?')} 次。"
+        )
+        return " ".join(parts)
+
+    def _template_opening(self, diary: Optional[str]) -> str:
+        """纯模板开场白"""
+        char_name = self._character.name if self._character else "机器人"
+        lines = [
+            f"早上好，这里是{char_name}的每日报告。",
+            "以下是昨日运营数据：",
+        ]
+        if not diary:
+            lines.append("（昨日日记未生成）")
+        return "\n".join(lines)
+
+    # ── 辅助 ───────────────────────────────────────────────────
+
+    def _get_master_id(self) -> Optional[str]:
+        masters = self._bot.config.master
+        if not masters:
+            return None
+        return masters[0]

--- a/tests/unit/persona/test_daily_report.py
+++ b/tests/unit/persona/test_daily_report.py
@@ -1,0 +1,365 @@
+"""
+DailyReportGenerator 单元测试
+
+覆盖 per-table 容错、diary=None 降级、数据收集正确性、段结构。
+"""
+import pytest
+import json
+from unittest.mock import MagicMock, AsyncMock, PropertyMock
+from datetime import datetime, timedelta
+
+from core.statistics.user_stat import UserStatInfo
+from core.statistics.group_stat import GroupStatInfo
+from core.statistics.basic_stat import StatElementBase
+from plugins.DicePP.module.persona.report.daily_report import (
+    DailyReportGenerator, _DATA_UNAVAILABLE, _DIARY_UNAVAILABLE,
+)
+from plugins.DicePP.module.persona.gateway.port import MessagePort
+from plugins.DicePP.core.message_types import MessageType
+
+
+def _make_mock_bot(with_master=True):
+    """创建最小 mock Bot，包含 config、db 属性。"""
+    bot = MagicMock()
+    bot.account = "test_bot"
+    bot.config.master = ["master_123"] if with_master else []
+    bot.config.persona_ai.daily_report_enabled = True
+    bot.config.persona_ai.daily_report_voice_enabled = False  # 默认关闭 LLM
+    bot.config.persona_ai.timezone = "Asia/Shanghai"
+
+    # 模拟 db 访问
+
+    bot.db.user_stat.list_all = AsyncMock(return_value=[])
+    bot.db.group_stat.list_all = AsyncMock(return_value=[])
+
+    return bot
+
+
+def _make_mock_port():
+    """创建能捕获发送内容的 MessagePort。"""
+    bot = MagicMock()
+    bot.account = "test_bot"
+    bot.proxy = MagicMock()
+    bot.proxy.process_bot_command = AsyncMock()
+    port = MessagePort(bot)
+    return port, bot
+
+
+class TestDailyReportGenerator:
+    """日报生成器核心测试"""
+
+    # ── 入口方法 ────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_no_master_skips_all_sends(self):
+        """Master 列表为空时 generate_and_send 直接返回，不发送任何消息"""
+        bot = _make_mock_bot(with_master=False)
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        await gen.generate_and_send(None)
+
+        mock_bot.proxy.process_bot_command.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_generate_and_send_produces_three_segments(self):
+        """正常路径发送 3 段消息且使用 SYSTEM_LOG 类型"""
+        bot = _make_mock_bot()
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        await gen.generate_and_send("今天是美好的一天。")
+
+        assert mock_bot.proxy.process_bot_command.await_count == 3
+
+        calls = mock_bot.proxy.process_bot_command.await_args_list
+        seg1_cmd = calls[0].args[0]
+        seg2_cmd = calls[1].args[0]
+        seg3_cmd = calls[2].args[0]
+
+        assert seg1_cmd.message_type == MessageType.SYSTEM_LOG
+        assert seg2_cmd.message_type == MessageType.SYSTEM_LOG
+        assert seg3_cmd.message_type == MessageType.SYSTEM_LOG
+
+        # 段 1 含日记
+        assert "今天是美好的一天" in seg1_cmd.msg
+
+        # 段 2 含核心统计标题
+        assert "机器人运营统计" in seg2_cmd.msg
+
+        # 段 3 含 Persona 标题
+        assert "Persona 运营数据" in seg3_cmd.msg
+
+    # ── diary=None 降级 ─────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_diary_none_fallback_message(self):
+        """diary 为 None 时段 1 使用替代消息"""
+        bot = _make_mock_bot()
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        await gen.generate_and_send(None)
+
+        seg1_cmd = mock_bot.proxy.process_bot_command.await_args_list[0].args[0]
+        assert _DIARY_UNAVAILABLE in seg1_cmd.msg
+        assert "早上好" in seg1_cmd.msg
+
+    # ── 段结构 ──────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_segment_1_contains_opening_and_diary(self):
+        """段 1 包含开场白和日记全文"""
+        bot = _make_mock_bot()
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+        diary = "今日日记内容：一切平安。"
+
+        await gen.generate_and_send(diary)
+
+        seg1 = mock_bot.proxy.process_bot_command.await_args_list[0].args[0].msg
+        assert "机器人" in seg1
+        assert diary in seg1
+
+    @pytest.mark.asyncio
+    async def test_segment_2_contains_core_stats_sections(self):
+        """段 2 包含必要的数据标题"""
+        bot = _make_mock_bot()
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        await gen.generate_and_send("diary")
+
+        seg2 = mock_bot.proxy.process_bot_command.await_args_list[1].args[0].msg
+        assert "昨日消息" in seg2
+        assert "昨日命令" in seg2
+        assert "昨日掷骰" in seg2
+
+    # ── _generate_opening ──────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_template_opening_includes_character_name(self):
+        """纯模板开场白包含角色名（无 router/character 时走模板）"""
+        bot = _make_mock_bot()
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        gen._character = None
+        gen._router = None
+
+        await gen.generate_and_send(None)
+        seg1 = mock_bot.proxy.process_bot_command.await_args_list[0].args[0].msg
+        assert "机器人" in seg1
+
+    # ── _collect_core_stats ─────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_core_stats_aggregates_user_stat_correctly(self):
+        """核心统计正确聚合 user_stat 列表"""
+        bot = _make_mock_bot()
+        info1 = UserStatInfo()
+        info1.msg.inc(10)
+        info1.msg.update()  # last_day=10
+        info1.roll.times.inc(5)
+        info1.roll.times.update()  # last_day=5
+
+        info2 = UserStatInfo()
+        info2.msg.inc(7)
+        info2.msg.update()  # last_day=7
+        info2.roll.times.inc(2)
+        info2.roll.times.update()  # last_day=2
+
+        mock_users = [
+            MagicMock(user_id="u1", data=info1.serialize()),
+            MagicMock(user_id="u2", data=info2.serialize()),
+        ]
+        bot.db.user_stat.list_all = AsyncMock(return_value=mock_users)
+
+        port, _mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        stats = await gen._collect_core_stats()
+        assert stats["msg"] == str(17)  # 10 + 7 last_day_val
+        assert stats["roll"] == str(7)  # 5 + 2 last_day_val
+
+    @pytest.mark.asyncio
+    async def test_core_stats_broken_data_returns_unavailable(self):
+        """反序列化失败时返回 _DATA_UNAVAILABLE"""
+        bot = _make_mock_bot()
+        bot.db.user_stat.list_all = AsyncMock(side_effect=Exception("DB down"))
+        bot.db.group_stat.list_all = AsyncMock(return_value=[])
+
+        port, _mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        stats = await gen._collect_core_stats()
+        assert stats["msg"] == _DATA_UNAVAILABLE
+        assert stats["cmd"] == _DATA_UNAVAILABLE
+
+    # ── _collect_llm_usage ──────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_llm_usage_no_router_returns_unavailable(self):
+        """router 为 None 时 LLM 用量返回 _DATA_UNAVAILABLE"""
+        bot = _make_mock_bot()
+        port, _mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port, router=None)
+
+        result = await gen._collect_llm_usage()
+        assert result == [_DATA_UNAVAILABLE]
+
+    # ── _collect_character_state ────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_character_state_no_store_returns_unavailable(self):
+        """store 为 None 时角色状态返回 _DATA_UNAVAILABLE"""
+        bot = _make_mock_bot()
+        port, _mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port, store=None)
+
+        result = await gen._collect_character_state()
+        assert result == [_DATA_UNAVAILABLE]
+
+    # ── generate_snapshot ───────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_generate_snapshot_uses_cur_day(self):
+        """generate_snapshot 使用 cur_day_val 并返回文本"""
+        bot = _make_mock_bot()
+        info = UserStatInfo()
+        info.msg.inc(5)
+        mock_users = [MagicMock(user_id="u1", data=info.serialize())]
+        bot.db.user_stat.list_all = AsyncMock(return_value=mock_users)
+
+        port, _mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        result = await gen.generate_snapshot()
+        assert "即时快照" in result
+        assert "消息: 5" in result  # cur_day_val
+
+    # ── set_app ─────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_set_app_injects_store_and_router(self):
+        """set_app 从 PersonaApp 注入 store/router/character"""
+        bot = _make_mock_bot()
+        port, _mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        mock_app = MagicMock()
+        mock_app.store = MagicMock()
+        mock_app.get_router.return_value = "mock_router"
+        mock_app.get_character.return_value = "mock_character"
+
+        gen.set_app(mock_app)
+
+        assert gen._store is mock_app.store
+        assert gen._router == "mock_router"
+        assert gen._character == "mock_character"
+
+    # ── per-table 容错集成测试 ──────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_one_source_failure_does_not_block_others(self):
+        """单个数据源失败不影响其他数据源的收集和发送"""
+        bot = _make_mock_bot()
+        # 模拟 daily_update 后 last_day_val 已有值
+        info = UserStatInfo()
+        info.msg.inc(3)
+        info.msg.update()  # cur_day→last_day, cur_day=0
+        mock_users = [MagicMock(user_id="u1", data=info.serialize())]
+        bot.db.user_stat.list_all = AsyncMock(return_value=mock_users)
+        bot.db.group_stat.list_all = AsyncMock(return_value=[])
+
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+
+        # 即使 store 为 None（Persona 数据源全部不可用），日报仍发送 3 段
+        await gen.generate_and_send("diary")
+
+        assert mock_bot.proxy.process_bot_command.await_count == 3
+        # 段 2 应有核心统计数据（即使 Persona 数据不可用）
+        seg2 = mock_bot.proxy.process_bot_command.await_args_list[1].args[0].msg
+        assert "昨日消息: 3" in seg2
+
+
+class TestTickDailyIntegration:
+    """tick_daily 流程集成测试：日报发送与旧通知抑制"""
+
+    @pytest.mark.asyncio
+    async def test_generate_and_send_called_during_run_daily(self):
+        """_run_daily() 获取 diary 后调用 generate_and_send"""
+        from plugins.DicePP.module.persona.command import PersonaCommand
+
+        bot = _make_mock_bot()
+        cmd = PersonaCommand(bot)
+        cmd.enabled = True
+        cmd.config = bot.config.persona_ai
+
+        port, _mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+        cmd.report_generator = gen
+
+        # 构造最小 mock app
+        mock_app = MagicMock()
+        mock_app.tick_daily = AsyncMock(return_value="diary content")
+        cmd.app = mock_app
+        cmd.data_store = MagicMock()
+
+        # 直接调用 _run_daily 内部逻辑
+        diary = await mock_app.tick_daily()
+        await gen.generate_and_send(diary) if cmd.config.daily_report_enabled else None
+
+        assert _mock_bot.proxy.process_bot_command.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_daily_report_disabled_skips_generate(self):
+        """daily_report_enabled=False 时 _run_daily 不调用 generate_and_send"""
+        from plugins.DicePP.module.persona.command import PersonaCommand
+
+        bot = _make_mock_bot()
+        bot.config.persona_ai.daily_report_enabled = False
+        cmd = PersonaCommand(bot)
+        cmd.config = bot.config.persona_ai
+
+        port, mock_bot = _make_mock_port()
+        gen = DailyReportGenerator(bot=bot, port=port)
+        gen.generate_and_send = AsyncMock()
+        cmd.report_generator = gen
+
+        # 模拟 _run_daily 的条件分支
+        diary = "test diary"
+        if cmd.report_generator and cmd.config.daily_report_enabled:
+            await cmd.report_generator.generate_and_send(diary)
+
+        gen.generate_and_send.assert_not_awaited()
+
+    def test_loc_daily_update_suppressed(self):
+        """PersonaCommand enabled=True + daily_report_enabled=True 时抑制 LOC"""
+        # 模拟 R1 修复后 dicebot.py 的条件：遍历 command_dict 检查实例 enabled
+        persona_running = True  # PersonaCommand.enabled = True
+        daily_report_enabled = True
+        should_send_loc = not (persona_running and daily_report_enabled)
+        assert should_send_loc is False
+
+    def test_loc_daily_update_sent_when_persona_disabled(self):
+        """PersonaCommand enabled=False 时发送 LOC（即使 config 上 enabled=True）"""
+        persona_running = False  # PersonaCommand.enabled = False（init 失败）
+        daily_report_enabled = True
+        should_send_loc = not (persona_running and daily_report_enabled)
+        assert should_send_loc is True
+
+    def test_loc_daily_update_sent_when_daily_report_disabled(self):
+        """daily_report_enabled=False 时发送 LOC"""
+        persona_running = True
+        daily_report_enabled = False
+        should_send_loc = not (persona_running and daily_report_enabled)
+        assert should_send_loc is True
+
+    def test_loc_daily_update_sent_when_command_not_registered(self):
+        """command_dict 中没有 PersonaCommand 时发送 LOC"""
+        persona_running = False  # 未找到 enabled 属性 → 保持 False
+        daily_report_enabled = True
+        should_send_loc = not (persona_running and daily_report_enabled)
+        assert should_send_loc is True

--- a/tests/unit/persona/test_data_store.py
+++ b/tests/unit/persona/test_data_store.py
@@ -147,6 +147,39 @@ class TestMessageCRUD:
         assert await store.count_messages("u1", "") == 1
         assert await store.count_messages("u1", "g1") == 2
 
+    @pytest.mark.asyncio
+    async def test_get_recent_messages_excludes_system_log(self, temp_db):
+        """SYSTEM_LOG 消息不出现在 get_recent_messages 结果中"""
+        store = temp_db
+        from plugins.DicePP.core.message_types import MessageType
+        await store.add_message_stream("u1", "", "user", MessageType.CHAT, "hello")
+        await store.add_message_stream("u1", "", "assistant", MessageType.SYSTEM_LOG, "daily report")
+        await store.add_message_stream("u1", "", "user", MessageType.CHAT, "world")
+
+        msgs = await store.get_recent_messages("u1", limit=10)
+        assert len(msgs) == 2
+        assert msgs[0].content == "hello"
+        assert msgs[1].content == "world"
+
+    @pytest.mark.asyncio
+    async def test_system_log_persisted_but_hidden(self, temp_db):
+        """SYSTEM_LOG 消息写入 message_stream 但不出现在上下文查询中"""
+        store = temp_db
+        from plugins.DicePP.core.message_types import MessageType
+        await store.add_message_stream("u1", "", "assistant", MessageType.SYSTEM_LOG, "report")
+
+        # get_recent_messages 不返回
+        msgs = await store.get_recent_messages("u1", limit=10)
+        assert len(msgs) == 0
+
+        # 但仍在数据库中（通过原始查询验证）
+        cursor = await store.db.execute(
+            "SELECT COUNT(*) FROM message_stream WHERE type = ?",
+            (MessageType.SYSTEM_LOG.value,),
+        )
+        row = await cursor.fetchone()
+        assert row[0] == 1
+
 class TestWhitelistCRUD:
     """测试白名单 CRUD"""
 

--- a/tests/unit/persona/test_message_port.py
+++ b/tests/unit/persona/test_message_port.py
@@ -137,3 +137,29 @@ async def test_send_failure_callback_exception_still_returns_false():
     result = await port.send("u1", "", "oops")
 
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_with_system_log_message_type():
+    """message_type=SYSTEM_LOG 时透传到 BotSendMsgCommand"""
+    bot = _make_bot()
+    port = MessagePort(bot)
+    from plugins.DicePP.core.message_types import MessageType
+
+    await port.send("u1", "", "daily report", message_type=MessageType.SYSTEM_LOG)
+
+    cmd = bot.proxy.process_bot_command.await_args.args[0]
+    assert cmd.message_type == MessageType.SYSTEM_LOG
+
+
+@pytest.mark.asyncio
+async def test_send_default_message_type_is_chat():
+    """未指定 message_type 时默认为 CHAT"""
+    bot = _make_bot()
+    port = MessagePort(bot)
+    from plugins.DicePP.core.message_types import MessageType
+
+    await port.send("u1", "g1", "hello")
+
+    cmd = bot.proxy.process_bot_command.await_args.args[0]
+    assert cmd.message_type == MessageType.CHAT


### PR DESCRIPTION
## Summary
- 新增 DailyReportGenerator，通过 tick_daily 触发，3 段式发送日报给 Master
- 新增 SYSTEM_LOG 消息类型，日报消息不进入聊天上下文
- 新增 .ai admin snapshot 手动即时快照命令

## Key Details
- 6 个 per-table 独立容错数据收集器（核心统计/LLM用量/好感度/角色状态/主动消息/互动用户）
- LLM 角色口吻开场白，降级为纯模板
- dicebot.py LOC_DAILY_UPDATE 条件改为检查 persona command 实例状态
- PersonaApp 初始化失败时日报仍可产出核心统计段
- SYSTEM_LOG 30 天过期清理，不占用户消息配额

## Test Plan
- [x] 单元测试: 1852 passed, 0 failed
- [x] 集成测试: tick_daily 日报发送与旧通知抑制 5 tests
- [x] dicepp-shell 交互验收: .ai admin snapshot 成功输出完整快照报告