### PR TITLE
refactor(core): adapter 命令分发改用字典注册，消除 isinstance 级联与模块反向导入

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -12,24 +12,29 @@
 
 ---
 
-## adapter
+## bot
 
-### [B-260520-de976f] Adapter 命令分发深化 — 消除 isinstance 级联与模块反向导入
+### [B-260520-b6f605] 从 Bot 中提取 TaskScheduler 模块，消除 todo_tasks 耦合
 - 创建: 2026-05-20
 - 优先级: P1
 - 类型: refactor
 - 改动量: M
 - 问题表现:
-    - NoneBotClientProxy.process_bot_command() 用 isinstance 级联检查 6 种 BotCommandBase 子类
-    - StandaloneClientProxy 和 WebChatProxy 部分复制了相同分支
-    - 新增 BotCommand 子类需在三个 proxy 中追加入口
-    - nonebot_adapter.py 直接从 module.common.log_command 导入 append_log_record，破坏依赖方向
+  Bot 持有 todo_tasks: Dict 并直接操作其内部结构，命令层可随意篡改（master_command 直接 todo_tasks={} 清空）
+  process_async_task 原地修改可变 bot_commands 列表，接口副作用不透明
+  register_task / process_async_task 无法独立测试，必须构造完整 Bot 实例
+  shell/bot_runner 直接调用 process_async_task，绕过 tick_loop 的正常路径
 - 工作计划:
-    - 在 BotCommandBase 上引入自描述 dispatch 方法，命令自身声明发送行为
-    - adapter 只做平台格式翻译，不再用 isinstance 分发
-    - 日志记录改用 Bot._post_send_hooks 统一路径，消除 adapter -> module 反向导入
-    - 影响面: adapter/nonebot_adapter.py, adapter/standalone_proxy.py, adapter/web_chat_proxy.py, core/command/user_cmd.py
-    - 风险: dispatch 接口需同时满足三种 adapter (NoneBot/Standalone/WebChat) 的差异化需求
+  新建 core/bot/task_scheduler.py: TaskScheduler 类
+    - schedule(task, is_async, timeout, timeout_callback) 注册任务
+    - async process(free_time) -> List[BotCommandBase] 纯返回值，消除副作用
+    - clear_all() 替代直接清空 dict
+    - error_handler 通过构造函数注入，dice_log 直接 import
+  修改 core/bot/dicebot.py: 移除 todo_tasks/register_task/process_async_task，Bot 持有 self._scheduler
+  迁移 4 个命令调用方: register_task -> bot._scheduler.schedule
+  迁移 shell/bot_runner.py: process_async_task -> bot._scheduler.process
+  影响面: core/bot/dicebot.py, master_command.py, persona/command.py, roll_dice_command.py, shell/bot_runner.py
+  风险: process() 返回值合并语义需与 tick_loop 的 bot_commands 累积逻辑对齐
 
 ## character
 

--- a/src/plugins/DicePP/adapter/client_proxy.py
+++ b/src/plugins/DicePP/adapter/client_proxy.py
@@ -1,18 +1,28 @@
 import abc
-from typing import List
+from typing import Callable, Dict, List
 
 from core.command import BotCommandBase
 from core.communication import GroupInfo, GroupMemberInfo
 
 
 class ClientProxy(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    async def process_bot_command(self, command: BotCommandBase):
-        pass
+    def __init__(self) -> None:
+        # 使用 type() 精确匹配，无 MRO 遍历。子类必须显式注册自己的 handler。
+        self._command_handlers: Dict[type, Callable] = {}
 
-    @abc.abstractmethod
-    async def process_bot_command_list(self, command_list: List[BotCommandBase]):
-        pass
+    async def process_bot_command(self, command: BotCommandBase) -> None:
+        handler = self._command_handlers.get(type(command))
+        if handler is not None:
+            await handler(command)
+        else:
+            await self._handle_unknown(command)
+
+    async def _handle_unknown(self, command: BotCommandBase) -> None:
+        raise NotImplementedError(f"未定义的BotCommand类型: {type(command).__name__}")
+
+    async def process_bot_command_list(self, command_list: List[BotCommandBase]) -> None:
+        for command in command_list:
+            await self.process_bot_command(command)
 
     @abc.abstractmethod
     async def get_group_list(self) -> List[GroupInfo]:

--- a/src/plugins/DicePP/adapter/nonebot_adapter.py
+++ b/src/plugins/DicePP/adapter/nonebot_adapter.py
@@ -22,7 +22,7 @@ from core.communication import RequestData, FriendRequestData, JoinGroupRequestD
 from core.command import BotCommandBase, BotSendMsgCommand, BotDelayCommand, BotLeaveGroupCommand, BotSendForwardMsgCommand, BotSendFileCommand
 from utils.logger import dice_log
 
-from module.common.log_command import append_log_record, delete_log_record_by_message_id  # type: ignore
+from module.common.log_command import delete_log_record_by_message_id
 
 from adapter.client_proxy import ClientProxy
 
@@ -90,129 +90,140 @@ async def _trigger_post_send_hooks(
 
 class NoneBotClientProxy(ClientProxy):
     def __init__(self, bot: NoneBot):
+        super().__init__()
         self.bot = bot
+        self._command_handlers = {
+            BotSendMsgCommand: self._handle_send_msg,
+            BotLeaveGroupCommand: self._handle_leave_group,
+            BotSendForwardMsgCommand: self._handle_send_forward_msg,
+            BotSendFileCommand: self._handle_send_file,
+            BotDelayCommand: self._handle_delay,
+        }
 
-    # noinspection PyBroadException
-    async def process_bot_command(self, command: BotCommandBase):
+    async def process_bot_command(self, command: BotCommandBase) -> None:
         dice_log(f"[OneBot] [BotCommand] {command}")
         try:
-            if isinstance(command, BotSendMsgCommand):
-                from core.message_types import MessageType
-                raw_type = getattr(command, "message_type", None)
-                msg_type_val = MessageType.from_str(raw_type).value if raw_type else "command"
-                msg_id = getattr(command, "msg_id", None)
-                skip_hook = getattr(command, "skip_history_record", False)
-
-                for target in command.targets:
-                    if target.group_id:
-                        await self.bot.send_group_msg(group_id=int(target.group_id), message=CQMessage(command.msg))
-                        try:
-                            append_log_record(all_bots[self.bot.self_id], target.group_id, str(self.bot.self_id), await all_bots[self.bot.self_id].get_nickname(self.bot.self_id, target.group_id) or "Bot", command.msg)
-                        except Exception:
-                            pass
-                        if not skip_hook:
-                            await _trigger_post_send_hooks(
-                                all_bots, self.bot.self_id, target.group_id, str(self.bot.self_id),
-                                "assistant", msg_type_val, command.msg, "我", msg_id,
-                            )
-                    else:
-                        await self.bot.send_private_msg(user_id=int(target.user_id), message=CQMessage(command.msg))
-                        if not skip_hook:
-                            await _trigger_post_send_hooks(
-                                all_bots, self.bot.self_id, "", target.user_id,
-                                "assistant", msg_type_val, command.msg, "我", msg_id,
-                            )
-            elif isinstance(command, BotLeaveGroupCommand):
-                await self.bot.set_group_leave(group_id=int(command.target_group_id))
-            elif isinstance(command, BotSendForwardMsgCommand):
-                try:
-                    for target in command.targets:
-                        await self.bot.call_api("send_group_forward_msg", group_id=int(target.group_id), messages=command.msg_json_list)
-                        # 合并转发中的每条子消息分别记录（保持原顺序）
-                        try:
-                            for sub_msg in command.msg:
-                                append_log_record(all_bots[self.bot.self_id], target.group_id, str(self.bot.self_id), await all_bots[self.bot.self_id].get_nickname(self.bot.self_id, target.group_id) or "Bot", sub_msg)
-                        except Exception:
-                            pass
-                except:
-                    if target.group_id:
-                        await self.bot.send_group_msg(group_id=int(target.group_id), message="合并转发失败！")
-                        for target in command.targets:
-                            for msg in command.msg:
-                                await self.bot.send_group_msg(group_id=int(target.group_id), message=CQMessage(msg))
-                                try:
-                                    append_log_record(all_bots[self.bot.self_id], target.group_id, str(self.bot.self_id), await all_bots[self.bot.self_id].get_nickname(self.bot.self_id, target.group_id) or "Bot", msg)
-                                except Exception:
-                                    pass
-                    else:
-                        await self.bot.send_group_msg(user_id=int(target.used_id), message="合并转发失败！")
-                        for target in command.targets:
-                            for msg in command.msg:
-                                await self.bot.send_private_msg(user_id=int(target.user_id), message=CQMessage(msg))
-            elif isinstance(command, BotSendFileCommand):
-                for target in command.targets:
-                    display_name = command.display_name
-                    folder_name = None
-                    real_name = display_name
-                    if '/' in display_name:
-                        folder_name, real_name = display_name.split('/', 1)
-                        folder_name = folder_name.strip() or None
-                        real_name = real_name.strip() or display_name.split('/', 1)[1]
-                    folder_id = None
-                    if folder_name:
-                        # 仅检查是否已存在该文件夹，不尝试创建；未找到时不写入None，便于下次再次尝试
-                        cache = _group_folder_cache.setdefault(target.group_id, {})
-                        if folder_name in cache and cache[folder_name]:
-                            folder_id = cache[folder_name]
-                        else:
-                            try:
-                                root_files = await self.bot.call_api("get_group_root_files", group_id=int(target.group_id))
-                                folders_list = root_files.get('folders') or []
-                                for fd in folders_list:
-                                    # 兼容不同实现的键名
-                                    name_candidate = fd.get('folder_name') or fd.get('name') or fd.get('file_name')
-                                    if name_candidate == folder_name:
-                                        folder_id = fd.get('folder_id') or fd.get('id')
-                                        break
-                                if folder_id:
-                                    cache[folder_name] = folder_id  # 仅缓存成功找到的
-                            except Exception:
-                                pass
-                    try:
-                        primary_done = False
-                        try:
-                            if folder_id:
-                                await self.bot.call_api("upload_group_file", group_id=int(target.group_id), file=command.file, name=real_name, folder=folder_id)
-                            else:
-                                await self.bot.call_api("upload_group_file", group_id=int(target.group_id), file=command.file, name=real_name)
-                            primary_done = True
-                        except Exception as e1:
-                            # 记录日志并尝试一次根目录回退
-                            dice_log(f"[OneBot][Upload][PrimaryFail] group={target.group_id} file={real_name} err={e1}")
-                            if folder_id:  # 若是因文件夹失败，再尝试根目录
-                                try:
-                                    await self.bot.call_api("upload_group_file", group_id=int(target.group_id), file=command.file, name=real_name)
-                                    primary_done = True
-                                except Exception as e2:
-                                    dice_log(f"[OneBot][Upload][FallbackFail] group={target.group_id} file={real_name} err={e2}")
-                        if primary_done:
-                            try:
-                                append_log_record(all_bots[self.bot.self_id], target.group_id, str(self.bot.self_id), await all_bots[self.bot.self_id].get_nickname(self.bot.self_id, target.group_id) or "Bot", f"[文件]{real_name}")
-                            except Exception:
-                                pass
-                        else:
-                            await self.bot.send_group_msg(group_id=int(target.group_id), message="文件发送失败！")
-                    except Exception as ex_outer:
-                        dice_log(f"[OneBot][Upload][Unexpected] group={target.group_id} file={real_name} err={ex_outer}")
-                        await self.bot.send_group_msg(group_id=int(target.group_id), message="文件发送失败！")
-            elif isinstance(command, BotDelayCommand):
-                await asyncio.sleep(command.seconds)
-            else:
-                raise NotImplementedError("未定义的BotCommand类型")
+            await super().process_bot_command(command)
         except ActionFailed as e:
             dice_log(f"[OneBot] [ActionFailed] {e}")
         except Exception as e:
             dice_log(f"[OneBot] [UnknownException] {e}")
+
+    async def _handle_send_msg(self, command: BotSendMsgCommand) -> None:
+        from core.message_types import MessageType
+        raw_type = getattr(command, "message_type", None)
+        msg_type_val = MessageType.from_str(raw_type).value if raw_type else "command"
+        msg_id = getattr(command, "msg_id", None)
+        skip_hook = getattr(command, "skip_history_record", False)
+
+        for target in command.targets:
+            if target.group_id:
+                await self.bot.send_group_msg(group_id=int(target.group_id), message=CQMessage(command.msg))
+                if not skip_hook:
+                    await _trigger_post_send_hooks(
+                        all_bots, self.bot.self_id, target.group_id, str(self.bot.self_id),
+                        "assistant", msg_type_val, command.msg, "我", msg_id,
+                    )
+            else:
+                await self.bot.send_private_msg(user_id=int(target.user_id), message=CQMessage(command.msg))
+                if not skip_hook:
+                    await _trigger_post_send_hooks(
+                        all_bots, self.bot.self_id, "", target.user_id,
+                        "assistant", msg_type_val, command.msg, "我", msg_id,
+                    )
+
+    async def _handle_leave_group(self, command: BotLeaveGroupCommand) -> None:
+        await self.bot.set_group_leave(group_id=int(command.target_group_id))
+
+    async def _handle_send_forward_msg(self, command: BotSendForwardMsgCommand) -> None:
+        try:
+            for target in command.targets:
+                await self.bot.call_api("send_group_forward_msg", group_id=int(target.group_id), messages=command.msg_json_list)
+                try:
+                    for sub_msg in command.msg:
+                        await _trigger_post_send_hooks(
+                            all_bots, self.bot.self_id, target.group_id, str(self.bot.self_id),
+                            "assistant", "forward", sub_msg, "我", None,
+                        )
+                except Exception:
+                    pass
+        except Exception:
+            for target in command.targets:
+                if target.group_id:
+                    await self.bot.send_group_msg(group_id=int(target.group_id), message="合并转发失败！")
+                    for msg in command.msg:
+                        await self.bot.send_group_msg(group_id=int(target.group_id), message=CQMessage(msg))
+                        try:
+                            await _trigger_post_send_hooks(
+                                all_bots, self.bot.self_id, target.group_id, str(self.bot.self_id),
+                                "assistant", "command", msg, "我", None,
+                            )
+                        except Exception:
+                            pass
+                else:
+                    await self.bot.send_private_msg(user_id=int(target.user_id), message="合并转发失败！")
+                    for msg in command.msg:
+                        await self.bot.send_private_msg(user_id=int(target.user_id), message=CQMessage(msg))
+
+    async def _handle_send_file(self, command: BotSendFileCommand) -> None:
+        for target in command.targets:
+            display_name = command.display_name
+            folder_name = None
+            real_name = display_name
+            if '/' in display_name:
+                folder_name, real_name = display_name.split('/', 1)
+                folder_name = folder_name.strip() or None
+                real_name = real_name.strip() or display_name.split('/', 1)[1]
+            folder_id = None
+            if folder_name:
+                cache = _group_folder_cache.setdefault(target.group_id, {})
+                if folder_name in cache and cache[folder_name]:
+                    folder_id = cache[folder_name]
+                else:
+                    try:
+                        root_files = await self.bot.call_api("get_group_root_files", group_id=int(target.group_id))
+                        folders_list = root_files.get('folders') or []
+                        for fd in folders_list:
+                            name_candidate = fd.get('folder_name') or fd.get('name') or fd.get('file_name')
+                            if name_candidate == folder_name:
+                                folder_id = fd.get('folder_id') or fd.get('id')
+                                break
+                        if folder_id:
+                            cache[folder_name] = folder_id
+                    except Exception:
+                        pass
+            try:
+                primary_done = False
+                try:
+                    if folder_id:
+                        await self.bot.call_api("upload_group_file", group_id=int(target.group_id), file=command.file, name=real_name, folder=folder_id)
+                    else:
+                        await self.bot.call_api("upload_group_file", group_id=int(target.group_id), file=command.file, name=real_name)
+                    primary_done = True
+                except Exception as e1:
+                    dice_log(f"[OneBot][Upload][PrimaryFail] group={target.group_id} file={real_name} err={e1}")
+                    if folder_id:
+                        try:
+                            await self.bot.call_api("upload_group_file", group_id=int(target.group_id), file=command.file, name=real_name)
+                            primary_done = True
+                        except Exception as e2:
+                            dice_log(f"[OneBot][Upload][FallbackFail] group={target.group_id} file={real_name} err={e2}")
+                if primary_done:
+                    try:
+                        await _trigger_post_send_hooks(
+                            all_bots, self.bot.self_id, target.group_id, str(self.bot.self_id),
+                            "assistant", "file", f"[文件]{real_name}", "我", None,
+                        )
+                    except Exception:
+                        pass
+                else:
+                    await self.bot.send_group_msg(group_id=int(target.group_id), message="文件发送失败！")
+            except Exception as ex_outer:
+                dice_log(f"[OneBot][Upload][Unexpected] group={target.group_id} file={real_name} err={ex_outer}")
+                await self.bot.send_group_msg(group_id=int(target.group_id), message="文件发送失败！")
+
+    async def _handle_delay(self, command: BotDelayCommand) -> None:
+        await asyncio.sleep(command.seconds)
 
     async def process_bot_command_list(self, command_list: List[BotCommandBase]):
         if len(command_list) > 1:

--- a/src/plugins/DicePP/adapter/standalone_proxy.py
+++ b/src/plugins/DicePP/adapter/standalone_proxy.py
@@ -18,28 +18,33 @@ DEFAULT_USER_ID = "10001"
 
 class StandaloneClientProxy(ClientProxy):
     def __init__(self) -> None:
+        super().__init__()
         self._outputs: List[str] = []
         self._lock = asyncio.Lock()
+        self._command_handlers = {
+            BotSendMsgCommand: self._handle_send_msg,
+            BotSendForwardMsgCommand: self._handle_send_forward_msg,
+            BotDelayCommand: self._handle_delay,
+        }
 
-    async def process_bot_command(self, command: BotCommandBase):
+    async def _handle_send_msg(self, command: BotSendMsgCommand) -> None:
         dice_log(f"[Standalone] [BotCommand] {command}")
-        if isinstance(command, BotSendMsgCommand):
-            async with self._lock:
-                self._outputs.append(command.msg)
-            return
-        if isinstance(command, BotSendForwardMsgCommand):
-            async with self._lock:
-                self._outputs.extend(command.msg)
-            return
-        if isinstance(command, BotDelayCommand):
-            await asyncio.sleep(command.seconds)
-            return
+        async with self._lock:
+            self._outputs.append(command.msg)
+
+    async def _handle_send_forward_msg(self, command: BotSendForwardMsgCommand) -> None:
+        dice_log(f"[Standalone] [BotCommand] {command}")
+        async with self._lock:
+            self._outputs.extend(command.msg)
+
+    async def _handle_delay(self, command: BotDelayCommand) -> None:
+        dice_log(f"[Standalone] [BotCommand] {command}")
+        await asyncio.sleep(command.seconds)
+
+    async def _handle_unknown(self, command: BotCommandBase) -> None:
+        dice_log(f"[Standalone] [BotCommand] {command}")
         async with self._lock:
             self._outputs.append(str(command))
-
-    async def process_bot_command_list(self, command_list: List[BotCommandBase]):
-        for command in command_list:
-            await self.process_bot_command(command)
 
     async def get_group_list(self) -> List[GroupInfo]:
         info = GroupInfo(group_id=DEFAULT_GROUP_ID)
@@ -76,4 +81,3 @@ class StandaloneClientProxy(ClientProxy):
             outputs = list(self._outputs)
             self._outputs.clear()
             return outputs
-

--- a/src/plugins/DicePP/adapter/web_chat_proxy.py
+++ b/src/plugins/DicePP/adapter/web_chat_proxy.py
@@ -24,37 +24,58 @@ def _normalize_web_user_id(user_id: str) -> str:
 
 class WebChatProxy(ClientProxy):
     def __init__(self, adapter: WebChatAdapter) -> None:
+        super().__init__()
         self._adapter = adapter
+        self._command_handlers = {
+            BotDelayCommand: self._handle_delay,
+            BotLeaveGroupCommand: self._handle_leave_group,
+            BotSendMsgCommand: self._handle_send_msg,
+            BotSendForwardMsgCommand: self._handle_send_forward_msg,
+            BotSendFileCommand: self._handle_send_file,
+        }
 
-    async def process_bot_command(self, command: BotCommandBase):
-        if isinstance(command, BotDelayCommand):
-            await asyncio.sleep(command.seconds)
-            return
-        if isinstance(command, BotLeaveGroupCommand):
-            return
-
+    def _resolve_and_check_target(self, command: BotCommandBase) -> tuple[str, str] | None:
         user_id, correlation_id = self._resolve_turn_target(command)
         if not user_id:
             dice_log(f"[WebChat] skip outbound command without web target: {command.__class__.__name__}")
-            return
+            return None
+        return user_id, correlation_id
 
-        if isinstance(command, BotSendMsgCommand):
-            await self._adapter.send_bot_message(user_id=user_id, content=command.msg, correlation_id=correlation_id)
-            return
-        if isinstance(command, BotSendForwardMsgCommand):
-            for segment in command.msg:
-                await self._adapter.send_bot_message(user_id=user_id, content=segment, correlation_id=correlation_id)
-            return
-        if isinstance(command, BotSendFileCommand):
-            text = f"[文件暂不支持网页显示，请在QQ中查看] {command.display_name}"
-            await self._adapter.send_bot_message(user_id=user_id, content=text, correlation_id=correlation_id)
-            return
+    async def _handle_delay(self, command: BotDelayCommand) -> None:
+        await asyncio.sleep(command.seconds)
 
+    async def _handle_leave_group(self, command: BotLeaveGroupCommand) -> None:
+        return
+
+    async def _handle_send_msg(self, command: BotSendMsgCommand) -> None:
+        target = self._resolve_and_check_target(command)
+        if target is None:
+            return
+        user_id, correlation_id = target
+        await self._adapter.send_bot_message(user_id=user_id, content=command.msg, correlation_id=correlation_id)
+
+    async def _handle_send_forward_msg(self, command: BotSendForwardMsgCommand) -> None:
+        target = self._resolve_and_check_target(command)
+        if target is None:
+            return
+        user_id, correlation_id = target
+        for segment in command.msg:
+            await self._adapter.send_bot_message(user_id=user_id, content=segment, correlation_id=correlation_id)
+
+    async def _handle_send_file(self, command: BotSendFileCommand) -> None:
+        target = self._resolve_and_check_target(command)
+        if target is None:
+            return
+        user_id, correlation_id = target
+        text = f"[文件暂不支持网页显示，请在QQ中查看] {command.display_name}"
+        await self._adapter.send_bot_message(user_id=user_id, content=text, correlation_id=correlation_id)
+
+    async def _handle_unknown(self, command: BotCommandBase) -> None:
+        target = self._resolve_and_check_target(command)
+        if target is None:
+            return
+        user_id, correlation_id = target
         await self._adapter.send_bot_message(user_id=user_id, content=str(command), correlation_id=correlation_id)
-
-    async def process_bot_command_list(self, command_list: List[BotCommandBase]):
-        for command in command_list:
-            await self.process_bot_command(command)
 
     async def get_group_list(self) -> List[GroupInfo]:
         info = GroupInfo(group_id=DEFAULT_GROUP_ID)

--- a/src/plugins/DicePP/core/bot/dicebot.py
+++ b/src/plugins/DicePP/core/bot/dicebot.py
@@ -110,8 +110,7 @@ class Bot:
         self._delay_init_done: bool = False
 
         # 消息发送后跨模块通知 hook 列表
-        # 设计意图：adapter 层发送群/私聊消息后，允许各模块订阅并记录。
-        # 长期路径：引入轻量级事件总线彻底解耦。
+        # adapter 层发送消息后触发 hook，各模块通过注册 hook 实现日志记录等横切关注点。
         self._post_send_hooks: List[PostSendHook] = []
 
         # 消息入站记录 hook 列表
@@ -480,6 +479,10 @@ class Bot:
                 await self.hub_manager.load_config()
             except Exception as exc:
                 dice_log(f"[DiceHub] 读取 Hub 配置失败，将使用内置默认值: {exc}")
+
+            # 注册日志记录 hook，消除 adapter -> log_command 反向导入
+            from module.common.log_command import register_log_hooks
+            register_log_hooks(self)
 
             init_info: List[str] = []
             for command in self.command_dict.values():

--- a/src/plugins/DicePP/module/common/log_command.py
+++ b/src/plugins/DicePP/module/common/log_command.py
@@ -633,6 +633,36 @@ def append_log_record(bot: Bot, group_id: str, user_id: str, nickname: str, cont
         pass
 
 
+def register_log_hooks(bot: Bot) -> None:
+    """注册 post_send_hook 以记录 bot 发出的消息到日志。
+
+    消除 adapter 层对 log_command 模块的直接导入依赖：
+    adapter 只负责触发 _post_send_hooks，日志记录由此 hook 统一完成。
+    """
+
+    async def _log_post_send(
+        group_id: str,
+        user_id: str,
+        role: str,
+        type: str,
+        content: str,
+        display_name: str,
+        msg_id: Optional[int] = None,
+    ) -> None:
+        if not group_id:
+            return
+        try:
+            nickname = await bot.get_nickname(bot.account, group_id)
+            if not nickname or nickname in ("UNDEF_NAME", "----"):
+                nickname = display_name or "Bot"
+            append_log_record(bot, group_id, user_id, nickname, content,
+                            str(msg_id) if msg_id else None)
+        except Exception:
+            pass
+
+    bot.add_post_send_hook(_log_post_send)
+
+
 class _StatsFormatter:
     @staticmethod
     def format(log_entry: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

- ClientProxy 基类新增 `_command_handlers` 字典分发，`process_bot_command` 改为具体方法，通过 `type(command)` 精确匹配路由到子类注册的 handler
- NoneBotClientProxy / StandaloneClientProxy / WebChatProxy 的 isinstance 分支链拆为独立 `_handle_*` 方法并注册到字典
- 日志记录统一走 `Bot._post_send_hooks`：log_command 模块在 Bot 初始化时注册 hook，adapter 对所有命令类型触发 hook，消除 `nonebot_adapter` 对 `append_log_record` 的直接导入
- `skip_history_record=True` 现在真正跳过日志记录（旧代码仅跳过 hook 但 `append_log_record` 仍执行），Persona 分段调度器预期行为不变
- WebChatProxy 提取 `_resolve_and_check_target` 辅助方法，消除四个 handler 中的 target resolution 重复
- 修复合并转发失败回退路径中 `target.used_id` typo 和私聊场景错误使用 `send_group_msg` 的 bug

## Test plan

- [x] `uv run pytest` 1852 passed
- [x] adapter 测试全部通过