### PR TITLE
feat(persona): gen 模型支持 max_prompt_chars 配置，超限返回错误给 LLM 重试

### DIFF
--- a/config/global.json
+++ b/config/global.json
@@ -99,7 +99,7 @@
         "api_key": "",
         "base_url": "https://api.minimaxi.com/v1",
         "models": [
-          {"name": "image-01", "category": "gen", "capabilities": ["image"], "quality": 0.5, "cost": 0.5}
+          {"name": "image-01", "category": "gen", "capabilities": ["image"], "quality": 0.5, "cost": 0.5, "max_prompt_chars": 1500}
         ]
       }
     },

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -54,17 +54,6 @@
 - 问题表现: MiniMax image-01 对参数错误（prompt length must be less than 1500）也返回 code=2013，被 classify_error 笼统判为 NON_RETRYABLE，导致 provider 被永久标记 dead，后续所有图片请求失败
 - 工作计划: minimax_image.py 的 classify_error 对 2013 做细分：status_msg 含 content/moderation/审核 → NON_RETRYABLE，含 params/invalid/length → RETRYABLE
 
-### [B-260522-a8953d] 图片生成 prompt 超 1500 字符限制，需配置化 + 截断 + LLM 重试
-- 创建: 2026-05-22
-- 优先级: P1
-- 类型: bug
-- 改动量: S
-- 问题表现: 七七 image_gen_appearance ~1050 字符 + image_gen_style ~150 + LLM prompt，超过 MiniMax image-01 的 1500 字符上限，导致生成失败并把 provider 标记为 dead
-- 工作计划:
-  1. global.json persona_ai 新增 image_gen_prompt_max_chars 配置项（默认 1500）
-  2. executor 超限时返回明确错误信息给 LLM（含当前长度、上限），让 LLM 缩短 prompt 重试
-  3. 缩短角色卡 image_gen_appearance 到 ~450 字符，只保留核心视觉锚点（体型、紫发、粉瞳、紫色衣裙、符咒、绷带袜、珠串、笔记）
-
 ### [B-260515-dd50eb] 用户自带 API Key 功能（.ai key config）
 - 创建: 2026-05-15
 - 优先级: P2

--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -25,6 +25,7 @@ class ModelConfig(BaseModel):
     quality: float = Field(default=0.5, ge=0.0, le=1.0)
     cost: float = Field(default=0.5, ge=0.0, le=1.0)
     circuit_breaker: Optional[CircuitBreakerConfig] = None
+    max_prompt_chars: Optional[int] = Field(default=None, ge=1)
 
     @model_validator(mode="after")
     def _validate_category_capabilities(self) -> "ModelConfig":

--- a/src/plugins/DicePP/module/persona/llm/providers/minimax_image.py
+++ b/src/plugins/DicePP/module/persona/llm/providers/minimax_image.py
@@ -1,5 +1,6 @@
 """MiniMax Image Provider — 实现 ImageGenProvider 协议，封装 MiniMax image-01 API"""
 import asyncio
+from typing import Optional
 
 import httpx
 from nonebot.log import logger
@@ -12,7 +13,6 @@ _PROBE_TIMEOUT = 10
 
 # MiniMax base_resp 错误码映射 (参考 https://platform.minimaxi.com/docs/api-reference/image-generation-t2i)
 _NON_RETRYABLE_CODES = {
-    1000,  # 参数错误
     1001,  # 模型不存在
     1002,  # 权限不足
     1004,  # 鉴权失败
@@ -26,10 +26,12 @@ _NON_RETRYABLE_CODES = {
 class MiniMaxImageProvider:
     """MiniMax image-01 图片生成提供者"""
 
-    def __init__(self, api_key: str, base_url: str, model: str = "image-01"):
+    def __init__(self, api_key: str, base_url: str, model: str = "image-01",
+                 max_prompt_chars: Optional[int] = None):
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
         self.model = model
+        self.max_prompt_chars = max_prompt_chars
         self._image_url = f"{self.base_url}{_IMAGE_GEN_PATH}"
 
     async def generate_image(self, prompt: str, **kwargs) -> str:

--- a/src/plugins/DicePP/module/persona/llm/providers/protocol.py
+++ b/src/plugins/DicePP/module/persona/llm/providers/protocol.py
@@ -72,6 +72,8 @@ class LLMProvider(Protocol):
 class ImageGenProvider(Protocol):
     """图片生成供应商协议"""
 
+    max_prompt_chars: Optional[int] = None
+
     async def generate_image(self, prompt: str, **kwargs) -> str:
         """生成图片，返回 URL。"""
         ...

--- a/src/plugins/DicePP/module/persona/llm/router.py
+++ b/src/plugins/DicePP/module/persona/llm/router.py
@@ -114,12 +114,16 @@ class LLMRouter:
                     continue
 
                 extra_params: Dict[str, Any] = {}
-                provider = provider_cls(
+                provider_kwargs: Dict[str, Any] = dict(
                     api_key=pconfig.api_key,
                     base_url=pconfig.base_url,
                     model=mconfig.name,
-                    **({"extra_params": extra_params} if mconfig.category == "llm" else {}),
                 )
+                if mconfig.category == "gen" and mconfig.max_prompt_chars is not None:
+                    provider_kwargs["max_prompt_chars"] = mconfig.max_prompt_chars
+                if mconfig.category == "llm":
+                    provider_kwargs["extra_params"] = extra_params
+                provider = provider_cls(**provider_kwargs)
                 provider._router_key = key
                 self._model_providers[key] = provider
                 self._model_configs[key] = mconfig

--- a/src/plugins/DicePP/module/persona/tools/generate_image.py
+++ b/src/plugins/DicePP/module/persona/tools/generate_image.py
@@ -80,6 +80,18 @@ def make_generate_image_executor(
             )
             return "图片生成功能暂时不可用，请稍后重试"
 
+        # 3. 检查 prompt 长度
+        max_chars = getattr(gen_provider, "max_prompt_chars", None)
+        if max_chars is not None and len(prompt) > max_chars:
+            logger.warning(
+                f"generate_image: prompt 过长 ({len(prompt)}/{max_chars} 字符)，"
+                f"返回错误消息给 LLM 以触发重试"
+            )
+            return (
+                f"图片生成 prompt 过长（当前 {len(prompt)} 字符，上限 {max_chars} 字符）。"
+                f"请缩短 prompt 描述后重试。"
+            )
+
         try:
             result = await asyncio.wait_for(
                 gen_provider.generate_image(prompt),
@@ -95,6 +107,12 @@ def make_generate_image_executor(
             return "图片生成超时，请稍后重试"
         except Exception as e:
             logger.warning(f"generate_image: 调用失败: {e}")
+            # MiniMax 1000=参数错误，prompt 过长是其中一种，返回重试消息不触发熔断
+            if "[1000]" in str(e):
+                return (
+                    f"图片生成 prompt 可能过长被远端拒绝。"
+                    f"请进一步缩短 prompt 描述后重试。"
+                )
             if handle_model_error:
                 handle_model_error(gen_provider, e)
             return f"图片生成失败: {e}"


### PR DESCRIPTION
## Summary

- `ModelConfig` 新增可选的 `max_prompt_chars` 字段（per-model 级别，默认不检查）
- 配置经 `router → provider → executor` 传递，executor 拼接 prompt 后检查长度
- 超限返回明确错误消息给 LLM，触发缩短重试，**不触发熔断**
- 远端因字符计数差异仍报错（MiniMax 1000）时同样拦截，返回重试消息
- image-01 模型配置 `"max_prompt_chars": 1500`

## Test plan

- [x] `uv run pytest tests/core/config/test_persona.py tests/unit/persona/ tests/module/persona/` — 704 passed
- [x] 代码审查通过