### PR TITLE
refactor(core): 从 Bot 中提取 TaskScheduler 模块，消除 todo_tasks 耦合

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -31,30 +31,6 @@
     - 影响面: adapter/nonebot_adapter.py, adapter/standalone_proxy.py, adapter/web_chat_proxy.py, core/command/user_cmd.py
     - 风险: dispatch 接口需同时满足三种 adapter (NoneBot/Standalone/WebChat) 的差异化需求
 
-## bot
-
-### [B-260520-b6f605] 从 Bot 中提取 TaskScheduler 模块，消除 todo_tasks 耦合
-- 创建: 2026-05-20
-- 优先级: P1
-- 类型: refactor
-- 改动量: M
-- 问题表现:
-  Bot 持有 todo_tasks: Dict 并直接操作其内部结构，命令层可随意篡改（master_command 直接 todo_tasks={} 清空）
-  process_async_task 原地修改可变 bot_commands 列表，接口副作用不透明
-  register_task / process_async_task 无法独立测试，必须构造完整 Bot 实例
-  shell/bot_runner 直接调用 process_async_task，绕过 tick_loop 的正常路径
-- 工作计划:
-  新建 core/bot/task_scheduler.py: TaskScheduler 类
-    - schedule(task, is_async, timeout, timeout_callback) 注册任务
-    - async process(free_time) -> List[BotCommandBase] 纯返回值，消除副作用
-    - clear_all() 替代直接清空 dict
-    - error_handler 通过构造函数注入，dice_log 直接 import
-  修改 core/bot/dicebot.py: 移除 todo_tasks/register_task/process_async_task，Bot 持有 self._scheduler
-  迁移 4 个命令调用方: register_task -> bot._scheduler.schedule
-  迁移 shell/bot_runner.py: process_async_task -> bot._scheduler.process
-  影响面: core/bot/dicebot.py, master_command.py, persona/command.py, roll_dice_command.py, shell/bot_runner.py
-  风险: process() 返回值合并语义需与 tick_loop 的 bot_commands 累积逻辑对齐
-
 ## character
 
 ### [B-260520-368eba] 角色卡模型统一 — 删除旧 JsonObject 体系，全量迁移到 Pydantic

--- a/src/plugins/DicePP/core/bot/dicebot.py
+++ b/src/plugins/DicePP/core/bot/dicebot.py
@@ -3,7 +3,7 @@ import asyncio
 import datetime
 import inspect
 import random
-from typing import List, Optional, Dict, Callable, Union, Set, Awaitable, Protocol, runtime_checkable
+from typing import List, Optional, Dict, Callable, Set, Awaitable, Protocol, runtime_checkable
 from random import choice
 
 from utils.logger import dice_log, get_exception_info
@@ -12,6 +12,7 @@ from core.localization import LocalizationManager, LOC_GROUP_ONLY_NOTICE, LOC_PE
 from core.config import Paths
 from core.config.loader import ConfigLoader, ConfigValidationError
 from core.config.pydantic_models import BotConfig
+from core.bot.task_scheduler import TaskScheduler
 from core.persona import PersonaLoader
 from core.communication import MessageMetaData, MessagePort, PrivateMessagePort, GroupMessagePort, preprocess_msg
 from core.communication import RequestData, FriendRequestData, JoinGroupRequestData, InviteGroupRequestData
@@ -100,7 +101,7 @@ class Bot:
         self.command_dict: Dict[str, command.UserCommandBase] = {}
 
         self.tick_task: Optional[asyncio.Task] = None
-        self.todo_tasks: Dict[Union[Callable, asyncio.Task], Dict] = {}
+        self.scheduler = TaskScheduler(error_handler=self.handle_exception)
         self._no_tick: bool = no_tick
 
         # Some packaged runs may receive events before on_bot_connect completes.
@@ -166,17 +167,6 @@ class Bot:
         # Apply persona overrides after commands have registered their loc keys
         self.loc_helper.set_persona(self.config.persona)
 
-    def register_task(self, task: Callable, is_async: bool = True, timeout: float = 10, timeout_callback: Optional[Callable] = None):
-        """
-        Args:
-            task: 等待执行的任务, 必须没有参数, 必须返回 List[BotCommandBase]
-            is_async: task是否已经是异步函数, 如不是, 将会在其他线程上运行task; 若为同步函数, timeout必须为0
-            timeout: 超时时间, 单位秒, 为0代表不会超时
-            timeout_callback: 超时后调用的回调函数, 必须为同步函数, 同样也应该返回 List[BotCommandBase]
-        """
-        assert is_async or timeout == 0
-        self.todo_tasks[task] = {"init": False, "is_async": is_async, "timeout": timeout, "callback": timeout_callback}
-
     async def tick_loop(self):
         from core.command import BotCommandBase
         loop = asyncio.get_event_loop()
@@ -220,13 +210,13 @@ class Bot:
                     async def update_group_info():
                         await self.update_group_info_all()
                         return []
-                    self.register_task(update_group_info, timeout=3600)
+                    self.scheduler.schedule(update_group_info, timeout=3600)
                     # 更新计时器
                     time_counter[1] = loop_begin_time
 
-                if self.todo_tasks:
+                if self.scheduler.pending:
                     free_time = max(loop_begin_time + 1 - loop.time(), 0.25)
-                    await self.process_async_task(bot_commands, free_time, loop)
+                    bot_commands += await self.scheduler.process(free_time)
 
                 if self.proxy:
                     for command in bot_commands:
@@ -237,52 +227,6 @@ class Bot:
             # 最多每秒执行一次循环
             free_time = max(loop_begin_time + 1 - loop.time(), 0)
             await asyncio.sleep(free_time)
-
-    async def process_async_task(self, bot_commands, free_time: float, loop):
-        init_task = [(task, info) for task, info in self.todo_tasks.items() if not info["init"]]
-        for func, info in init_task:
-            func: Callable
-            del self.todo_tasks[func]
-            if not info["is_async"]:
-                dice_log(f"[Async Task] Init Sync: {func.__name__}")
-
-                async def task_wrapper():
-                    future = loop.run_in_executor(None, func)
-                    await future
-                    return future.result()
-
-                task: asyncio.Task = asyncio.create_task(task_wrapper())
-            else:
-                dice_log(f"[Async Task] Init Async: {func.__name__}")
-                task: asyncio.Task = asyncio.create_task(func())
-            info["init"] = True
-            self.todo_tasks[task] = info
-
-        dice_log(f"[Async Task] Try: "
-                 f"{[(task.get_coro().cr_code.co_name, self.todo_tasks[task]['timeout']) for task in self.todo_tasks.keys()]}"
-                 f" for {free_time} s")
-        try:
-            done_tasks, pending_tasks = await asyncio.wait(self.todo_tasks.keys(), timeout=free_time)
-            task: asyncio.Task
-            for task in done_tasks:
-                try:
-                    bot_commands += task.result()
-                except (AttributeError, TypeError, RuntimeError):
-                    dice_log(str(self.handle_exception(f"Async Task: CODE114")[0]))
-                del self.todo_tasks[task]
-                dice_log(f"[Async Task] Finish {task.get_coro().cr_code.co_name}")
-            for task in pending_tasks:
-                if self.todo_tasks[task]["timeout"] > 0:
-                    self.todo_tasks[task]["timeout"] -= free_time
-                    if self.todo_tasks[task]["timeout"] < 0:
-                        dice_log(f"[Async Task] Timeout: {task.get_coro().cr_code.co_name}")
-                        if self.todo_tasks[task]["callback"]:
-                            dice_log(f"[Async Task] Timeout callback: {self.todo_tasks[task]['callback'].__name__}")
-                            bot_commands += self.todo_tasks[task]["callback"]()
-                        task.cancel()
-                        del self.todo_tasks[task]
-        except (AttributeError, TypeError, KeyError, RuntimeError):
-            dice_log(str(self.handle_exception(f"Async Task: CODE112")[0]))
 
     async def _check_memory_and_handle(self) -> None:
         """内存监控：检查内存使用情况，必要时发送警告或触发重启"""
@@ -370,7 +314,7 @@ class Bot:
             res = await self.clear_expired_data()
             return res
 
-        self.register_task(clear_expired_data, timeout=3600)
+        self.scheduler.schedule(clear_expired_data, timeout=3600)
 
         # 调用每个command的tick_daily方法
         for command in self.command_dict.values():

--- a/src/plugins/DicePP/core/bot/task_scheduler.py
+++ b/src/plugins/DicePP/core/bot/task_scheduler.py
@@ -1,0 +1,101 @@
+import asyncio
+from typing import Callable, Dict, List, Optional, Union
+
+from utils.logger import dice_log
+
+
+class TaskScheduler:
+    """异步任务调度器，管理待执行任务的注册、处理与清理。
+
+    将原本散落在 Bot 中的 todo_tasks / register_task / process_async_task
+    收敛为一个独立可测试的类。
+    """
+
+    def __init__(self, error_handler: Callable[[str], List]):
+        self._tasks: Dict[Union[Callable, asyncio.Task], Dict] = {}
+        self._error_handler = error_handler
+
+    @property
+    def pending(self) -> bool:
+        return len(self._tasks) > 0
+
+    def schedule(
+        self,
+        task: Callable,
+        is_async: bool = True,
+        timeout: float = 10,
+        timeout_callback: Optional[Callable] = None,
+    ):
+        assert is_async or timeout == 0
+        self._tasks[task] = {
+            "init": False,
+            "is_async": is_async,
+            "timeout": timeout,
+            "callback": timeout_callback,
+        }
+
+    def clear_all(self):
+        for key in list(self._tasks.keys()):
+            if isinstance(key, asyncio.Task):
+                key.cancel()
+        self._tasks.clear()
+
+    async def process(self, free_time: float) -> List:
+        """处理已注册的异步任务，返回完成的 BotCommandBase 列表。
+
+        Args:
+            free_time: 最大等待时间（秒）
+        Returns:
+            已完成任务产生的 BotCommandBase 列表（不再原地修改入参）
+        """
+        loop = asyncio.get_event_loop()
+        results: List = []
+
+        init_task = [(task, info) for task, info in self._tasks.items() if not info["init"]]
+        for func, info in init_task:
+            func: Callable
+            del self._tasks[func]
+            if not info["is_async"]:
+                dice_log(f"[Async Task] Init Sync: {func.__name__}")
+
+                async def task_wrapper(_func=func):
+                    future = loop.run_in_executor(None, _func)
+                    await future
+                    return future.result()
+
+                task: asyncio.Task = asyncio.create_task(task_wrapper())
+            else:
+                dice_log(f"[Async Task] Init Async: {func.__name__}")
+                task: asyncio.Task = asyncio.create_task(func())
+            info["init"] = True
+            self._tasks[task] = info
+
+        dice_log(
+            f"[Async Task] Try: "
+            f"{[(task.get_coro().cr_code.co_name, self._tasks[task]['timeout']) for task in self._tasks.keys()]}"
+            f" for {free_time} s"
+        )
+        try:
+            done_tasks, pending_tasks = await asyncio.wait(self._tasks.keys(), timeout=free_time)
+            task: asyncio.Task
+            for task in done_tasks:
+                try:
+                    results += task.result()
+                except (AttributeError, TypeError, RuntimeError):
+                    dice_log(str(self._error_handler("Async Task: CODE114")[0]))
+                del self._tasks[task]
+                dice_log(f"[Async Task] Finish {task.get_coro().cr_code.co_name}")
+            for task in pending_tasks:
+                if self._tasks[task]["timeout"] > 0:
+                    self._tasks[task]["timeout"] -= free_time
+                    if self._tasks[task]["timeout"] < 0:
+                        dice_log(f"[Async Task] Timeout: {task.get_coro().cr_code.co_name}")
+                        if self._tasks[task]["callback"]:
+                            dice_log(f"[Async Task] Timeout callback: {self._tasks[task]['callback'].__name__}")
+                            results += self._tasks[task]["callback"]()
+                        task.cancel()
+                        del self._tasks[task]
+        except (AttributeError, TypeError, KeyError, RuntimeError):
+            dice_log(str(self._error_handler("Async Task: CODE112")[0]))
+
+        return results

--- a/src/plugins/DicePP/module/common/master_command.py
+++ b/src/plugins/DicePP/module/common/master_command.py
@@ -118,7 +118,7 @@ class MasterCommand(UserCommandBase):
                 return []
             
             import asyncio
-            self.bot.register_task(delayed_reboot, timeout=delay_sec + 30)
+            self.bot.scheduler.schedule(delayed_reboot, timeout=delay_sec + 30)
             feedback = f"已安排延迟重启，将在 {delay_sec} 秒后执行"
         elif arg_str.startswith("send"):
             arg_list = arg_str[4:].split(":", 2)
@@ -141,14 +141,14 @@ class MasterCommand(UserCommandBase):
                     update_feedback += f"\n{group_info.group_name}({group_info.group_id}): 群成员{group_info.member_count}/{group_info.max_member_count}"
                 return [BotSendMsgCommand(self.bot.account, update_feedback, [port])]
 
-            self.bot.register_task(async_task, timeout=60, timeout_callback=lambda: [BotSendMsgCommand(self.bot.account, "更新超时!", [port])])
+            self.bot.scheduler.schedule(async_task, timeout=60, timeout_callback=lambda: [BotSendMsgCommand(self.bot.account, "更新超时!", [port])])
             feedback = "更新开始..."
         elif arg_str == "clean":
             async def clear_expired_data():
                 res = await self.bot.clear_expired_data()
                 return res
 
-            self.bot.register_task(clear_expired_data, timeout=3600)
+            self.bot.scheduler.schedule(clear_expired_data, timeout=3600)
             feedback = "清理开始..."
         elif arg_str == "debug-tick":
             feedback = f"异步任务状态: {self.bot.tick_task.get_name()} Done:{self.bot.tick_task.done()} Cancelled:{self.bot.tick_task.cancelled()}\n" \
@@ -156,7 +156,7 @@ class MasterCommand(UserCommandBase):
         elif arg_str == "redo-tick":
             import asyncio
             self.bot.tick_task = asyncio.create_task(self.bot.tick_loop())
-            self.bot.todo_tasks = {}
+            self.bot.scheduler.clear_all()
             feedback = "Redo tick finish!"
         elif arg_str == "log-clean":
             # 立即删除本Bot data_path/logs 下所有文件

--- a/src/plugins/DicePP/module/persona/command.py
+++ b/src/plugins/DicePP/module/persona/command.py
@@ -119,7 +119,7 @@ class PersonaCommand(UserCommandBase):
             return []
 
         self._register_admin_handlers()
-        self.bot.register_task(init_persona, is_async=True, timeout=30)
+        self.bot.scheduler.schedule(init_persona, is_async=True, timeout=30)
 
         return [f"Persona AI 模块加载中 (角色: {config.character_name})"]
 

--- a/src/plugins/DicePP/module/roll/roll_dice_command.py
+++ b/src/plugins/DicePP/module/roll/roll_dice_command.py
@@ -211,7 +211,7 @@ class RollDiceCommand(UserCommandBase):
                 exp_result = await get_roll_exp_result(exp_str)
                 exp_feedback = self.format_loc(LOC_ROLL_EXP, expression=exp_str, expectation=exp_result)
                 return [BotSendMsgCommand(self.bot.account, exp_feedback, [port])]
-            self.bot.register_task(roll_exp_task, timeout=30, timeout_callback=lambda: [BotSendMsgCommand(self.bot.account, "计算超时!", [port])])
+            self.bot.scheduler.schedule(roll_exp_task, timeout=30, timeout_callback=lambda: [BotSendMsgCommand(self.bot.account, "计算超时!", [port])])
 
             feedback = self.format_loc(LOC_ROLL_EXP_START)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]

--- a/src/plugins/DicePP/shell/bot_runner.py
+++ b/src/plugins/DicePP/shell/bot_runner.py
@@ -123,18 +123,18 @@ class BotRunner:
             await self.bot.delay_init_command()
 
             # no_tick=True 时 tick_loop 不运行，需要手动处理待办任务（如 persona 异步初始化）
-            if self.bot._no_tick and self.bot.todo_tasks:
+            if self.bot._no_tick and self.bot.scheduler.pending:
                 completed = False
                 for _ in range(BotRunner.TODO_MAX_WAIT_ITERATIONS):  # 最多等待 30 秒
-                    await self.bot.process_async_task([], BotRunner.TODO_POLL_INTERVAL, asyncio.get_running_loop())
-                    if not self.bot.todo_tasks:
+                    await self.bot.scheduler.process(BotRunner.TODO_POLL_INTERVAL)
+                    if not self.bot.scheduler.pending:
                         completed = True
                         break
                     await asyncio.sleep(BotRunner.TODO_POLL_INTERVAL)
                 if completed:
-                    logging.info("todo_tasks 处理完成")
+                    logging.info("pending tasks 处理完成")
                 else:
-                    logging.warning("todo_tasks 等待超时（30s），仍有未完成任务")
+                    logging.warning("pending tasks 等待超时（30s），仍有未完成任务")
 
             self._started = True
         finally:

--- a/tests/core/bot/test_tick_daily.py
+++ b/tests/core/bot/test_tick_daily.py
@@ -24,7 +24,7 @@ async def test_tick_daily_awaits_async_command_tick_daily():
     bot.db.group_stat.upsert_many = AsyncMock()
 
     # 其他依赖 mocks
-    bot.register_task = MagicMock()
+    bot.scheduler = MagicMock()
     bot.clear_expired_data = AsyncMock(return_value=[])
     bot.loc_helper.format_loc_text = MagicMock(return_value="")
     bot.send_msg_to_master = AsyncMock()
@@ -67,7 +67,7 @@ async def test_tick_daily_skips_command_on_exception():
     bot.db.user_stat.upsert_many = AsyncMock()
     bot.db.group_stat.list_all = AsyncMock(return_value=[])
     bot.db.group_stat.upsert_many = AsyncMock()
-    bot.register_task = MagicMock()
+    bot.scheduler = MagicMock()
     bot.clear_expired_data = AsyncMock(return_value=[])
     bot.loc_helper.format_loc_text = MagicMock(return_value="")
     bot.send_msg_to_master = AsyncMock()


### PR DESCRIPTION
## Summary

- 新建 `TaskScheduler` 类，将 `todo_tasks`/`register_task`/`process_async_task` 收敛为独立可测试模块
- `process()` 改为纯返回值接口，消除原地修改入参的副作用
- `clear_all()` 在清空前正确取消 pending asyncio Task，修复旧 `todo_tasks = {}` 的资源泄漏
- 迁移 4 个命令调用方 + shell 到 `bot.scheduler` 公有接口

## Test plan

- [x] 全量测试通过 (1851 passed)
- [x] tick_daily 测试通过
- [x] 无回归