### PR TITLE
docs(beta-merge): archive β-only modules + write merge guide

### DIFF
--- a/docs/beta_merge_guide.md
+++ b/docs/beta_merge_guide.md
@@ -1,0 +1,169 @@
+# β 版本独有功能合并指南
+
+α 经过较大重构（Pydantic + Repository 模式），β 的代码（JsonObject + DataChunk 模式）**不能直接拷贝**到 α —— 导入路径全部失配。
+
+本指南给出每个 β 独有模块的：
+1. 它在 β 里依赖了什么 core 设施
+2. α 里对应的等价物
+3. 重写工作量评估
+
+β 模块源文件已归档到 `docs/beta_merge_reference/`，按子目录分类，方便对照原文重写。
+
+---
+
+## 合并优先级表（第二轮更新）
+
+| 模块 | 价值 | 工作量 | 状态 |
+|---|---|---|---|
+| `DND5E2024.db` (DND5E 2024 规则查询库) | ⭐⭐⭐⭐⭐ | 已完成 | ✅ 已复制到 `content/queries/` |
+| 查询数据库管理 UI | ⭐⭐⭐ | 已完成 | ✅ admin 后台「查询库」tab，可对 content/queries/*.db 增删改查 |
+| 宏指令 (define) | ⭐⭐⭐⭐ | 已完成 | ✅ `.define` 命令已注册（增/删/查），存储在 `macros` 表。展开执行需 hook 到 dicebot |
+| 变量指令 (.set/.get/.del) | ⭐⭐⭐ | 已完成 | ✅ `.set` `.get` `.del` 已注册，支持 = / + / - 操作和骰子表达式赋值 |
+| 点数指令 (.point) | ⭐⭐ | 已完成 | ✅ `.point` 已注册，跨天自动补发，master 可 set/get |
+| COC 角色卡 | ⭐⭐⭐⭐ | 已取消 | ❌ β 的 character/coc/ 其实是 dnd5e 的复制粘贴（字段、技能、检定全一样），未实现真正 COC7 规则。α 的 DND5E 已覆盖。真要支持 COC 需从零实现 9 特征/D100 体系 |
+| log_db (日志落 SQLite) | ⭐⭐⭐ | 不合并 | α 已有 LogRepository（admin 后台日志检索基于它） |
+| bot_presence (在线状态) | ⭐⭐ | 不合并 | admin 内置实例状态展示已覆盖 |
+| 先攻 entity/list 拆分 | ⭐ | 不合并 | α initiative 已能工作，没必要重构 |
+| DiceHub 加密/数据层 | ⭐⭐ | 待评估 | 看 α 是否已有等价物 |
+
+---
+
+## 1. COC 角色卡（推荐先做）
+
+**源文件**：`docs/beta_merge_reference/character_coc/`
+- `__init__.py`, `ability.py`, `character.py`, `health.py`, `hp_command.py`, `money.py`, `spell.py`
+- 注：β 的 COC 是参照 DND5E 的拆分结构做的，几乎对称
+
+### β 依赖
+```python
+from core.data import JsonObject, custom_json_object       # ❌ α 没有
+from core.data import DataChunkBase, custom_data_chunk     # ❌ α 没有
+from core.command.const import *                            # ✅ α 有
+from core.command import UserCommandBase, custom_user_command  # ✅ α 有
+from module.roll import exec_roll_exp, RollDiceError       # ✅ α 有
+```
+
+### α 中的等价物
+- `JsonObject` → α 使用 `pydantic.BaseModel`（看 `core/data/models/character.py`）
+- `custom_data_chunk` + `DataChunkBase` → α 使用 `Repository[T]`（看 `core/data/repository.py`）
+- 角色卡数据落库方式不一样：
+  - β：`DataChunk` 序列化为 JSON 存进 bot_data
+  - α：`Repository` 直接管理 SQLite 表，data 字段是 pydantic model 的 JSON
+
+### 重写步骤
+1. 在 `core/data/models/` 新建 `character_coc.py`，定义 `COCCharacter(BaseModel)`，字段照搬 β 的 `DNDCharInfo` 但改成 pydantic
+2. 在 `core/data/database.py` 的 `BotDatabase` 加一个 `characters_coc: Repository[COCCharacter]` 属性
+3. 在 `core/data/migrations/` 加一个 v3_coc_character.py 创建表
+4. 在 `src/plugins/DicePP/module/character/coc/` 新建命令文件，照搬 β 的命令逻辑，把 DataChunk 操作改成 Repository 操作
+
+预计 1-2 天工作量。
+
+---
+
+## 2. 宏指令（define）
+
+**源文件**：`docs/beta_merge_reference/common/macro_command.py` + `docs/beta_merge_reference/core_bot/macro.py`
+
+### β 依赖
+```python
+from core.bot import Bot, BotMacro, MACRO_COMMAND_SPLIT   # ❌ α 的 core.bot 没暴露
+from core.data import DataManagerError, DC_MACRO          # ❌ α 没这个 DC
+```
+
+### 重写步骤
+1. 把 `core_bot/macro.py` 改写为 `core/bot/macro.py`，把里面的 `JsonObject` 改成 `pydantic.BaseModel`
+2. 在 `core/data/models/` 新建 `macro.py`（如 `UserMacro(BaseModel)`）
+3. 在 `BotDatabase` 加 `macros: Repository[UserMacro]`
+4. 在 `module/common/` 新建 `macro_command.py`，照搬 β 的命令注册逻辑
+
+预计 1 天工作量。
+
+---
+
+## 3. 变量指令（.var）
+
+**源文件**：`docs/beta_merge_reference/common/variable_command.py` + `docs/beta_merge_reference/core_bot/variable.py`
+
+跟宏指令几乎是孪生关系，重写步骤同上。
+
+α 的 `core/data/models/extended.py` 里已有 `UserVariable`，可以复用。
+
+预计半天。
+
+---
+
+## 4. 点数指令（.point）
+
+**源文件**：`docs/beta_merge_reference/common/point_command.py`
+
+跟变量类似，但更简单（只是计数器）。预计半天。
+
+---
+
+## 5. log_db
+
+**源文件**：`docs/beta_merge_reference/common/log_db.py`
+
+α 已有 `core/data/log_repository.py`，提供了完整的 logs/records 表管理（admin 后台的日志检索已经基于它）。
+
+**建议：不合并 β 的 log_db**，α 的 LogRepository 已经够用。
+
+如果非要合并，把 β 的 `DATA_PATH` 引用改成 α 的 `Paths.DATA_DIR` 即可。
+
+---
+
+## 6. bot_presence
+
+**源文件**：`docs/beta_merge_reference/utils/bot_presence.py`
+
+依赖 `from core.config import DATA_PATH`（β 风格），α 没有这个变量。
+
+**建议：不直接合并**。α 的管理后台已经通过 `instance_manager.is_running()` 提供了实例状态展示。
+
+如果想保留"按 QQ 号显示在线状态"，把它改写到 `utils/` 下，把 `DATA_PATH` 换成 `Paths.DATA_DIR`。
+
+---
+
+## 7. DiceHub 加密 / 数据层
+
+**源文件**：`docs/beta_merge_reference/dice_hub/data.py` + `encrypt.py`
+
+α 已有 `module/dice_hub/api_client.py` + `manager.py`。看是否有加密需求，按需移植 `encrypt.py` 的工具函数。
+
+`data.py` 主要是数据结构定义，对照 α 的 dice_hub 改一下即可。
+
+---
+
+## 8. 先攻 entity/list 拆分
+
+**源文件**：`docs/beta_merge_reference/initiative/`
+
+α 的 `module/initiative/initiative_command.py` 自身已经实现先攻逻辑。β 把 entity/list 拆成单独的 dataclass，是更"工程化"的做法。
+
+**建议：不合并**。α 当前实现能跑，没必要重构。
+
+---
+
+## 9. query_database 管理（DND5E2024.db 配套）
+
+**源文件**：`docs/beta_merge_reference/query/query_database.py`
+
+α 已有 `module/query/query_command.py` 和 `homebrew_command.py`，但缺乏对 SQLite 查询库（即 `content/queries/DND5E2024.db`）的 CRUD 管理界面。
+
+**建议**：α 的 query_command 应该已经能从 `content/queries/*.db` 读数据（如果它本来就支持的话）；如果需要可视化编辑数据库，可以在管理后台的「SQLite 浏览器」tab 里直接打开 `DND5E2024.db`（admin 后台已经支持任意 SQLite CRUD，把数据库路径传过去即可）。
+
+---
+
+## 总结：什么"白送"了
+
+合并这次直接到位的：
+- ✅ **DND5E2024 规则查询库**（10MB 数据，已落到 `content/queries/`）
+- ✅ **可视化后台**全套（取代 β 后台、设计更轻量）
+- ✅ **一键部署 + 多实例管理**（取代 β 整合包，5MB 包代替 500MB）
+
+需要 1-3 天手工重写的：
+- COC 角色卡（DND5E2024 已有数据，但 COC 还是空白）
+- 宏 / 变量 / 点数指令
+
+可以不合并（α 已有等价物）：
+- log_db、initiative 拆分、bot_presence

--- a/docs/beta_merge_reference/character_coc/__init__.py
+++ b/docs/beta_merge_reference/character_coc/__init__.py
@@ -1,0 +1,10 @@
+from .health import HPInfo, CHAR_INFO_KEY_HP, CHAR_INFO_KEY_HP_DICE
+from .spell import SpellInfo
+from .ability import AbilityInfo, CHAR_INFO_KEY_ABILITY, CHAR_INFO_KEY_LEVEL, CHAR_INFO_KEY_EXT, CHAR_INFO_KEY_PROF
+from .ability import ability_list, skill_list, saving_list, attack_list, check_item_list, check_item_index_dict, ext_item_list, ext_item_index_dict
+from .money import MoneyInfo
+from .character import DNDCharInfo, gen_template_char
+
+from .hp_command import HPCommand, DC_CHAR_HP
+
+DC_CHAR_DND = "character_dnd"

--- a/docs/beta_merge_reference/character_coc/ability.py
+++ b/docs/beta_merge_reference/character_coc/ability.py
@@ -1,0 +1,360 @@
+from typing import List, Tuple, Dict
+import json
+
+from core.data import JsonObject, custom_json_object
+from module.roll import exec_roll_exp, RollDiceError
+
+CHAR_INFO_KEY_LEVEL = "$等级$"
+CHAR_INFO_KEY_ABILITY = "$属性$"
+CHAR_INFO_KEY_PROF = "$熟练$"
+CHAR_INFO_KEY_EXT = "$额外加值$"
+
+
+# 属性值
+ability_list = ["力量", "敏捷", "体质", "智力", "感知", "魅力", ]
+ability_num = len(ability_list)
+assert ability_num == 6
+
+# 技能
+skill_list = ["运动",
+              "体操", "巧手", "隐匿", "先攻",
+              "奥秘", "历史", "调查", "自然", "宗教",
+              "驯兽", "洞悉", "医药", "察觉", "求生",
+              "欺瞒", "威吓", "表演", "游说", ]
+skill_num = len(skill_list)
+assert skill_num == 19
+
+skill_parent_dict = {
+    "运动": "力量",
+    "体操": "敏捷", "巧手": "敏捷", "隐匿": "敏捷", "先攻": "敏捷",
+    "奥秘": "智力", "历史": "智力", "调查": "智力", "自然": "智力", "宗教": "智力",
+    "驯兽": "感知", "洞悉": "感知", "医药": "感知", "察觉": "感知", "求生": "感知",
+    "欺瞒": "魅力", "威吓": "魅力", "表演": "魅力", "游说": "魅力",
+
+}
+assert len(skill_parent_dict) == skill_num
+assert sum([1 for v in skill_parent_dict.values() if v not in ability_list]) == 0
+skill_synonym_dict = {
+    "特技": "体操", "妙手": "巧手", "潜行": "隐匿", "隐蔽": "隐匿", "隐秘": "隐匿", "躲藏": "隐匿",
+    "驯养": "驯兽", "驯服": "驯兽", "医疗": "医药", "医术": "医药", "观察": "察觉", "生存": "求生",
+    "欺骗": "欺瞒", "欺诈": "欺瞒", "哄骗": "欺瞒", "唬骗": "欺瞒", "威胁": "威吓", "说服": "游说"}
+assert sum([1 for v in skill_synonym_dict.values() if v not in skill_list]) == 0
+
+# 豁免
+saving_list = ["力量豁免", "敏捷豁免", "体质豁免", "智力豁免", "感知豁免", "魅力豁免", ]
+saving_num = len(saving_list)
+assert saving_num == ability_num
+saving_parent_dict = {
+    "力量豁免": "力量", "敏捷豁免": "敏捷", "体质豁免": "体质", "智力豁免": "智力", "感知豁免": "感知", "魅力豁免": "魅力",
+}
+assert len(saving_parent_dict) == saving_num
+assert sum([1 for v in saving_parent_dict.values() if v not in ability_list]) == 0
+
+# 攻击
+attack_list = ["力量攻击", "敏捷攻击", "体质攻击", "智力攻击", "感知攻击", "魅力攻击", ]
+attack_num = len(attack_list)
+assert attack_num == ability_num
+attack_parent_dict = {
+    "力量攻击": "力量", "敏捷攻击": "敏捷", "体质攻击": "体质", "智力攻击": "智力", "感知攻击": "感知", "魅力攻击": "魅力",
+}
+assert len(attack_parent_dict) == attack_num
+assert sum([1 for v in attack_parent_dict.values() if v not in ability_list]) == 0
+
+# 可检定条目
+check_item_list = ability_list + skill_list + saving_list + attack_list
+check_item_num = ability_num * 3 + skill_num
+
+check_item_index_dict = dict(list((k, i) for i, k in enumerate(check_item_list)))
+assert len(check_item_list) == len(check_item_index_dict) == check_item_num
+
+# 可额外加值条目
+saving_all_key = "豁免"
+attack_all_key = "攻击"
+ext_item_list = check_item_list + [saving_all_key, attack_all_key]
+ext_item_num = check_item_num + 2
+
+ext_item_index_dict = dict(list((k, i) for i, k in enumerate(ext_item_list)))
+assert len(ext_item_list) == len(ext_item_index_dict) == ext_item_num
+
+
+@custom_json_object
+class AbilityInfo(JsonObject):
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.is_init: bool = False
+        self.version = 1  # 版本号
+
+        self.level: int = 0  # 等级
+
+        self.ability: List[int] = [0] * ability_num  # 力量, 敏捷, 体质, 智力, 感知, 魅力
+        self.check_prof: List[int] = [0] * check_item_num  # 检定的熟练加值的倍数
+        self.check_ext: List[str] = [""] * ext_item_num  # 描述检定的额外加值的表达式
+        self.check_adv: List[int] = [0] * ext_item_num  # 是否自带优势或劣势
+
+    def initialize(self, level_str: str, ability_info_list: List[int], prof_list: List[str], ext_dict: Dict[str, str]):
+        """
+        通过用户输入初始化属性, 初始化失败则抛出AssertionError
+        Args:
+            level_str: 正整数字符串, 代表等级
+            ability_info_list: 长度为6的正整数字符串列表, 代表六项属性
+            prof_list: 长度任意的字符串列表, 代表熟练的检定条目, 如["2*奥秘", "智力豁免"]代表奥秘有双倍熟练加值, 智力豁免拥有单倍熟练加值, 其余检定没有熟练加值
+            ext_dict: key为检定条目, value为对应检定的额外加值
+        """
+        # 初始化等级
+        try:
+            assert int(level_str) > 0
+        except (AssertionError, ValueError):
+            raise AssertionError("等级必须为正整数")
+        level = int(level_str)
+
+        # 初始化属性值
+        ability = [0] * ability_num
+        assert len(ability_info_list) == ability_num, f"必须设定全部的{ability_num}项属性"
+        for index, val_str in enumerate(ability_info_list):
+            try:
+                assert int(val_str) > 0
+            except(AssertionError, ValueError):
+                raise AssertionError(f"{ability_list[index]}属性值{val_str}必须为正整数")
+            ability[index] = int(val_str)
+
+        # 初始化熟练加值
+        check_prof = [0] * check_item_num
+        for attack_name in attack_list:  # 默认熟练所有攻击
+            attack_index: int = check_item_index_dict[attack_name]
+            check_prof[attack_index] = 1
+        for check_name in prof_list:
+            prof_scale = 1
+            if "*" in check_name:
+                scale_str, check_name = check_name.split("*", 1)
+                try:
+                    prof_scale = int(scale_str)
+                    assert prof_scale >= 0
+                except (ValueError, AssertionError):
+                    raise AssertionError(f"{check_name}熟练加值倍数必须为非负整数")
+            if check_name in skill_synonym_dict:
+                check_name = skill_synonym_dict[check_name]
+            assert check_name in check_item_list, f"{check_name}为无效的检定条目, 可用条目:{check_item_list}"
+            check_index: int = check_item_index_dict[check_name]
+            check_prof[check_index] = prof_scale
+
+        # 初始化调整值
+        check_ext = [""] * ext_item_num
+        check_adv = [0] * ext_item_num
+        for check_name, ext_str in ext_dict.items():
+            if not ext_str:
+                continue
+            if check_name in skill_synonym_dict:
+                check_name = skill_synonym_dict[check_name]
+            assert check_name in ext_item_list, f"{check_name}为无效条目, 可用条目:\n{ext_item_list}"
+            check_index: int = ext_item_index_dict[check_name]
+
+            # 处理优劣势
+            if ext_str.startswith("优势") or ext_str.startswith("劣势"):
+                if ext_str.startswith("优势"):
+                    check_adv[check_index] = 1
+                if ext_str.startswith("劣势"):
+                    check_adv[check_index] = -1
+                ext_str = ext_str[2:]
+            if not ext_str:
+                continue
+
+            # 校验开头
+            assert ext_str[0] in ["+", "-"], f"调整值无效: 必须以[优势/劣势]+/-开头\n{check_name}:{ext_str} "
+            # 校验表达式合法性
+            try:
+                res = exec_roll_exp("D20" + ext_str)
+                res.get_complete_result()
+            except RollDiceError as e:
+                raise AssertionError(f"无效的调整值: {check_name}:{ext_str} {e.info}")
+            check_ext[check_index] = ext_str
+
+        self.is_init = True
+        self.level = level
+        self.ability = ability
+        self.check_ext = check_ext
+        self.check_adv = check_adv
+        self.check_prof = check_prof
+
+    def get_prof_bonus(self) -> int:
+        prof_bonus = 2 + (self.level - 1) // 4
+        return prof_bonus
+
+    def get_modifier(self, ability_index: int) -> int:
+        ability_score = self.ability[ability_index]
+        modifier = (ability_score - 10) // 2
+        return modifier
+
+    def perform_check(self, check_name: str, advantage: int, mod_str: str) -> Tuple[str, str, int]:
+        """
+        进行技能检定, 失败抛出AssertionError
+        Args:
+            check_name: 必须为skill_dict中的元素, 如: 力量/运动
+            advantage: 该次检定是否具有优势, 1为优势, -1为劣势, =0为无优无劣
+            mod_str: 该次检定的临时加值
+        Returns:
+            hint_str: 提示信息
+            result_str: 检定的计算过程
+            result_val: 检定结果
+        """
+        hint_str: str = ""
+        result_str: str
+        result_val: int
+        assert self.is_init, "未初始化属性值"
+        if check_name in skill_synonym_dict:
+            check_name = skill_synonym_dict[check_name]
+        assert check_name in check_item_list, f"{check_name}无效, 可用检定条目:\n{check_item_list}"
+        is_skill: bool = check_name in skill_list  # 计算技能检定时 会 叠加基础属性的额外加值与优劣势
+        is_saving: bool = check_name in saving_list  # 计算豁免检定时 不会 叠加基础属性的额外加值与优劣势
+        is_attack: bool = check_name in attack_list  # 计算攻击检定时 不会 叠加基础属性的额外加值与优劣势
+
+        check_index = check_item_index_dict[check_name]
+        parent_index = -1
+        if is_skill:
+            parent_index = ext_item_index_dict[skill_parent_dict[check_name]]
+        if is_saving:
+            parent_index = ext_item_index_dict[saving_parent_dict[check_name]]
+        if is_attack:
+            parent_index = ext_item_index_dict[attack_parent_dict[check_name]]
+
+        # 计算熟练加值
+        prof_bonus = self.check_prof[check_index] * self.get_prof_bonus()
+        if self.check_prof[check_index] == 0:
+            hint_str += f"无熟练加值 "
+        elif self.check_prof[check_index] == 1:
+            hint_str += f"熟练加值:{prof_bonus} "
+        else:
+            hint_str += f"熟练加值:{self.get_prof_bonus()}*{self.check_prof[check_index]} "
+        prof_bonus_str: str = ""
+        if prof_bonus != 0:
+            prof_bonus_str = "+" + str(prof_bonus) if prof_bonus > 0 else str(prof_bonus)
+
+        # 计算属性调整值
+        ability_modifier: int
+        if parent_index != -1:
+            ability_modifier = self.get_modifier(parent_index)
+            hint_str += f"{ability_list[parent_index]}调整值:{ability_modifier} "
+        else:
+            ability_modifier = self.get_modifier(check_index)
+            hint_str += f"{ability_list[check_index]}调整值:{ability_modifier} "
+        ability_modifier_str: str = ""
+        if ability_modifier != 0:
+            ability_modifier_str = "+" + str(ability_modifier) if ability_modifier > 0 else str(ability_modifier)
+
+        # 得到额外加值
+        ext_str = self.check_ext[check_index]
+        if parent_index != -1:
+            ext_str += self.check_ext[parent_index]
+        if is_saving:
+            all_index = ext_item_index_dict[saving_all_key]
+            ext_str += self.check_ext[all_index]
+        if is_attack:
+            all_index = ext_item_index_dict[attack_all_key]
+            ext_str += self.check_ext[all_index]
+        if ext_str:
+            hint_str += f"额外加值:{ext_str} "
+
+        # 临时加值
+        if mod_str:
+            hint_str += f"临时加值:{mod_str} "
+
+        # 计算优劣势
+        assert advantage in [-1, 0, 1], "Unexpected Code: 0"
+        is_counter: bool  # 优劣势是否被抵消过
+        adv_flag = self.check_adv[check_index]
+        parent_flag = 0
+        if is_skill:
+            parent_flag = self.check_adv[parent_index]
+        adv_flag = max(min(adv_flag + parent_flag, 1), -1)
+        is_counter = (adv_flag == 0 and parent_flag != 0)
+        adv_flag = max(min(adv_flag + advantage, 1), -1)
+        is_counter = is_counter or (adv_flag == 0 and advantage != 0)
+        if is_counter:
+            adv_flag = 0
+            hint_str += "优劣抵消 "
+        if adv_flag != 0 and advantage == 0:
+            if adv_flag > 0:
+                hint_str += "自带优势 "
+            else:
+                hint_str += "自带劣势 "
+
+        hint_str = hint_str.strip()
+
+        # 组合成掷骰表达式
+        roll_exp: str
+        if adv_flag != 0:
+            if adv_flag > 0:
+                roll_exp = "D20优势"
+            else:
+                roll_exp = "D20劣势"
+        else:
+            roll_exp = "D20"
+
+        roll_exp = f"{roll_exp}{prof_bonus_str}{ability_modifier_str}{ext_str}{mod_str}"
+        try:
+            roll_result = exec_roll_exp(roll_exp)
+            result_str = roll_result.get_complete_result()
+            result_val = roll_result.get_val()
+        except RollDiceError as e:
+            raise AssertionError(f"Unexpected Code: {roll_exp}->{e.info}")
+
+        return hint_str, result_str, result_val
+
+    def get_char_info(self) -> str:
+        """
+        返回可用来组合成初始化角色卡的字符串
+        例子:
+        $等级$ 5
+        $属性$ 10/11/12/15/12
+        $熟练$ 力量/2*隐匿/奥秘
+        $额外加值$ 运动:优势/隐匿:优势+2/游说:-2
+        """
+        info = ""
+        # 等级信息
+        info += f"{CHAR_INFO_KEY_LEVEL} {self.level}\n"
+        # 属性值信息
+        info += f"{CHAR_INFO_KEY_ABILITY} {'/'.join([str(val) for val in self.ability])}\n"
+
+        # 熟练信息
+        prof_info = [(scale, check_item_list[index]) for index, scale in enumerate(self.check_prof) if scale > 0]
+        prof_list = []
+        for scale, prof_name in prof_info:
+            if scale == 1:
+                prof_list.append(prof_name)
+            else:
+                prof_list.append(f"{scale}*{prof_name}")
+        if len(prof_list) > 0:
+            info += f"{CHAR_INFO_KEY_PROF} {'/'.join(prof_list)}\n"
+
+        # 额外加值信息
+        ext_info = [(ext_item_list[index], ext_str) for index, ext_str in enumerate(self.check_ext) if ext_str]
+        adv_dict = dict([(ext_item_list[index], adv_flag) for index, adv_flag in enumerate(self.check_adv) if adv_flag != 0])
+        ext_list = []
+        for check_name, ext_str in ext_info:
+            ext_str_prefix = ""
+            if check_name in adv_dict:
+                if adv_dict[check_name] > 0:
+                    ext_str_prefix = "优势"
+                else:
+                    ext_str_prefix = "劣势"
+            ext_list.append(f"{check_name}:{ext_str_prefix}{ext_str}")
+        if len(ext_list) > 0:
+            info += f"{CHAR_INFO_KEY_EXT} {'/'.join(ext_list)}\n"
+
+        return info.strip()

--- a/docs/beta_merge_reference/character_coc/char_command.py
+++ b/docs/beta_merge_reference/character_coc/char_command.py
@@ -1,0 +1,323 @@
+"""
+DND角色卡指令
+"""
+
+from typing import List, Tuple, Any, Optional
+import re
+import json
+
+from core.bot import Bot
+from core.data import DataChunkBase, custom_data_chunk, DataManagerError
+from core.command.const import *
+from core.command import UserCommandBase, custom_user_command
+from core.command import BotCommandBase, BotSendMsgCommand
+from core.communication import MessageMetaData, PrivateMessagePort, GroupMessagePort
+
+from module.character.dnd5e import DNDCharInfo, gen_template_char
+
+LOC_CHAR_SET = "char_set"
+LOC_CHAR_MISS = "char_miss"
+LOC_CHAR_DEL = "char_delete"
+LOC_CHECK_RES = "check_result"
+
+DC_CHAR_DND = "character_dnd"
+
+CMD_TYPE_CHAR = "char"
+CMD_TYPE_STATE = "state"
+CMD_TYPE_CHECK = "check"
+CMD_TYPE_SAVING = "check_saving"
+CMD_TYPE_ATTACK = "check_attack"
+CMD_TYPE_HP_DICE = "hp_dice"
+CMD_TYPE_REST_LONG = "rest_long"
+
+
+@custom_data_chunk(identifier=DC_CHAR_DND, include_json_object=True)
+class _(DataChunkBase):
+    def __init__(self):
+        super().__init__()
+
+
+@custom_user_command(readable_name="DND5E角色卡", priority=DPP_COMMAND_PRIORITY_DEFAULT+10,
+                     flag=DPP_COMMAND_FLAG_CHAR | DPP_COMMAND_FLAG_DND, group_only=True)
+class CharacterCommand(UserCommandBase):
+    """
+    角色卡指令
+    """
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_CHAR_SET, "成功设置角色卡", "成功设置角色卡")
+        bot.loc_helper.register_loc_text(LOC_CHAR_MISS, "无法找到有效的角色卡", "找不到有效的角色卡")
+        bot.loc_helper.register_loc_text(LOC_CHAR_DEL, "已经删除了你的角色卡", "删除角色卡")
+        bot.loc_helper.register_loc_text(LOC_CHECK_RES, "{name} throw {check}\n{hint}\n{result}", "删除角色卡")
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        should_proc: bool = True
+        should_pass: bool = False
+        cmd_type = ""
+        info: Any = 0
+        if msg_str.startswith("."):
+            if msg_str.startswith(".角色卡"):
+                cmd_type = CMD_TYPE_CHAR
+                info = msg_str[4:].strip()
+            elif msg_str.startswith(".状态"):
+                cmd_type = CMD_TYPE_STATE
+            elif re.match(r"\.([1-9]#)?..检定", msg_str):
+                cmd_type = CMD_TYPE_CHECK
+                msg_str = msg_str[1:]
+                time: int = 1
+                check_name, mod_str = msg_str.split("检定", maxsplit=1)
+                if "#" in check_name:
+                    time_str, check_name = check_name.split("#")
+                    time = int(time_str)
+                info = (time, check_name, mod_str)
+            elif re.match(r"\.([1-9]#)?..豁免", msg_str):
+                cmd_type = CMD_TYPE_SAVING
+                msg_str = msg_str[1:]
+                time: int = 1
+                check_name, mod_str = msg_str.split("豁免", maxsplit=1)
+                if "#" in check_name:
+                    time_str, check_name = check_name.split("#")
+                    time = int(time_str)
+                info = (time, check_name+"豁免", mod_str)
+            elif re.match(r"\.([1-9]#)?..攻击", msg_str):
+                cmd_type = CMD_TYPE_ATTACK
+                msg_str = msg_str[1:]
+                time: int = 1
+                check_name, mod_str = msg_str.split("攻击", maxsplit=1)
+                if "#" in check_name:
+                    time_str, check_name = check_name.split("#")
+                    time = int(time_str)
+                info = (time, check_name+"攻击", mod_str)
+            elif re.match(r"\.([1-9][0-9]?#)?生命骰", msg_str):
+                cmd_type = CMD_TYPE_HP_DICE
+                msg_str = msg_str[1:]
+                time: int = 1
+                if "#" in msg_str:
+                    time_str, _ = msg_str.split("#", maxsplit=1)
+                    time = int(time_str)
+                info = time
+            elif msg_str.startswith(".长休"):
+                cmd_type = CMD_TYPE_REST_LONG
+            else:
+                should_proc = False
+        else:
+            should_proc = False
+
+        return should_proc, should_pass, (cmd_type, info)
+
+    def process_msg(self, msg_str: str, meta: MessageMetaData, hint: Any) -> List[BotCommandBase]:
+        port = GroupMessagePort(meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
+        # 解析语句
+        cmd_type: str = hint[0]
+        feedback: str = ""
+        # 获取当前角色卡
+        char_info: Optional[DNDCharInfo]
+        try:
+            char_info = self.bot.data_manager.get_data(DC_CHAR_DND, [meta.group_id, meta.user_id])
+        except DataManagerError:
+            char_info = None
+
+        # Defensive normalization: ensure char_info nested objects are correct types
+        if char_info:
+            try:
+                from module.character.dnd5e import HPInfo, AbilityInfo, SpellInfo, MoneyInfo
+                # hp_info
+                try:
+                    if not isinstance(char_info.hp_info, HPInfo):
+                        hp_obj = HPInfo()
+                        if isinstance(char_info.hp_info, dict):
+                            hp_obj.deserialize(json.dumps(char_info.hp_info))
+                        elif isinstance(char_info.hp_info, str):
+                            # try json or plain int
+                            try:
+                                parsed = json.loads(char_info.hp_info)
+                                if isinstance(parsed, dict):
+                                    hp_obj.deserialize(json.dumps(parsed))
+                                elif isinstance(parsed, int):
+                                    hp_obj.initialize(parsed, parsed)
+                            except Exception:
+                                try:
+                                    hp_cur = int(char_info.hp_info)
+                                    hp_obj.initialize(hp_cur, hp_cur)
+                                except Exception:
+                                    pass
+                        char_info.hp_info = hp_obj
+                except Exception:
+                    # ignore and leave as-is
+                    pass
+
+                # ability_info
+                try:
+                    if not isinstance(char_info.ability_info, AbilityInfo):
+                        abil_obj = AbilityInfo()
+                        if isinstance(char_info.ability_info, dict):
+                            abil_obj.deserialize(json.dumps(char_info.ability_info))
+                        elif isinstance(char_info.ability_info, str):
+                            try:
+                                parsed = json.loads(char_info.ability_info)
+                                if isinstance(parsed, dict):
+                                    abil_obj.deserialize(json.dumps(parsed))
+                            except Exception:
+                                # cannot parse, leave default
+                                pass
+                        char_info.ability_info = abil_obj
+                except Exception:
+                    pass
+            except Exception:
+                # if import fails, skip normalization
+                pass
+
+        if cmd_type == CMD_TYPE_CHAR:
+            content: str = hint[1]
+            if not content:  # 查看角色卡
+                if not char_info:
+                    feedback = self.format_loc(LOC_CHAR_MISS)
+                else:
+                    feedback = char_info.get_char_info()
+
+            elif content.startswith("记录"):  # 记录角色卡
+                content = content[2:].strip()
+                char_info = DNDCharInfo()
+                try:
+                    char_info.initialize(content)
+                    self.bot.data_manager.set_data(DC_CHAR_DND, [meta.group_id, meta.user_id], char_info)
+                    feedback = self.format_loc(LOC_CHAR_SET)
+                except AssertionError as e:
+                    char_info = None
+                    feedback = e.args[0]
+                # 设置昵称
+                if char_info and char_info.name:
+                    self.bot.update_nickname(meta.user_id, meta.group_id, char_info.name)
+
+            elif content.startswith("清除"):  # 清除角色卡
+                self.bot.data_manager.delete_data(DC_CHAR_DND, [meta.group_id, meta.user_id], ignore_miss=True)
+                feedback = self.format_loc(LOC_CHAR_DEL)
+
+            elif content.startswith("模板"):  # 查看角色卡模板
+                temp_char = gen_template_char()
+                feedback = temp_char.get_char_info()
+            else:
+                feedback = "可用的角色卡指令: [记录, 清除, 模板]"
+
+        elif cmd_type == CMD_TYPE_STATE:  # 查看角色卡状态
+            if not char_info:
+                feedback = self.format_loc(LOC_CHAR_MISS)
+            else:
+                feedback = char_info.hp_info.get_info()
+                if char_info.hp_info.hp_dice_type != 0:
+                    feedback += f"\n生命骰:{char_info.hp_info.hp_dice_num}/{char_info.hp_info.hp_dice_max} D{char_info.hp_info.hp_dice_type}"
+
+        elif cmd_type in [CMD_TYPE_CHECK, CMD_TYPE_SAVING, CMD_TYPE_ATTACK]:  # 执行检定
+            time, check_name, mod_str = hint[1]
+            advantage: int = 0
+            if mod_str.startswith("优势"):
+                advantage = 1
+                mod_str = mod_str[2:]
+            if mod_str.startswith("劣势"):
+                advantage = -1
+                mod_str = mod_str[2:]
+            if not char_info:
+                feedback = self.format_loc(LOC_CHAR_MISS)
+            else:
+                check_result_list: List[str] = []
+                check_value_list: List[int] = []
+                name_str = ""
+                if check_name == "先攻":
+                    time = 1
+                try:
+                    hint_str = ""
+                    for t in range(time):
+                        hint_str, result_str, result_val = char_info.ability_info.perform_check(check_name, advantage, mod_str)
+                        check_result_list.append(result_str)
+                        check_value_list.append(result_val)
+                    name_str = char_info.name
+                    if not name_str:
+                        name_str = self.bot.get_nickname(meta.user_id, meta.group_id)
+                    check_name = check_name + "检定" if time <= 1 else f"{time}次{check_name}检定"
+                    result_str = "\n".join(check_result_list)
+                    feedback = self.format_loc(LOC_CHECK_RES, name=name_str, check=check_name, hint=hint_str, result=result_str)
+                except AssertionError as e:
+                    feedback = e.args[0]
+                if check_name == "先攻检定" and len(check_value_list) > 0:
+                    try:
+                        from module.initiative import InitiativeCommand
+                        assert InitiativeCommand.__name__ in self.bot.command_dict, "未注册先攻指令"
+                        init_cmd: InitiativeCommand = self.bot.command_dict[InitiativeCommand.__name__]
+                        assert name_str, "Unexpected Code: name_str is empty"
+                        result_dict = {name_str: (check_value_list[0], check_result_list[0])}
+                        init_feedback = init_cmd.add_initiative_entities(result_dict, meta.user_id, meta.group_id)
+                        if check_result_list[0] in feedback:
+                            feedback = feedback.replace(check_result_list[0], init_feedback)
+                        else:
+                            feedback += f"\n{init_feedback}"
+                    except (ImportError, AssertionError) as e:
+                        feedback += f"\n加入先攻列表失败: {e}"
+
+        elif cmd_type == CMD_TYPE_HP_DICE:  # 使用生命骰
+            time = hint[1]
+            if not char_info:
+                feedback = self.format_loc(LOC_CHAR_MISS)
+            else:
+                feedback = char_info.use_hp_dice(time)
+                self.bot.data_manager.set_data(DC_CHAR_DND, [meta.group_id, meta.user_id], char_info)
+        elif cmd_type == CMD_TYPE_REST_LONG:  # 进行长休
+            if not char_info:
+                feedback = self.format_loc(LOC_CHAR_MISS)
+            else:
+                feedback = char_info.long_rest()
+                self.bot.data_manager.set_data(DC_CHAR_DND, [meta.group_id, meta.user_id], char_info)
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword == "角色卡":  # help后的接着的内容
+            feedback: str = ".角色卡  #查看角色卡\n" \
+                            ".角色卡记录 [角色卡内容]  #生成角色卡\n" \
+                            ".角色卡清除  # 删除当前角色卡\n" \
+                            ".角色卡模板  # 查看角色卡模板\n" \
+                            "使用方法:\n" \
+                            "先使用角色卡模板指令获得模板, 自行修改模板中的内容后再使用角色卡记录指令记录角色卡\n" \
+                            "示例:\n" \
+                            ".角色卡记录\n" \
+                            "$姓名$ 伊丽莎白\n" \
+                            "$等级$ 20\n" \
+                            "... (以下略)" \
+                            "将上述内容作为一条指令输入即可记录伊丽莎白的角色卡\n" \
+                            "每人在每个群中只能拥有一张角色卡, 但通过记录[.角色卡]指令返回的内容即可自行保存多张角色卡\n" \
+                            "输入 .help角色卡内容 可查看每个条目的含义, .help角色卡使用 可查看角色卡衍生指令的说明"
+            return feedback
+        elif keyword == "角色卡内容":
+            feedback: str = "$姓名$ (可选) 若给定姓名, 将会在设置角色卡时自动设置玩家昵称(.nn)\n" \
+                            "$等级$ 正整数\n" \
+                            "$生命值$ (可选) [当前生命值]/[最大生命值] ([临时生命值]) 最大生命值和临时生命值可以不给出\n" \
+                            "$生命骰$ (可选) [当前生命骰]/[最大生命骰] D[生命骰面数] 必须先给定生命值才有效\n" \
+                            "$属性$ 六个用/分隔的正整数, 依次为力量,敏捷,体质,智力,感知,魅力\n" \
+                            "$熟练$ (可选) 不同熟练项用/分隔, 可选熟练项为18种技能, 先攻, 6大属性及对应的攻击和豁免. 所有攻击默认熟练. " \
+                            "熟练项默认倍数为1, 若拥有双倍或多倍熟练可通过[倍数]*[熟练项]的方式指定, 倍数为非负正整数\n" \
+                            "$额外加值$ (可选) 不同额外加值项目用/分割, 每个项目由[项目名]:[加值内容]构成, 项目除上述熟练项以外还可以从[攻击, 豁免, 熟练加值]中选择 " \
+                            "加值内容必须以[+, -, 优势, 劣势]其中之一开头, 除优劣势以外的加值内容会直接叠加到掷骰表达式末尾"
+            return feedback
+        elif keyword == "角色卡使用":
+            feedback: str = "角色卡目前的衍生指令包括[检定, 生命骰, 长休]功能\n" \
+                            "--- 检定功能 ---\n" \
+                            ".[次数#][检定条目][临时调整值]\n" \
+                            "次数必须为1~9之间的整数, 检定条目包括以下几种:\n" \
+                            "1. [力量/敏捷/...]检定\n2. [运动/体操/...]检定\n3. 先攻检定(会将角色加入到先攻列表中)\n4. [力量/敏捷/...]豁免\n5. [力量/敏捷/...]攻击\n" \
+                            "临时调整值规则和额外加值相同, 必须以[+, -, 优势, 劣势]开头\n" \
+                            "示例:\n" \
+                            ".运动检定\n" \
+                            ".2#力量检定\n" \
+                            ".智力豁免+d4\n" \
+                            ".3#敏捷攻击优势+d8\n" \
+                            "--- 生命骰功能 ---\n" \
+                            ".[次数#]生命骰\n" \
+                            "次数必须为1~99之间的整数, 不输入则默认为1, 回复后的生命值不会超过上限\n" \
+                            "--- 长休功能 ---\n" \
+                            ".长休\n" \
+                            "长休时会回复生命至上限, 并按规则回复生命骰"
+            return feedback
+        return ""
+
+    def get_description(self) -> str:
+        return ".角色卡 DND5E角色卡, 衍生功能包括检定/生命骰/长休等"  # help指令中返回的内容

--- a/docs/beta_merge_reference/character_coc/character.py
+++ b/docs/beta_merge_reference/character_coc/character.py
@@ -1,0 +1,246 @@
+from typing import List, Dict
+from collections import defaultdict
+import json
+
+from core.data import JsonObject, custom_json_object
+
+from module.character.dnd5e import HPInfo, AbilityInfo, SpellInfo, MoneyInfo
+from module.character.dnd5e import check_item_index_dict, ext_item_index_dict
+
+from module.character.dnd5e import CHAR_INFO_KEY_HP, CHAR_INFO_KEY_HP_DICE
+from module.character.dnd5e import CHAR_INFO_KEY_LEVEL, CHAR_INFO_KEY_PROF, CHAR_INFO_KEY_ABILITY, CHAR_INFO_KEY_EXT
+
+CHAR_INFO_KEY_NAME = "$姓名$"
+
+CHAR_INFO_KEY_LIST = [
+    CHAR_INFO_KEY_NAME,  # 姓名
+    CHAR_INFO_KEY_LEVEL,  # 等级
+    CHAR_INFO_KEY_HP, CHAR_INFO_KEY_HP_DICE,  # 生命值
+    CHAR_INFO_KEY_ABILITY,  # 属性
+    CHAR_INFO_KEY_PROF,  # 熟练
+    CHAR_INFO_KEY_EXT,  # 额外加值
+]
+
+
+def read_data_from_str_to_dict(input_str: str, output_dict: Dict[str, str]):
+    """
+    使用类似角色卡描述的字符串填充输出字典, 本质只是分割字符串
+    默认所有关键字都被$符号包裹, 且$符号不会出现在普通信息中
+    """
+    info_list = input_str.split("$")
+    index = 0
+    while index < len(info_list)-1:
+        key = f"${info_list[index]}$"
+        if key in CHAR_INFO_KEY_LIST:
+            content = info_list[index+1].strip()
+            if content and content not in CHAR_INFO_KEY_LIST:
+                output_dict[key] = content
+                index += 1
+        index += 1
+
+
+@custom_json_object
+class DNDCharInfo(JsonObject):
+    """
+    DND5E 角色信息
+    """
+
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                    # self.__setattr__(key, value_init)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.is_init = False
+        self.name: str = ""
+        self.hp_info: HPInfo = HPInfo()
+        self.ability_info: AbilityInfo = AbilityInfo()
+        self.spell_info: SpellInfo = SpellInfo()
+        self.money_info: MoneyInfo = MoneyInfo()
+
+    def initialize(self, input_str: str):
+        """
+        通过用户输入初始化属性, 任意内容初始化失败则抛出AssertionError, 并且不会产生实际影响
+        角色卡示例:
+        $姓名$ 伊丽莎白
+        $等级$ 5
+        $生命值$ 5/10(4)
+        $生命骰$ 4/10 D6
+        $属性$ 10/11/12/15/12
+        $熟练$ 力量/2*隐匿/奥秘
+        $额外加值$ 运动:优势/隐匿:优势+2/游说:-2
+        """
+        hp_info: HPInfo = HPInfo()
+        ability_info: AbilityInfo = AbilityInfo()
+        spell_info: SpellInfo = SpellInfo()
+        money_info: MoneyInfo = MoneyInfo()
+
+        char_info_dict: Dict[str, str] = defaultdict(str)
+        read_data_from_str_to_dict(input_str, char_info_dict)
+
+        # 记录姓名
+        name_str = char_info_dict[CHAR_INFO_KEY_NAME]
+
+        # 处理生命值相关信息
+        hp_info_str = char_info_dict[CHAR_INFO_KEY_HP]
+        if hp_info_str:
+            # 处理生命值信息
+            hp_cur: int
+            hp_max: int = 0
+            hp_temp: int = 0
+
+            hp_str: str
+            hp_max_str: str
+            hp_temp_str: str
+            if hp_info_str.find("/") != -1:
+                hp_str, hp_max_str = hp_info_str.split("/", maxsplit=1)
+            else:
+                hp_str, hp_max_str = hp_info_str, ""
+            if hp_info_str.find("(") != -1:
+                if hp_str.find("(") != -1:
+                    hp_str, hp_temp_str = hp_str.split("(", maxsplit=1)
+                else:
+                    hp_max_str, hp_temp_str = hp_max_str.split("(", maxsplit=1)
+                hp_temp_str = hp_temp_str.replace(")", "")
+            else:
+                hp_temp_str = ""
+
+            try:
+                hp_cur = int(hp_str)
+            except ValueError:
+                raise AssertionError(f"无效的生命数值:{hp_str}")
+
+            if hp_max_str:
+                try:
+                    hp_max = int(hp_max_str)
+                except ValueError:
+                    raise AssertionError(f"无效的最大生命值:{hp_max_str}")
+            if hp_temp_str:
+                try:
+                    hp_temp = int(hp_temp_str)
+                except ValueError:
+                    raise AssertionError(f"无效的临时生命值:{hp_temp_str}")
+
+            # 处理生命骰信息
+            hp_dice_type: int = 0
+            hp_dice_num: int = 0
+            hp_dice_max: int = 0
+
+            hp_dice_info_str = char_info_dict[CHAR_INFO_KEY_HP_DICE]
+            if hp_dice_info_str:
+                hp_dice_type_str: str
+                hp_dice_num_str: str
+                hp_dice_max_str: str
+                if hp_dice_info_str.find("d") == -1:
+                    raise AssertionError(f"生命骰信息不完整:{hp_dice_info_str}, 必须指定生命骰大小")
+                hp_dice_max_str, hp_dice_type_str = hp_dice_info_str.split("d", maxsplit=1)
+                if hp_dice_max_str.find("/") != -1:
+                    hp_dice_num_str, hp_dice_max_str = hp_dice_max_str.split("/", maxsplit=1)
+                else:
+                    hp_dice_num_str = hp_dice_max_str
+
+                try:
+                    hp_dice_type = int(hp_dice_type_str)
+                    hp_dice_num = int(hp_dice_num_str)
+                    hp_dice_max = int(hp_dice_max_str)
+                except ValueError:
+                    raise AssertionError(f"生命骰信息不正确{hp_dice_info_str}, 示例: 8/10 D6")
+
+            hp_info.initialize(hp_cur, hp_max, hp_temp, hp_dice_type, hp_dice_num, hp_dice_max)
+        # 处理属性相关信息
+        level_str = char_info_dict[CHAR_INFO_KEY_LEVEL]
+        ability_str = char_info_dict[CHAR_INFO_KEY_ABILITY]
+        prof_str = char_info_dict[CHAR_INFO_KEY_PROF]
+        ext_str = char_info_dict[CHAR_INFO_KEY_EXT]
+
+        assert level_str and ability_str, "必须设定等级与属性"
+
+        ability_info_list: List[int] = []
+        prof_list: List[str] = []
+        ext_dict: Dict[str, str] = {}
+
+        for ability_item_str in ability_str.split("/"):
+            try:
+                ability_info_list.append(int(ability_item_str))
+            except ValueError:
+                raise AssertionError("属性值必须为正整数!")
+        if prof_str:
+            prof_list = prof_str.split("/")
+        if ext_str:
+            ext_list = ext_str.split("/")
+            for ext_item_str in ext_list:
+                assert ext_item_str.find(":") > 0 and not ext_item_str.endswith(":"), "必须使用冒号(:)分割额外加值条目和内容"
+                key_str, content_str = ext_item_str.split(":", maxsplit=1)
+                ext_dict[key_str] = content_str
+
+        ability_info.initialize(level_str, ability_info_list, prof_list, ext_dict)
+
+        # 应用初始化
+        self.is_init = True
+        self.name = name_str
+        self.hp_info = hp_info
+        self.ability_info = ability_info
+        self.spell_info = spell_info
+        self.money_info = money_info
+
+    def get_char_info(self) -> str:
+        """返回完整角色卡描述"""
+        # 重组顺序
+        char_info_dict: Dict[str, str] = {}
+        if self.name:
+            char_info_dict[CHAR_INFO_KEY_NAME] = self.name
+        read_data_from_str_to_dict(self.hp_info.get_char_info(), char_info_dict)
+        read_data_from_str_to_dict(self.ability_info.get_char_info(), char_info_dict)
+        char_info = ""
+        for key in CHAR_INFO_KEY_LIST:
+            if key in char_info_dict:
+                char_info += f"{key} {char_info_dict[key]}\n"
+        return char_info.strip()
+
+    def use_hp_dice(self, num: int) -> str:
+        con_mod: int = self.ability_info.get_modifier(check_item_index_dict["体质"])
+        return self.name + self.hp_info.use_hp_dice(num, con_mod)
+
+    def long_rest(self) -> str:
+        result: str = f"{self.name}进行了一次长休\n"
+        result += self.hp_info.long_rest()
+        return result.strip()
+
+
+def gen_template_char() -> DNDCharInfo:
+    char_info = DNDCharInfo()
+    char_info.name = "张三"
+
+    char_info.hp_info.hp_cur = 20
+    char_info.hp_info.hp_max = 30
+    char_info.hp_info.hp_temp = 5
+    char_info.hp_info.hp_dice_type = 8
+    char_info.hp_info.hp_dice_num = 3
+    char_info.hp_info.hp_dice_max = 4
+
+    char_info.ability_info.level = 4
+    char_info.ability_info.ability = [10, 15, 12, 13, 8, 11]
+    char_info.ability_info.check_prof[check_item_index_dict["敏捷攻击"]] = 1
+    char_info.ability_info.check_prof[check_item_index_dict["敏捷豁免"]] = 1
+    char_info.ability_info.check_prof[check_item_index_dict["体操"]] = 1
+    char_info.ability_info.check_prof[check_item_index_dict["隐匿"]] = 2
+
+    char_info.ability_info.check_adv[ext_item_index_dict["隐匿"]] = 1
+
+    char_info.ability_info.check_ext[ext_item_index_dict["豁免"]] = "+2"
+    char_info.ability_info.check_ext[ext_item_index_dict["敏捷攻击"]] = "+1d4"
+    return char_info

--- a/docs/beta_merge_reference/character_coc/health.py
+++ b/docs/beta_merge_reference/character_coc/health.py
@@ -1,0 +1,243 @@
+from typing import Literal, Optional
+import json
+
+from core.data import JsonObject, custom_json_object
+from module.roll import exec_roll_exp, RollDiceError, RollResult
+
+CHAR_INFO_KEY_HP = "$生命值$"
+CHAR_INFO_KEY_HP_DICE = "$生命骰$"
+
+
+@custom_json_object
+class HPInfo(JsonObject):
+    """
+    HP信息
+    """
+
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                self.__setattr__(key, value)
+
+    def __init__(self):
+        self.is_init = False
+        self.is_alive = True
+        self.hp_cur = 0  # 当前生命值
+        self.hp_max = 0  # 最大生命值
+        self.hp_temp = 0  # 临时生命值
+        self.hp_dice_type = 0  # 生命骰面数
+        self.hp_dice_num = 0  # 生命骰数量
+        self.hp_dice_max = 0  # 生命骰最大数量
+
+    def initialize(self, hp_cur: int, hp_max: int = 0, hp_temp: int = 0, hp_dice_type: int = 0, hp_dice_num: int = 0, hp_dice_max: int = 0):
+        assert hp_max >= hp_cur >= 0, f"无效的生命值信息: {hp_cur}/{hp_max}"
+        assert hp_temp >= 0, f"无效的临时生命值信息: {hp_temp}"
+        assert 100 >= hp_dice_type >= 0 and 1000 >= hp_dice_max >= 0, f"无效的生命骰信息: {hp_dice_max}颗{hp_dice_type}面骰"
+
+        self.is_init = True
+        self.is_alive = True
+
+        self.hp_cur = hp_cur
+        self.hp_max = hp_max
+        self.hp_temp = hp_temp
+        self.hp_dice_type = hp_dice_type
+        self.hp_dice_num = hp_dice_num
+        self.hp_dice_max = hp_dice_max
+
+    def is_record_normal(self) -> bool:
+        """当前是否正常记录生命值 (拥有hp, 而不是单纯记录受损hp)"""
+        return self.hp_cur > 0 or (self.hp_cur == 0 and not self.is_alive)
+
+    def is_record_damage(self) -> bool:
+        """当前是否是记录受损生命值的情况"""
+        return not self.is_record_normal()
+
+    def take_damage(self, value: int):
+        # 临时生命值
+        if self.hp_temp > 0:
+            if self.hp_temp >= value:
+                self.hp_temp -= value
+                return
+            else:
+                value -= self.hp_temp
+                self.hp_temp = 0
+        # 生命值
+        if self.is_alive:
+            if self.hp_cur > 0:
+                if self.hp_cur > value:
+                    self.hp_cur -= value
+                else:
+                    self.hp_cur = 0
+                    self.is_alive = False
+            else:  # self.hp_cur <= 0 hp_cur如果小于等于0且is_alive==True说明当前记录的是受损生命值
+                self.hp_cur -= value
+
+    def heal(self, value: int):
+        if self.is_record_normal():
+            if self.hp_max == 0:  # 没有设置生命值上限
+                self.hp_cur += value
+            else:
+                self.hp_cur = min(self.hp_max, self.hp_cur + value)
+        else:  # 记录受损生命值的情况
+            self.hp_cur = min(0, self.hp_cur + value)
+        self.is_alive = True
+
+    def get_info(self) -> str:
+        hp_info: str
+        hp_temp_info = f" ({self.hp_temp})" if self.hp_temp != 0 else ""
+        if self.is_record_normal():
+            hp_max_info = f"/{self.hp_max}" if self.hp_max != 0 else ""
+            hp_info = f"HP:{self.hp_cur}{hp_max_info}{hp_temp_info}"
+            if not self.is_alive:
+                hp_info += " 昏迷"
+        else:
+            hp_info = f"损失HP:{-self.hp_cur}{hp_temp_info}"
+        return hp_info
+
+    def use_hp_dice(self, num: int, con_mod: int) -> str:
+        """
+        使用生命骰, 并返回修改结果描述, 如
+        使用2颗D4生命骰, 体质调整值为1, 回复(4+1)+(2+1)=8点生命值
+        HP: 2/4 -> 4/4
+        """
+        if not self.is_init or self.hp_dice_type <= 0:
+            return "尚未设置生命骰"
+        if num <= 0 or num > 1000:
+            return f"无效的生命骰数量({num})"
+        if self.hp_dice_num < num:
+            return f"生命骰数量不足, 还有{self.hp_dice_num}颗生命骰"
+        roll_exp = f"1D{self.hp_dice_type}+{con_mod}"
+
+        roll_result_list = []
+        roll_result_val = 0
+        for i in range(num):
+            try:
+                roll_result = exec_roll_exp(roll_exp)
+            except RollDiceError as e:
+                return f"未知掷骰错误:{e.info}"
+            if num > 1:
+                roll_result_list.append(f"({roll_result.get_info()})")
+            else:
+                roll_result_list.append(roll_result.get_info())
+            roll_val = roll_result.get_val()
+            if roll_val < 0:
+                roll_val = 0
+                roll_result_list[-1] = f"({roll_result_list[-1]}->0)"
+            roll_result_val += roll_val
+
+        roll_result_str = f"{'+'.join(roll_result_list)}={roll_result_val}"
+
+        mod_info = f"使用{num}颗D{self.hp_dice_type}生命骰, 体质调整值为{con_mod}, 回复{roll_result_str}点生命值\n"
+        hp_info_str_prev = self.get_info()
+        self.hp_dice_num -= num
+        self.heal(roll_result_val)
+        mod_info += f"{hp_info_str_prev} -> {self.get_info()}"
+        return mod_info
+
+    def long_rest(self):
+        info = ""
+        if self.hp_max != 0:
+            info = f"生命值回复至上限({self.hp_max})"
+            self.hp_cur = self.hp_max
+        if self.hp_temp != 0:
+            info += f" {self.hp_temp}点临时生命值失效"
+            self.hp_temp = 0
+        if self.hp_dice_max != 0 and self.hp_dice_type != 0:
+            prev_hp_dice_num = self.hp_dice_num
+            self.hp_dice_num = int(max(1, min(self.hp_dice_max, self.hp_dice_num + self.hp_dice_max // 2)))
+            info += f"\n回复{self.hp_dice_num-prev_hp_dice_num}个生命骰, 当前拥有{self.hp_dice_num}/{self.hp_dice_max}个D{self.hp_dice_type}生命骰"
+        return info.strip()
+
+    def process_roll_result(self, cmd_type: Literal["=", "+", "-"],
+                            hp_cur_mod_result: Optional[RollResult] = None,
+                            hp_max_mod_result: Optional[RollResult] = None,
+                            hp_temp_mod_result: Optional[RollResult] = None,
+                            short_feedback=False) -> str:
+        """
+        根据输入进行修改, 返回修改结果描述, 如:
+        当前HP减少 2*4 = 8
+        HP: 10 -> HP: 2
+        """
+        mod_info = ""
+        if cmd_type == "=":  # 设置生命值
+            self.is_init = True
+            if hp_cur_mod_result:
+                if self.is_record_normal():
+                    self.is_alive = hp_cur_mod_result.get_val() > 0
+                self.hp_cur = hp_cur_mod_result.get_val()
+                mod_info = f"HP={hp_cur_mod_result.get_result()}"
+            if hp_max_mod_result:
+                self.hp_max = hp_max_mod_result.get_val()
+                if self.hp_cur > self.hp_max:
+                    self.take_damage(self.hp_cur - self.hp_max)
+                mod_info = f"HP={hp_cur_mod_result.get_result()}/{hp_max_mod_result.get_result()}"
+            if hp_temp_mod_result:
+                self.hp_temp = hp_temp_mod_result.get_val()
+                if "HP=" in mod_info:
+                    mod_info += f" ({hp_temp_mod_result.get_result()})"
+                else:
+                    mod_info = f"临时HP={hp_temp_mod_result.get_result()}"
+            mod_info += f"\n当前{self.get_info()}"
+        elif cmd_type == "+":  # 增加生命值
+            hp_info_str_prev = self.get_info()
+            if hp_max_mod_result:  # 先结算生命值上限
+                self.hp_max += hp_max_mod_result.get_val()
+                mod_info += f"最大HP增加{hp_max_mod_result.get_result()}, "
+            if hp_cur_mod_result:
+                self.heal(hp_cur_mod_result.get_val())
+                mod_info += f"当前HP增加{hp_cur_mod_result.get_result()}"
+            if hp_temp_mod_result:
+                self.hp_temp += hp_temp_mod_result.get_val()
+                if mod_info:
+                    mod_info += ", "
+                mod_info += f"临时HP增加{hp_temp_mod_result.get_result()}"
+            mod_info += f"\n{hp_info_str_prev} -> {self.get_info()}"
+        else:  # cmd_type == "-"  扣除生命值
+            hp_info_str_prev = self.get_info()
+            if hp_temp_mod_result:  # 先结算临时生命值
+                self.hp_temp = max(0, self.hp_temp - hp_temp_mod_result.get_val())
+                mod_info += f"临时HP减少{hp_temp_mod_result.get_result()}"
+            if hp_max_mod_result:  # 先结算生命值上限
+                self.hp_max -= hp_max_mod_result.get_val()
+                if mod_info:
+                    mod_info += ", "
+                mod_info += f"最大HP减少{hp_max_mod_result.get_result()}"
+                if self.hp_cur > self.hp_max:
+                    self.take_damage(self.hp_cur - self.hp_max)
+            if hp_cur_mod_result:
+                self.take_damage(hp_cur_mod_result.get_val())
+                if mod_info:
+                    mod_info += ", "
+                mod_info += f"当前HP减少{hp_cur_mod_result.get_result()}"
+            mod_info += f"\n{hp_info_str_prev} -> {self.get_info()}"
+
+        mod_info = mod_info.strip()
+        if short_feedback:
+            mod_info = mod_info.replace("\n", "; ")
+        return mod_info
+
+    def get_char_info(self) -> str:
+        """
+        返回可用来组合成初始化角色卡的字符串
+        例子:
+        $生命值$ 5/10 (4)
+        $生命骰$ 4/10 D6
+        例子2:
+        $生命值$ 8
+        """
+        info: str
+        # 生命值信息
+        info = f"{CHAR_INFO_KEY_HP} {self.hp_cur}"
+        if self.hp_max > 0:
+            info += f"/{self.hp_max}"
+        if self.hp_temp > 0:
+            info += f" ({self.hp_temp})"
+        # 生命骰信息
+        if self.hp_dice_type > 0:
+            info += f"\n{CHAR_INFO_KEY_HP_DICE} {self.hp_dice_num}/{self.hp_dice_max} D{self.hp_dice_type}"
+        return info

--- a/docs/beta_merge_reference/character_coc/hp_command.py
+++ b/docs/beta_merge_reference/character_coc/hp_command.py
@@ -1,0 +1,396 @@
+"""
+hp指令
+"""
+
+from typing import List, Tuple, Any, Literal, Optional, Dict
+import re
+import json
+
+from core.bot import Bot
+from core.data import DataChunkBase, custom_data_chunk, DataManagerError
+from core.command.const import *
+from core.command import UserCommandBase, custom_user_command
+from core.command import BotCommandBase, BotSendMsgCommand
+from core.communication import MessageMetaData, PrivateMessagePort, GroupMessagePort
+
+from utils.string import match_substring
+from module.roll import exec_roll_exp, RollDiceError, RollResult
+from module.character.dnd5e import DNDCharInfo, HPInfo
+
+LOC_HP_INFO = "hp_info"
+LOC_HP_INFO_MISS = "hp_info_miss"
+LOC_HP_INFO_MULTI = "hp_info_multi"
+LOC_HP_INFO_NONE = "hp_info_none"
+LOC_HP_MOD = "hp_mod"
+LOC_HP_MOD_ERR = "hp_mod_error"
+LOC_HP_DEL = "hp_delete"
+
+# 增加自定义DataChunk, 只存放NPC生命值信息, 玩家生命值信息存储在 DC_CHAR_DND【占位】
+DC_CHAR_DND = "character_dnd"
+DC_CHAR_HP = "char_hp"
+
+
+@custom_data_chunk(identifier=DC_CHAR_HP, include_json_object=True)
+class _(DataChunkBase):
+    def __init__(self):
+        super().__init__()
+
+
+@custom_user_command(readable_name="生命值指令", priority=DPP_COMMAND_PRIORITY_DEFAULT,
+                     flag=DPP_COMMAND_FLAG_CHAR | DPP_COMMAND_FLAG_DND | DPP_COMMAND_FLAG_BATTLE, group_only=True)
+class HPCommand(UserCommandBase):
+    """
+    调整和记录生命值的指令, 以.hp开头
+    """
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_HP_INFO, "{name}: {hp_info}", "查看当前生命值")
+        bot.loc_helper.register_loc_text(LOC_HP_INFO_MISS, "Cannot find hp info for: {name}", "找不到指定的生命值信息")
+        bot.loc_helper.register_loc_text(LOC_HP_INFO_MULTI, "Possible target is: {name_list}", "匹配到多个可能的生命值信息")
+        bot.loc_helper.register_loc_text(LOC_HP_INFO_NONE, "None of hp info in this group", "查看生命值列表时找不到任何信息")
+        bot.loc_helper.register_loc_text(LOC_HP_MOD, "{name}: {hp_mod}", "修改生命值信息")
+        bot.loc_helper.register_loc_text(LOC_HP_MOD_ERR, "Error when modify hp: {error}", "修改生命值信息时出现错误")
+        bot.loc_helper.register_loc_text(LOC_HP_DEL, "Delete hp info for {name}", "成功删除生命值信息")
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        should_proc: bool = msg_str.startswith(".hp")
+        should_pass: bool = False
+        return should_proc, should_pass, msg_str[3:].strip()
+
+    def process_msg(self, msg_str: str, meta: MessageMetaData, hint: Any) -> List[BotCommandBase]:
+        port = GroupMessagePort(meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
+        # 解析语句
+        arg_str: str = hint
+        feedback: str
+
+        if not arg_str:  # 查看自己生命值
+            target: List[str] = [meta.group_id, meta.user_id]  # 目标是自己
+            nickname = self.bot.get_nickname(meta.user_id, meta.group_id)
+            try:
+                char_info: DNDCharInfo = self.bot.data_manager.get_data(DC_CHAR_DND, target)
+                hp_info = char_info.hp_info
+                if not isinstance(hp_info, HPInfo):
+                    try:
+                        if isinstance(hp_info, dict):
+                            new_hp = HPInfo()
+                            new_hp.deserialize(json.dumps(hp_info))
+                            hp_info = new_hp
+                        else:
+                            new_hp = HPInfo()
+                            try:
+                                new_hp.hp_cur = int(str(hp_info))
+                                hp_info = new_hp
+                            except Exception:
+                                hp_info = new_hp
+                    except Exception:
+                        hp_info = HPInfo()
+                feedback = self.format_loc(LOC_HP_INFO, name=nickname, hp_info=hp_info.get_info())
+            except DataManagerError:
+                feedback = self.format_loc(LOC_HP_INFO_MISS, name=nickname)
+        elif arg_str.startswith("list"):  # 查看当前群聊的所有生命值信息
+            try:
+                char_info_dict: Dict[str, DNDCharInfo] = self.bot.data_manager.get_data(DC_CHAR_DND, [meta.group_id])
+            except DataManagerError:
+                char_info_dict = {}
+            try:
+                hp_info_dict: Dict[str, HPInfo] = self.bot.data_manager.get_data(DC_CHAR_HP, [meta.group_id])
+            except DataManagerError:
+                hp_info_dict = {}
+            if char_info_dict or hp_info_dict:
+                feedback = ""
+                for char_id, char_info in char_info_dict.items():
+                    nickname = self.bot.get_nickname(char_id, meta.group_id)
+                    hp_info = getattr(char_info, 'hp_info', None)
+                    if not isinstance(hp_info, HPInfo):
+                        try:
+                            if isinstance(hp_info, dict):
+                                tmp = HPInfo()
+                                tmp.deserialize(json.dumps(hp_info))
+                                hp_info = tmp
+                            else:
+                                hp_info = HPInfo()
+                        except Exception:
+                            hp_info = HPInfo()
+                    feedback += f"{nickname} {hp_info.get_info()}\n"
+                for name, hp_info in hp_info_dict.items():
+                    if not isinstance(hp_info, HPInfo):
+                        try:
+                            if isinstance(hp_info, dict):
+                                tmp = HPInfo()
+                                tmp.deserialize(json.dumps(hp_info))
+                                hp_info = tmp
+                            else:
+                                hp_info = HPInfo()
+                        except Exception:
+                            hp_info = HPInfo()
+                    feedback += f"{name} {hp_info.get_info()}\n"
+                feedback = feedback.strip()
+            else:  # 没有任何生命值信息
+                feedback = self.format_loc(LOC_HP_INFO_NONE)
+        elif arg_str.startswith("del") or arg_str.startswith("clr"):  # 删除某人生命值
+            arg_str = arg_str[3:].strip()
+            target: Tuple[str, List[str]] = (DC_CHAR_DND, [meta.group_id, meta.user_id])  # 默认目标是自己
+            if arg_str:
+                # 查找已存在的生命值信息
+                target_intent = arg_str
+                source_key, target_id = self.search_target(target_intent, meta.group_id)
+                if not source_key:
+                    feedback = self.format_loc(LOC_HP_INFO_MISS, name=target_intent)
+                    return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+                elif source_key == "multiple":
+                    target_poss = target_id.split("/")
+                    feedback = self.format_loc(LOC_HP_INFO_MULTI, name_list=target_poss)
+                    return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+                target: Tuple[str, List[str]] = (source_key, [meta.group_id, target_id])
+
+            try:
+                self.bot.data_manager.delete_data(target[0], target[1])
+            except DataManagerError:
+                pass
+            if target[0] == DC_CHAR_DND:
+                name = self.bot.get_nickname(target[1][1], meta.group_id)
+            else:
+                name = target[1][1]
+            feedback = self.format_loc(LOC_HP_DEL, name=name)
+
+        else:  # 调整生命值
+            # 判断操作类型
+            cmd_type: Literal["+", "-", "="] = "="
+            max_len = 2 ** 20
+            cmd_index_eq = arg_str.find("=") if arg_str.find("=") != -1 else max_len
+            cmd_index_add = arg_str.find("+") if arg_str.find("+") != -1 else max_len
+            cmd_index_sub = arg_str.find("-") if arg_str.find("-") != -1 else max_len
+            cmd_index_space = arg_str.find(" ") if arg_str.find(" ") != -1 else max_len
+            cmd_index: int = min(cmd_index_eq, cmd_index_add, cmd_index_sub, cmd_index_space)
+            if cmd_index == max_len:  # 都没有找到
+                cmd_index = -1
+            elif cmd_index == cmd_index_eq or cmd_index == cmd_index_space:
+                cmd_type = "="
+            elif cmd_index == cmd_index_add:
+                cmd_type = "+"
+            elif cmd_index == cmd_index_sub:
+                cmd_type = "-"
+
+            # 查找指定的对象
+            target_list: List[Tuple[str, List[str]]] = []
+            if cmd_index == 0:  # 给定了类型但没有指定对象
+                arg_str = arg_str[1:].strip()
+            if cmd_index > 0:  # 给定类型并指定其他对象
+                target_intent_list = arg_str[:cmd_index].split(";")
+                arg_str = arg_str[cmd_index + 1:].strip()
+
+                for target_intent in target_intent_list:
+                    target_intent = target_intent.strip()
+                    source_key, target_id = self.search_target(target_intent, meta.group_id)
+                    if source_key in [DC_CHAR_DND, DC_CHAR_HP]:
+                        target_list.append((source_key, [meta.group_id, target_id]))
+                    else:  # 提示错误信息
+                        if source_key == "multiple":
+                            target_poss = target_id.split("/")
+                            feedback = self.format_loc(LOC_HP_INFO_MULTI, name_list=target_poss)
+                            return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+                        else:  # not source_key
+                            feedback = self.format_loc(LOC_HP_INFO_MISS, name=target_intent)
+                            return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+            if not target_list:
+                target_list = [(DC_CHAR_DND, [meta.group_id, meta.user_id])]  # 默认目标是自己的角色卡信息
+            # 计算调整值
+            # 处理临时生命值
+            temp_pattern = r"\((.*?)\)$"
+            temp_match = re.search(temp_pattern, arg_str)
+            hp_temp_mod_result: Optional[RollResult] = None
+            if temp_match:
+                try:
+                    hp_temp_mod_result = exec_roll_exp(temp_match.group(1))
+                except RollDiceError as e:
+                    feedback = self.format_loc(LOC_HP_MOD_ERR, error=e.info)
+                    return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+                arg_str = arg_str[:temp_match.span()[0]].strip()
+
+            if not arg_str and not temp_match:
+                feedback = self.format_loc(LOC_HP_MOD_ERR, error="没有给定调整值")
+                return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+            # 处理当前和最大生命值
+            hp_cur_mod_result: Optional[RollResult] = None
+            hp_max_mod_result: Optional[RollResult] = None
+            if arg_str:
+                arg_list = arg_str.split("/", 1)
+                try:
+                    if len(arg_list) == 2:
+                        hp_cur_mod_result = exec_roll_exp(arg_list[0])
+                        hp_max_mod_result = exec_roll_exp(arg_list[1])
+                    else:
+                        hp_cur_mod_result = exec_roll_exp(arg_str)
+                except RollDiceError as e:
+                    feedback = self.format_loc(LOC_HP_MOD_ERR, error=e.info)
+                    return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+            # 应用调整值
+            feedback = ""
+            for source_key, target in target_list:
+                assert source_key in (DC_CHAR_DND, DC_CHAR_HP)
+                if source_key == DC_CHAR_DND:
+                    char_info = self.bot.data_manager.get_data(DC_CHAR_DND, target, default_gen=DNDCharInfo, get_ref=True)
+                    hp_info: HPInfo = getattr(char_info, 'hp_info', None)
+                    if not isinstance(hp_info, HPInfo):
+                        try:
+                            if isinstance(hp_info, dict):
+                                tmp = HPInfo()
+                                tmp.deserialize(json.dumps(hp_info))
+                                hp_info = tmp
+                            else:
+                                hp_info = HPInfo()
+                        except Exception:
+                            hp_info = HPInfo()
+                else:
+                    hp_info: HPInfo = self.bot.data_manager.get_data(DC_CHAR_HP, target, default_gen=HPInfo, get_ref=True)
+                if not isinstance(hp_info, HPInfo):
+                    hp_info = HPInfo()
+                mod_info: str = hp_info.process_roll_result(cmd_type, hp_cur_mod_result, hp_max_mod_result, hp_temp_mod_result,
+                                                            short_feedback=(len(target_list) > 1))
+
+                if source_key == DC_CHAR_DND:
+                    name = self.bot.get_nickname(target[1], meta.group_id)
+                else:
+                    name = target[1]
+                feedback += self.format_loc(LOC_HP_MOD, name=name, hp_mod=mod_info) + "\n"
+            feedback = feedback.strip()
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword == "hp":  # help后的接着的内容
+            feedback: str = "设置生命值: .hp [对象, 可以指定已设置过生命值的或先攻列表中的角色, 用;分割多个对象] [=, 或空格] [当前生命值/最大生命值(可不填)] [(临时生命值), 可不填]\n" \
+                            "示例:\n" \
+                            ".hp 20/30 -> 将自己的当前生命值设为20, 最大生命值设为30\n" \
+                            ".hp (10) -> 将自己的临时生命值设为10, 当前和最大生命值不变\n" \
+                            ".hp 队友A 30/30 (10) -> 将队友A的当前和最大生命值都设为30, 临时生命值设为10\n" \
+                            ".hp 哥布林 4d6 -> 将先攻列表中的哥布林的当前生命值设为4d6\n" \
+                            "调整生命值: .hp [对象] [+/-] [调整值] 具体规则同上\n" \
+                            "示例:\n" \
+                            ".hp +2d10 -> 将自己的当前生命值增加2d10\n" \
+                            ".hp +(10) -> 将自己的临时生命值增加\n" \
+                            ".hp +20/10 -> 先将自己的最大生命值增加10, 再将当前生命值增加20, 当前生命值不会超过最大生命值\n" \
+                            ".hp 哥布林 -4d6 -> 对先攻列表中的哥布林造成4d6点伤害, 扣除伤害时会先扣除临时生命值\n" \
+                            ".hp a;b;c -2d4 -> 对先攻列表中含有a,b,c的三个对象造成4d6点伤害\n" \
+                            "删除生命值: .hp del [对象]\n" \
+                            "示例:\n" \
+                            ".hp del -> 删除自己的生命值信息\n" \
+                            ".hp del 哥布林 -> 删除哥布林的先攻信息, .init clr时会自动清除所有没有,一般不需要手动删除其他人的生命值信息)\n" \
+                            "查看生命值: .hp -> 查看自己当前的生命值信息\n" \
+                            "注意: 在指定对象时不需要指定全名, 只需要指定名称中独一无二的一部分即可, 比如所有可选择的对象中只有哥布林有'哥'字, 指定时只需要写'哥'即可\n" \
+                            "设置的生命值信息会在查看先攻列表时显示, 请注意PC需要自己掷先攻骰, 通过.ri [名称]设置的先攻都会被视为NPC\n" \
+                            "不需要设置当前生命值和最大生命值也可以使用, 此时只会记录已损失的生命值, 已损失的生命值不会低于0\n" \
+                            "由于/已经被作为分割最大生命值的关键字, 表达式中出现除法可能会导致出现意外情况, 如有需求可以通过在最后加上抗性两个字达到类似效果"
+            return feedback
+        return ""
+
+    def get_description(self) -> str:
+        return ".hp 记录生命值"  # help指令中返回的内容
+
+    def search_target(self, target_intent: str, group_id: str) -> Tuple[str, str]:
+        """
+        从角色卡信息, 生命值信息和先攻列表中查询是否有符合target_intent, 如果找到结果返回字符串元组(DC, PC账号/NPC名称), 没有找到则返回元组("", "")
+        DC可以为
+        * DC_CHAR_DND (从角色卡信息或先攻列表中找到, 元组第二位为pc账号)
+        * DC_CHAR_HP (从生命值信息或先攻列表中找到, 元组第二位为npc名称)
+        * "multiple" (多个模糊的结果, 此时元组第二位为以/分割的pc或npc名称)
+        匹配优先级为 完全匹配角色卡信息>完全匹配生命值信息>完全匹配先攻列表>部分匹配角色卡信息>部分匹配生命值信息>部分匹配先攻列表
+        """
+        MULTI_SOURCE = "multiple"
+        source = ""
+        target_id = ""
+        target_id_name_dict: Dict[str, str] = {}
+        # 查找角色卡信息
+        try:
+            for char_id in self.bot.data_manager.get_keys(DC_CHAR_DND, [group_id]):
+                target_id_name_dict[char_id] = self.bot.get_nickname(char_id, group_id)
+        except DataManagerError:
+            pass
+        target_poss = match_substring(target_intent, target_id_name_dict.values())
+        if len(target_poss) == 1:
+            source = DC_CHAR_DND
+            for key, value in target_id_name_dict.items():
+                if value == target_poss[0]:
+                    target_id = key
+                    if value == target_intent:  # 完全匹配
+                        return source, target_id
+                    break
+        elif len(target_poss) > 1:  # 模糊的结果
+            source = MULTI_SOURCE
+            target_id = "/".join(target_poss)
+            return source, target_id
+        # 查找当前已经存在的生命值信息
+        try:
+            npc_set = set(self.bot.data_manager.get_keys(DC_CHAR_HP, [group_id]))
+        except DataManagerError:
+            npc_set = {}
+        target_poss = match_substring(target_intent, npc_set)
+        if len(target_poss) == 1:
+            for npc_id in npc_set:
+                if npc_id == target_poss[0]:
+                    if not target_id:  # 之前没有匹配结果
+                        source = DC_CHAR_HP
+                        target_id = npc_id
+                    if npc_id == target_intent:  # 完全匹配
+                        source = DC_CHAR_HP
+                        return source, npc_id
+                    break
+        elif len(target_poss) > 1:  # 模糊的结果
+            source = MULTI_SOURCE
+            target_id = "/".join(target_poss)
+            return source, target_id
+        # 查找先攻列表
+        target_id_name_dict = {}
+        pc_set = set()
+        try:
+            from module.initiative import DC_INIT, InitList, InitEntity
+            init_list: InitList = self.bot.data_manager.get_data(DC_INIT, [group_id])
+            for entity in getattr(init_list, 'entities', []):
+                if isinstance(entity, InitEntity):
+                    if entity.owner:
+                        target_id_name_dict[entity.owner] = entity.name
+                        pc_set.add(entity.owner)
+                    else:
+                        target_id_name_dict[entity.name] = entity.name
+                elif isinstance(entity, dict):
+                    name = entity.get('name') or ''
+                    owner = entity.get('owner') or ''
+                    if owner:
+                        target_id_name_dict[owner] = name
+                        pc_set.add(owner)
+                    else:
+                        target_id_name_dict[name] = name
+                else:
+                    try:
+                        name = str(entity)
+                    except Exception:
+                        name = ''
+                    target_id_name_dict[name] = name
+        except DataManagerError:
+            pass
+        target_poss = match_substring(target_intent, target_id_name_dict.values())
+        if len(target_poss) == 1:
+            for key, value in target_id_name_dict.items():
+                if value == target_poss[0]:
+                    if not target_id:  # 之前没有匹配结果
+                        if key in pc_set:
+                            source = DC_CHAR_DND
+                        else:
+                            source = DC_CHAR_HP
+                        target_id = key
+                    if value == target_intent:
+                        if key in pc_set:
+                            source = DC_CHAR_DND
+                        else:
+                            source = DC_CHAR_HP
+                        return source, key
+                    break
+        elif len(target_poss) > 1:  # 模糊的结果
+            source = MULTI_SOURCE
+            target_id = "/".join(target_poss)
+            return source, target_id
+        return source, target_id

--- a/docs/beta_merge_reference/character_coc/money.py
+++ b/docs/beta_merge_reference/character_coc/money.py
@@ -1,0 +1,29 @@
+import json
+
+from core.data import JsonObject, custom_json_object
+
+
+@custom_json_object
+class MoneyInfo(JsonObject):
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.gold = 0
+        self.silver = 0
+        self.copper = 0

--- a/docs/beta_merge_reference/character_coc/spell.py
+++ b/docs/beta_merge_reference/character_coc/spell.py
@@ -1,0 +1,29 @@
+from typing import List
+import json
+
+from core.data import JsonObject, custom_json_object
+
+
+@custom_json_object
+class SpellInfo(JsonObject):
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.slot_num: List[int] = [0] * 9  # 当前法术位数量
+        self.slot_max: List[int] = [0] * 9  # 最大法术位数量

--- a/docs/beta_merge_reference/character_dnd5e_split/ability.py
+++ b/docs/beta_merge_reference/character_dnd5e_split/ability.py
@@ -1,0 +1,360 @@
+from typing import List, Tuple, Dict
+import json
+
+from core.data import JsonObject, custom_json_object
+from module.roll import exec_roll_exp, RollDiceError
+
+CHAR_INFO_KEY_LEVEL = "$等级$"
+CHAR_INFO_KEY_ABILITY = "$属性$"
+CHAR_INFO_KEY_PROF = "$熟练$"
+CHAR_INFO_KEY_EXT = "$额外加值$"
+
+
+# 属性值
+ability_list = ["力量", "敏捷", "体质", "智力", "感知", "魅力", ]
+ability_num = len(ability_list)
+assert ability_num == 6
+
+# 技能
+skill_list = ["运动",
+              "体操", "巧手", "隐匿", "先攻",
+              "奥秘", "历史", "调查", "自然", "宗教",
+              "驯兽", "洞悉", "医药", "察觉", "求生",
+              "欺瞒", "威吓", "表演", "游说", ]
+skill_num = len(skill_list)
+assert skill_num == 19
+
+skill_parent_dict = {
+    "运动": "力量",
+    "体操": "敏捷", "巧手": "敏捷", "隐匿": "敏捷", "先攻": "敏捷",
+    "奥秘": "智力", "历史": "智力", "调查": "智力", "自然": "智力", "宗教": "智力",
+    "驯兽": "感知", "洞悉": "感知", "医药": "感知", "察觉": "感知", "求生": "感知",
+    "欺瞒": "魅力", "威吓": "魅力", "表演": "魅力", "游说": "魅力",
+
+}
+assert len(skill_parent_dict) == skill_num
+assert sum([1 for v in skill_parent_dict.values() if v not in ability_list]) == 0
+skill_synonym_dict = {
+    "特技": "体操", "妙手": "巧手", "潜行": "隐匿", "隐蔽": "隐匿", "隐秘": "隐匿", "躲藏": "隐匿",
+    "驯养": "驯兽", "驯服": "驯兽", "医疗": "医药", "医术": "医药", "观察": "察觉", "生存": "求生",
+    "欺骗": "欺瞒", "欺诈": "欺瞒", "哄骗": "欺瞒", "唬骗": "欺瞒", "威胁": "威吓", "说服": "游说"}
+assert sum([1 for v in skill_synonym_dict.values() if v not in skill_list]) == 0
+
+# 豁免
+saving_list = ["力量豁免", "敏捷豁免", "体质豁免", "智力豁免", "感知豁免", "魅力豁免", ]
+saving_num = len(saving_list)
+assert saving_num == ability_num
+saving_parent_dict = {
+    "力量豁免": "力量", "敏捷豁免": "敏捷", "体质豁免": "体质", "智力豁免": "智力", "感知豁免": "感知", "魅力豁免": "魅力",
+}
+assert len(saving_parent_dict) == saving_num
+assert sum([1 for v in saving_parent_dict.values() if v not in ability_list]) == 0
+
+# 攻击
+attack_list = ["力量攻击", "敏捷攻击", "体质攻击", "智力攻击", "感知攻击", "魅力攻击", ]
+attack_num = len(attack_list)
+assert attack_num == ability_num
+attack_parent_dict = {
+    "力量攻击": "力量", "敏捷攻击": "敏捷", "体质攻击": "体质", "智力攻击": "智力", "感知攻击": "感知", "魅力攻击": "魅力",
+}
+assert len(attack_parent_dict) == attack_num
+assert sum([1 for v in attack_parent_dict.values() if v not in ability_list]) == 0
+
+# 可检定条目
+check_item_list = ability_list + skill_list + saving_list + attack_list
+check_item_num = ability_num * 3 + skill_num
+
+check_item_index_dict = dict(list((k, i) for i, k in enumerate(check_item_list)))
+assert len(check_item_list) == len(check_item_index_dict) == check_item_num
+
+# 可额外加值条目
+saving_all_key = "豁免"
+attack_all_key = "攻击"
+ext_item_list = check_item_list + [saving_all_key, attack_all_key]
+ext_item_num = check_item_num + 2
+
+ext_item_index_dict = dict(list((k, i) for i, k in enumerate(ext_item_list)))
+assert len(ext_item_list) == len(ext_item_index_dict) == ext_item_num
+
+
+@custom_json_object
+class AbilityInfo(JsonObject):
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.is_init: bool = False
+        self.version = 1  # 版本号
+
+        self.level: int = 0  # 等级
+
+        self.ability: List[int] = [0] * ability_num  # 力量, 敏捷, 体质, 智力, 感知, 魅力
+        self.check_prof: List[int] = [0] * check_item_num  # 检定的熟练加值的倍数
+        self.check_ext: List[str] = [""] * ext_item_num  # 描述检定的额外加值的表达式
+        self.check_adv: List[int] = [0] * ext_item_num  # 是否自带优势或劣势
+
+    def initialize(self, level_str: str, ability_info_list: List[int], prof_list: List[str], ext_dict: Dict[str, str]):
+        """
+        通过用户输入初始化属性, 初始化失败则抛出AssertionError
+        Args:
+            level_str: 正整数字符串, 代表等级
+            ability_info_list: 长度为6的正整数字符串列表, 代表六项属性
+            prof_list: 长度任意的字符串列表, 代表熟练的检定条目, 如["2*奥秘", "智力豁免"]代表奥秘有双倍熟练加值, 智力豁免拥有单倍熟练加值, 其余检定没有熟练加值
+            ext_dict: key为检定条目, value为对应检定的额外加值
+        """
+        # 初始化等级
+        try:
+            assert int(level_str) > 0
+        except (AssertionError, ValueError):
+            raise AssertionError("等级必须为正整数")
+        level = int(level_str)
+
+        # 初始化属性值
+        ability = [0] * ability_num
+        assert len(ability_info_list) == ability_num, f"必须设定全部的{ability_num}项属性"
+        for index, val_str in enumerate(ability_info_list):
+            try:
+                assert int(val_str) > 0
+            except(AssertionError, ValueError):
+                raise AssertionError(f"{ability_list[index]}属性值{val_str}必须为正整数")
+            ability[index] = int(val_str)
+
+        # 初始化熟练加值
+        check_prof = [0] * check_item_num
+        for attack_name in attack_list:  # 默认熟练所有攻击
+            attack_index: int = check_item_index_dict[attack_name]
+            check_prof[attack_index] = 1
+        for check_name in prof_list:
+            prof_scale = 1
+            if "*" in check_name:
+                scale_str, check_name = check_name.split("*", 1)
+                try:
+                    prof_scale = int(scale_str)
+                    assert prof_scale >= 0
+                except (ValueError, AssertionError):
+                    raise AssertionError(f"{check_name}熟练加值倍数必须为非负整数")
+            if check_name in skill_synonym_dict:
+                check_name = skill_synonym_dict[check_name]
+            assert check_name in check_item_list, f"{check_name}为无效的检定条目, 可用条目:{check_item_list}"
+            check_index: int = check_item_index_dict[check_name]
+            check_prof[check_index] = prof_scale
+
+        # 初始化调整值
+        check_ext = [""] * ext_item_num
+        check_adv = [0] * ext_item_num
+        for check_name, ext_str in ext_dict.items():
+            if not ext_str:
+                continue
+            if check_name in skill_synonym_dict:
+                check_name = skill_synonym_dict[check_name]
+            assert check_name in ext_item_list, f"{check_name}为无效条目, 可用条目:\n{ext_item_list}"
+            check_index: int = ext_item_index_dict[check_name]
+
+            # 处理优劣势
+            if ext_str.startswith("优势") or ext_str.startswith("劣势"):
+                if ext_str.startswith("优势"):
+                    check_adv[check_index] = 1
+                if ext_str.startswith("劣势"):
+                    check_adv[check_index] = -1
+                ext_str = ext_str[2:]
+            if not ext_str:
+                continue
+
+            # 校验开头
+            assert ext_str[0] in ["+", "-"], f"调整值无效: 必须以[优势/劣势]+/-开头\n{check_name}:{ext_str} "
+            # 校验表达式合法性
+            try:
+                res = exec_roll_exp("D20" + ext_str)
+                res.get_complete_result()
+            except RollDiceError as e:
+                raise AssertionError(f"无效的调整值: {check_name}:{ext_str} {e.info}")
+            check_ext[check_index] = ext_str
+
+        self.is_init = True
+        self.level = level
+        self.ability = ability
+        self.check_ext = check_ext
+        self.check_adv = check_adv
+        self.check_prof = check_prof
+
+    def get_prof_bonus(self) -> int:
+        prof_bonus = 2 + (self.level - 1) // 4
+        return prof_bonus
+
+    def get_modifier(self, ability_index: int) -> int:
+        ability_score = self.ability[ability_index]
+        modifier = (ability_score - 10) // 2
+        return modifier
+
+    def perform_check(self, check_name: str, advantage: int, mod_str: str) -> Tuple[str, str, int]:
+        """
+        进行技能检定, 失败抛出AssertionError
+        Args:
+            check_name: 必须为skill_dict中的元素, 如: 力量/运动
+            advantage: 该次检定是否具有优势, 1为优势, -1为劣势, =0为无优无劣
+            mod_str: 该次检定的临时加值
+        Returns:
+            hint_str: 提示信息
+            result_str: 检定的计算过程
+            result_val: 检定结果
+        """
+        hint_str: str = ""
+        result_str: str
+        result_val: int
+        assert self.is_init, "未初始化属性值"
+        if check_name in skill_synonym_dict:
+            check_name = skill_synonym_dict[check_name]
+        assert check_name in check_item_list, f"{check_name}无效, 可用检定条目:\n{check_item_list}"
+        is_skill: bool = check_name in skill_list  # 计算技能检定时 会 叠加基础属性的额外加值与优劣势
+        is_saving: bool = check_name in saving_list  # 计算豁免检定时 不会 叠加基础属性的额外加值与优劣势
+        is_attack: bool = check_name in attack_list  # 计算攻击检定时 不会 叠加基础属性的额外加值与优劣势
+
+        check_index = check_item_index_dict[check_name]
+        parent_index = -1
+        if is_skill:
+            parent_index = ext_item_index_dict[skill_parent_dict[check_name]]
+        if is_saving:
+            parent_index = ext_item_index_dict[saving_parent_dict[check_name]]
+        if is_attack:
+            parent_index = ext_item_index_dict[attack_parent_dict[check_name]]
+
+        # 计算熟练加值
+        prof_bonus = self.check_prof[check_index] * self.get_prof_bonus()
+        if self.check_prof[check_index] == 0:
+            hint_str += f"无熟练加值 "
+        elif self.check_prof[check_index] == 1:
+            hint_str += f"熟练加值:{prof_bonus} "
+        else:
+            hint_str += f"熟练加值:{self.get_prof_bonus()}*{self.check_prof[check_index]} "
+        prof_bonus_str: str = ""
+        if prof_bonus != 0:
+            prof_bonus_str = "+" + str(prof_bonus) if prof_bonus > 0 else str(prof_bonus)
+
+        # 计算属性调整值
+        ability_modifier: int
+        if parent_index != -1:
+            ability_modifier = self.get_modifier(parent_index)
+            hint_str += f"{ability_list[parent_index]}调整值:{ability_modifier} "
+        else:
+            ability_modifier = self.get_modifier(check_index)
+            hint_str += f"{ability_list[check_index]}调整值:{ability_modifier} "
+        ability_modifier_str: str = ""
+        if ability_modifier != 0:
+            ability_modifier_str = "+" + str(ability_modifier) if ability_modifier > 0 else str(ability_modifier)
+
+        # 得到额外加值
+        ext_str = self.check_ext[check_index]
+        if parent_index != -1:
+            ext_str += self.check_ext[parent_index]
+        if is_saving:
+            all_index = ext_item_index_dict[saving_all_key]
+            ext_str += self.check_ext[all_index]
+        if is_attack:
+            all_index = ext_item_index_dict[attack_all_key]
+            ext_str += self.check_ext[all_index]
+        if ext_str:
+            hint_str += f"额外加值:{ext_str} "
+
+        # 临时加值
+        if mod_str:
+            hint_str += f"临时加值:{mod_str} "
+
+        # 计算优劣势
+        assert advantage in [-1, 0, 1], "Unexpected Code: 0"
+        is_counter: bool  # 优劣势是否被抵消过
+        adv_flag = self.check_adv[check_index]
+        parent_flag = 0
+        if is_skill:
+            parent_flag = self.check_adv[parent_index]
+        adv_flag = max(min(adv_flag + parent_flag, 1), -1)
+        is_counter = (adv_flag == 0 and parent_flag != 0)
+        adv_flag = max(min(adv_flag + advantage, 1), -1)
+        is_counter = is_counter or (adv_flag == 0 and advantage != 0)
+        if is_counter:
+            adv_flag = 0
+            hint_str += "优劣抵消 "
+        if adv_flag != 0 and advantage == 0:
+            if adv_flag > 0:
+                hint_str += "自带优势 "
+            else:
+                hint_str += "自带劣势 "
+
+        hint_str = hint_str.strip()
+
+        # 组合成掷骰表达式
+        roll_exp: str
+        if adv_flag != 0:
+            if adv_flag > 0:
+                roll_exp = "D20优势"
+            else:
+                roll_exp = "D20劣势"
+        else:
+            roll_exp = "D20"
+
+        roll_exp = f"{roll_exp}{prof_bonus_str}{ability_modifier_str}{ext_str}{mod_str}"
+        try:
+            roll_result = exec_roll_exp(roll_exp)
+            result_str = roll_result.get_complete_result()
+            result_val = roll_result.get_val()
+        except RollDiceError as e:
+            raise AssertionError(f"Unexpected Code: {roll_exp}->{e.info}")
+
+        return hint_str, result_str, result_val
+
+    def get_char_info(self) -> str:
+        """
+        返回可用来组合成初始化角色卡的字符串
+        例子:
+        $等级$ 5
+        $属性$ 10/11/12/15/12
+        $熟练$ 力量/2*隐匿/奥秘
+        $额外加值$ 运动:优势/隐匿:优势+2/游说:-2
+        """
+        info = ""
+        # 等级信息
+        info += f"{CHAR_INFO_KEY_LEVEL} {self.level}\n"
+        # 属性值信息
+        info += f"{CHAR_INFO_KEY_ABILITY} {'/'.join([str(val) for val in self.ability])}\n"
+
+        # 熟练信息
+        prof_info = [(scale, check_item_list[index]) for index, scale in enumerate(self.check_prof) if scale > 0]
+        prof_list = []
+        for scale, prof_name in prof_info:
+            if scale == 1:
+                prof_list.append(prof_name)
+            else:
+                prof_list.append(f"{scale}*{prof_name}")
+        if len(prof_list) > 0:
+            info += f"{CHAR_INFO_KEY_PROF} {'/'.join(prof_list)}\n"
+
+        # 额外加值信息
+        ext_info = [(ext_item_list[index], ext_str) for index, ext_str in enumerate(self.check_ext) if ext_str]
+        adv_dict = dict([(ext_item_list[index], adv_flag) for index, adv_flag in enumerate(self.check_adv) if adv_flag != 0])
+        ext_list = []
+        for check_name, ext_str in ext_info:
+            ext_str_prefix = ""
+            if check_name in adv_dict:
+                if adv_dict[check_name] > 0:
+                    ext_str_prefix = "优势"
+                else:
+                    ext_str_prefix = "劣势"
+            ext_list.append(f"{check_name}:{ext_str_prefix}{ext_str}")
+        if len(ext_list) > 0:
+            info += f"{CHAR_INFO_KEY_EXT} {'/'.join(ext_list)}\n"
+
+        return info.strip()

--- a/docs/beta_merge_reference/character_dnd5e_split/character.py
+++ b/docs/beta_merge_reference/character_dnd5e_split/character.py
@@ -1,0 +1,246 @@
+from typing import List, Dict
+from collections import defaultdict
+import json
+
+from core.data import JsonObject, custom_json_object
+
+from module.character.dnd5e import HPInfo, AbilityInfo, SpellInfo, MoneyInfo
+from module.character.dnd5e import check_item_index_dict, ext_item_index_dict
+
+from module.character.dnd5e import CHAR_INFO_KEY_HP, CHAR_INFO_KEY_HP_DICE
+from module.character.dnd5e import CHAR_INFO_KEY_LEVEL, CHAR_INFO_KEY_PROF, CHAR_INFO_KEY_ABILITY, CHAR_INFO_KEY_EXT
+
+CHAR_INFO_KEY_NAME = "$姓名$"
+
+CHAR_INFO_KEY_LIST = [
+    CHAR_INFO_KEY_NAME,  # 姓名
+    CHAR_INFO_KEY_LEVEL,  # 等级
+    CHAR_INFO_KEY_HP, CHAR_INFO_KEY_HP_DICE,  # 生命值
+    CHAR_INFO_KEY_ABILITY,  # 属性
+    CHAR_INFO_KEY_PROF,  # 熟练
+    CHAR_INFO_KEY_EXT,  # 额外加值
+]
+
+
+def read_data_from_str_to_dict(input_str: str, output_dict: Dict[str, str]):
+    """
+    使用类似角色卡描述的字符串填充输出字典, 本质只是分割字符串
+    默认所有关键字都被$符号包裹, 且$符号不会出现在普通信息中
+    """
+    info_list = input_str.split("$")
+    index = 0
+    while index < len(info_list)-1:
+        key = f"${info_list[index]}$"
+        if key in CHAR_INFO_KEY_LIST:
+            content = info_list[index+1].strip()
+            if content and content not in CHAR_INFO_KEY_LIST:
+                output_dict[key] = content
+                index += 1
+        index += 1
+
+
+@custom_json_object
+class DNDCharInfo(JsonObject):
+    """
+    DND5E 角色信息
+    """
+
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                    # self.__setattr__(key, value_init)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.is_init = False
+        self.name: str = ""
+        self.hp_info: HPInfo = HPInfo()
+        self.ability_info: AbilityInfo = AbilityInfo()
+        self.spell_info: SpellInfo = SpellInfo()
+        self.money_info: MoneyInfo = MoneyInfo()
+
+    def initialize(self, input_str: str):
+        """
+        通过用户输入初始化属性, 任意内容初始化失败则抛出AssertionError, 并且不会产生实际影响
+        角色卡示例:
+        $姓名$ 伊丽莎白
+        $等级$ 5
+        $生命值$ 5/10(4)
+        $生命骰$ 4/10 D6
+        $属性$ 10/11/12/15/12
+        $熟练$ 力量/2*隐匿/奥秘
+        $额外加值$ 运动:优势/隐匿:优势+2/游说:-2
+        """
+        hp_info: HPInfo = HPInfo()
+        ability_info: AbilityInfo = AbilityInfo()
+        spell_info: SpellInfo = SpellInfo()
+        money_info: MoneyInfo = MoneyInfo()
+
+        char_info_dict: Dict[str, str] = defaultdict(str)
+        read_data_from_str_to_dict(input_str, char_info_dict)
+
+        # 记录姓名
+        name_str = char_info_dict[CHAR_INFO_KEY_NAME]
+
+        # 处理生命值相关信息
+        hp_info_str = char_info_dict[CHAR_INFO_KEY_HP]
+        if hp_info_str:
+            # 处理生命值信息
+            hp_cur: int
+            hp_max: int = 0
+            hp_temp: int = 0
+
+            hp_str: str
+            hp_max_str: str
+            hp_temp_str: str
+            if hp_info_str.find("/") != -1:
+                hp_str, hp_max_str = hp_info_str.split("/", maxsplit=1)
+            else:
+                hp_str, hp_max_str = hp_info_str, ""
+            if hp_info_str.find("(") != -1:
+                if hp_str.find("(") != -1:
+                    hp_str, hp_temp_str = hp_str.split("(", maxsplit=1)
+                else:
+                    hp_max_str, hp_temp_str = hp_max_str.split("(", maxsplit=1)
+                hp_temp_str = hp_temp_str.replace(")", "")
+            else:
+                hp_temp_str = ""
+
+            try:
+                hp_cur = int(hp_str)
+            except ValueError:
+                raise AssertionError(f"无效的生命数值:{hp_str}")
+
+            if hp_max_str:
+                try:
+                    hp_max = int(hp_max_str)
+                except ValueError:
+                    raise AssertionError(f"无效的最大生命值:{hp_max_str}")
+            if hp_temp_str:
+                try:
+                    hp_temp = int(hp_temp_str)
+                except ValueError:
+                    raise AssertionError(f"无效的临时生命值:{hp_temp_str}")
+
+            # 处理生命骰信息
+            hp_dice_type: int = 0
+            hp_dice_num: int = 0
+            hp_dice_max: int = 0
+
+            hp_dice_info_str = char_info_dict[CHAR_INFO_KEY_HP_DICE]
+            if hp_dice_info_str:
+                hp_dice_type_str: str
+                hp_dice_num_str: str
+                hp_dice_max_str: str
+                if hp_dice_info_str.find("d") == -1:
+                    raise AssertionError(f"生命骰信息不完整:{hp_dice_info_str}, 必须指定生命骰大小")
+                hp_dice_max_str, hp_dice_type_str = hp_dice_info_str.split("d", maxsplit=1)
+                if hp_dice_max_str.find("/") != -1:
+                    hp_dice_num_str, hp_dice_max_str = hp_dice_max_str.split("/", maxsplit=1)
+                else:
+                    hp_dice_num_str = hp_dice_max_str
+
+                try:
+                    hp_dice_type = int(hp_dice_type_str)
+                    hp_dice_num = int(hp_dice_num_str)
+                    hp_dice_max = int(hp_dice_max_str)
+                except ValueError:
+                    raise AssertionError(f"生命骰信息不正确{hp_dice_info_str}, 示例: 8/10 D6")
+
+            hp_info.initialize(hp_cur, hp_max, hp_temp, hp_dice_type, hp_dice_num, hp_dice_max)
+        # 处理属性相关信息
+        level_str = char_info_dict[CHAR_INFO_KEY_LEVEL]
+        ability_str = char_info_dict[CHAR_INFO_KEY_ABILITY]
+        prof_str = char_info_dict[CHAR_INFO_KEY_PROF]
+        ext_str = char_info_dict[CHAR_INFO_KEY_EXT]
+
+        assert level_str and ability_str, "必须设定等级与属性"
+
+        ability_info_list: List[int] = []
+        prof_list: List[str] = []
+        ext_dict: Dict[str, str] = {}
+
+        for ability_item_str in ability_str.split("/"):
+            try:
+                ability_info_list.append(int(ability_item_str))
+            except ValueError:
+                raise AssertionError("属性值必须为正整数!")
+        if prof_str:
+            prof_list = prof_str.split("/")
+        if ext_str:
+            ext_list = ext_str.split("/")
+            for ext_item_str in ext_list:
+                assert ext_item_str.find(":") > 0 and not ext_item_str.endswith(":"), "必须使用冒号(:)分割额外加值条目和内容"
+                key_str, content_str = ext_item_str.split(":", maxsplit=1)
+                ext_dict[key_str] = content_str
+
+        ability_info.initialize(level_str, ability_info_list, prof_list, ext_dict)
+
+        # 应用初始化
+        self.is_init = True
+        self.name = name_str
+        self.hp_info = hp_info
+        self.ability_info = ability_info
+        self.spell_info = spell_info
+        self.money_info = money_info
+
+    def get_char_info(self) -> str:
+        """返回完整角色卡描述"""
+        # 重组顺序
+        char_info_dict: Dict[str, str] = {}
+        if self.name:
+            char_info_dict[CHAR_INFO_KEY_NAME] = self.name
+        read_data_from_str_to_dict(self.hp_info.get_char_info(), char_info_dict)
+        read_data_from_str_to_dict(self.ability_info.get_char_info(), char_info_dict)
+        char_info = ""
+        for key in CHAR_INFO_KEY_LIST:
+            if key in char_info_dict:
+                char_info += f"{key} {char_info_dict[key]}\n"
+        return char_info.strip()
+
+    def use_hp_dice(self, num: int) -> str:
+        con_mod: int = self.ability_info.get_modifier(check_item_index_dict["体质"])
+        return self.name + self.hp_info.use_hp_dice(num, con_mod)
+
+    def long_rest(self) -> str:
+        result: str = f"{self.name}进行了一次长休\n"
+        result += self.hp_info.long_rest()
+        return result.strip()
+
+
+def gen_template_char() -> DNDCharInfo:
+    char_info = DNDCharInfo()
+    char_info.name = "张三"
+
+    char_info.hp_info.hp_cur = 20
+    char_info.hp_info.hp_max = 30
+    char_info.hp_info.hp_temp = 5
+    char_info.hp_info.hp_dice_type = 8
+    char_info.hp_info.hp_dice_num = 3
+    char_info.hp_info.hp_dice_max = 4
+
+    char_info.ability_info.level = 4
+    char_info.ability_info.ability = [10, 15, 12, 13, 8, 11]
+    char_info.ability_info.check_prof[check_item_index_dict["敏捷攻击"]] = 1
+    char_info.ability_info.check_prof[check_item_index_dict["敏捷豁免"]] = 1
+    char_info.ability_info.check_prof[check_item_index_dict["体操"]] = 1
+    char_info.ability_info.check_prof[check_item_index_dict["隐匿"]] = 2
+
+    char_info.ability_info.check_adv[ext_item_index_dict["隐匿"]] = 1
+
+    char_info.ability_info.check_ext[ext_item_index_dict["豁免"]] = "+2"
+    char_info.ability_info.check_ext[ext_item_index_dict["敏捷攻击"]] = "+1d4"
+    return char_info

--- a/docs/beta_merge_reference/character_dnd5e_split/health.py
+++ b/docs/beta_merge_reference/character_dnd5e_split/health.py
@@ -1,0 +1,243 @@
+from typing import Literal, Optional
+import json
+
+from core.data import JsonObject, custom_json_object
+from module.roll import exec_roll_exp, RollDiceError, RollResult
+
+CHAR_INFO_KEY_HP = "$生命值$"
+CHAR_INFO_KEY_HP_DICE = "$生命骰$"
+
+
+@custom_json_object
+class HPInfo(JsonObject):
+    """
+    HP信息
+    """
+
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                self.__setattr__(key, value)
+
+    def __init__(self):
+        self.is_init = False
+        self.is_alive = True
+        self.hp_cur = 0  # 当前生命值
+        self.hp_max = 0  # 最大生命值
+        self.hp_temp = 0  # 临时生命值
+        self.hp_dice_type = 0  # 生命骰面数
+        self.hp_dice_num = 0  # 生命骰数量
+        self.hp_dice_max = 0  # 生命骰最大数量
+
+    def initialize(self, hp_cur: int, hp_max: int = 0, hp_temp: int = 0, hp_dice_type: int = 0, hp_dice_num: int = 0, hp_dice_max: int = 0):
+        assert hp_max >= hp_cur >= 0, f"无效的生命值信息: {hp_cur}/{hp_max}"
+        assert hp_temp >= 0, f"无效的临时生命值信息: {hp_temp}"
+        assert 100 >= hp_dice_type >= 0 and 1000 >= hp_dice_max >= 0, f"无效的生命骰信息: {hp_dice_max}颗{hp_dice_type}面骰"
+
+        self.is_init = True
+        self.is_alive = True
+
+        self.hp_cur = hp_cur
+        self.hp_max = hp_max
+        self.hp_temp = hp_temp
+        self.hp_dice_type = hp_dice_type
+        self.hp_dice_num = hp_dice_num
+        self.hp_dice_max = hp_dice_max
+
+    def is_record_normal(self) -> bool:
+        """当前是否正常记录生命值 (拥有hp, 而不是单纯记录受损hp)"""
+        return self.hp_cur > 0 or (self.hp_cur == 0 and not self.is_alive)
+
+    def is_record_damage(self) -> bool:
+        """当前是否是记录受损生命值的情况"""
+        return not self.is_record_normal()
+
+    def take_damage(self, value: int):
+        # 临时生命值
+        if self.hp_temp > 0:
+            if self.hp_temp >= value:
+                self.hp_temp -= value
+                return
+            else:
+                value -= self.hp_temp
+                self.hp_temp = 0
+        # 生命值
+        if self.is_alive:
+            if self.hp_cur > 0:
+                if self.hp_cur > value:
+                    self.hp_cur -= value
+                else:
+                    self.hp_cur = 0
+                    self.is_alive = False
+            else:  # self.hp_cur <= 0 hp_cur如果小于等于0且is_alive==True说明当前记录的是受损生命值
+                self.hp_cur -= value
+
+    def heal(self, value: int):
+        if self.is_record_normal():
+            if self.hp_max == 0:  # 没有设置生命值上限
+                self.hp_cur += value
+            else:
+                self.hp_cur = min(self.hp_max, self.hp_cur + value)
+        else:  # 记录受损生命值的情况
+            self.hp_cur = min(0, self.hp_cur + value)
+        self.is_alive = True
+
+    def get_info(self) -> str:
+        hp_info: str
+        hp_temp_info = f" ({self.hp_temp})" if self.hp_temp != 0 else ""
+        if self.is_record_normal():
+            hp_max_info = f"/{self.hp_max}" if self.hp_max != 0 else ""
+            hp_info = f"HP:{self.hp_cur}{hp_max_info}{hp_temp_info}"
+            if not self.is_alive:
+                hp_info += " 昏迷"
+        else:
+            hp_info = f"损失HP:{-self.hp_cur}{hp_temp_info}"
+        return hp_info
+
+    def use_hp_dice(self, num: int, con_mod: int) -> str:
+        """
+        使用生命骰, 并返回修改结果描述, 如
+        使用2颗D4生命骰, 体质调整值为1, 回复(4+1)+(2+1)=8点生命值
+        HP: 2/4 -> 4/4
+        """
+        if not self.is_init or self.hp_dice_type <= 0:
+            return "尚未设置生命骰"
+        if num <= 0 or num > 1000:
+            return f"无效的生命骰数量({num})"
+        if self.hp_dice_num < num:
+            return f"生命骰数量不足, 还有{self.hp_dice_num}颗生命骰"
+        roll_exp = f"1D{self.hp_dice_type}+{con_mod}"
+
+        roll_result_list = []
+        roll_result_val = 0
+        for i in range(num):
+            try:
+                roll_result = exec_roll_exp(roll_exp)
+            except RollDiceError as e:
+                return f"未知掷骰错误:{e.info}"
+            if num > 1:
+                roll_result_list.append(f"({roll_result.get_info()})")
+            else:
+                roll_result_list.append(roll_result.get_info())
+            roll_val = roll_result.get_val()
+            if roll_val < 0:
+                roll_val = 0
+                roll_result_list[-1] = f"({roll_result_list[-1]}->0)"
+            roll_result_val += roll_val
+
+        roll_result_str = f"{'+'.join(roll_result_list)}={roll_result_val}"
+
+        mod_info = f"使用{num}颗D{self.hp_dice_type}生命骰, 体质调整值为{con_mod}, 回复{roll_result_str}点生命值\n"
+        hp_info_str_prev = self.get_info()
+        self.hp_dice_num -= num
+        self.heal(roll_result_val)
+        mod_info += f"{hp_info_str_prev} -> {self.get_info()}"
+        return mod_info
+
+    def long_rest(self):
+        info = ""
+        if self.hp_max != 0:
+            info = f"生命值回复至上限({self.hp_max})"
+            self.hp_cur = self.hp_max
+        if self.hp_temp != 0:
+            info += f" {self.hp_temp}点临时生命值失效"
+            self.hp_temp = 0
+        if self.hp_dice_max != 0 and self.hp_dice_type != 0:
+            prev_hp_dice_num = self.hp_dice_num
+            self.hp_dice_num = int(max(1, min(self.hp_dice_max, self.hp_dice_num + self.hp_dice_max // 2)))
+            info += f"\n回复{self.hp_dice_num-prev_hp_dice_num}个生命骰, 当前拥有{self.hp_dice_num}/{self.hp_dice_max}个D{self.hp_dice_type}生命骰"
+        return info.strip()
+
+    def process_roll_result(self, cmd_type: Literal["=", "+", "-"],
+                            hp_cur_mod_result: Optional[RollResult] = None,
+                            hp_max_mod_result: Optional[RollResult] = None,
+                            hp_temp_mod_result: Optional[RollResult] = None,
+                            short_feedback=False) -> str:
+        """
+        根据输入进行修改, 返回修改结果描述, 如:
+        当前HP减少 2*4 = 8
+        HP: 10 -> HP: 2
+        """
+        mod_info = ""
+        if cmd_type == "=":  # 设置生命值
+            self.is_init = True
+            if hp_cur_mod_result:
+                if self.is_record_normal():
+                    self.is_alive = hp_cur_mod_result.get_val() > 0
+                self.hp_cur = hp_cur_mod_result.get_val()
+                mod_info = f"HP={hp_cur_mod_result.get_result()}"
+            if hp_max_mod_result:
+                self.hp_max = hp_max_mod_result.get_val()
+                if self.hp_cur > self.hp_max:
+                    self.take_damage(self.hp_cur - self.hp_max)
+                mod_info = f"HP={hp_cur_mod_result.get_result()}/{hp_max_mod_result.get_result()}"
+            if hp_temp_mod_result:
+                self.hp_temp = hp_temp_mod_result.get_val()
+                if "HP=" in mod_info:
+                    mod_info += f" ({hp_temp_mod_result.get_result()})"
+                else:
+                    mod_info = f"临时HP={hp_temp_mod_result.get_result()}"
+            mod_info += f"\n当前{self.get_info()}"
+        elif cmd_type == "+":  # 增加生命值
+            hp_info_str_prev = self.get_info()
+            if hp_max_mod_result:  # 先结算生命值上限
+                self.hp_max += hp_max_mod_result.get_val()
+                mod_info += f"最大HP增加{hp_max_mod_result.get_result()}, "
+            if hp_cur_mod_result:
+                self.heal(hp_cur_mod_result.get_val())
+                mod_info += f"当前HP增加{hp_cur_mod_result.get_result()}"
+            if hp_temp_mod_result:
+                self.hp_temp += hp_temp_mod_result.get_val()
+                if mod_info:
+                    mod_info += ", "
+                mod_info += f"临时HP增加{hp_temp_mod_result.get_result()}"
+            mod_info += f"\n{hp_info_str_prev} -> {self.get_info()}"
+        else:  # cmd_type == "-"  扣除生命值
+            hp_info_str_prev = self.get_info()
+            if hp_temp_mod_result:  # 先结算临时生命值
+                self.hp_temp = max(0, self.hp_temp - hp_temp_mod_result.get_val())
+                mod_info += f"临时HP减少{hp_temp_mod_result.get_result()}"
+            if hp_max_mod_result:  # 先结算生命值上限
+                self.hp_max -= hp_max_mod_result.get_val()
+                if mod_info:
+                    mod_info += ", "
+                mod_info += f"最大HP减少{hp_max_mod_result.get_result()}"
+                if self.hp_cur > self.hp_max:
+                    self.take_damage(self.hp_cur - self.hp_max)
+            if hp_cur_mod_result:
+                self.take_damage(hp_cur_mod_result.get_val())
+                if mod_info:
+                    mod_info += ", "
+                mod_info += f"当前HP减少{hp_cur_mod_result.get_result()}"
+            mod_info += f"\n{hp_info_str_prev} -> {self.get_info()}"
+
+        mod_info = mod_info.strip()
+        if short_feedback:
+            mod_info = mod_info.replace("\n", "; ")
+        return mod_info
+
+    def get_char_info(self) -> str:
+        """
+        返回可用来组合成初始化角色卡的字符串
+        例子:
+        $生命值$ 5/10 (4)
+        $生命骰$ 4/10 D6
+        例子2:
+        $生命值$ 8
+        """
+        info: str
+        # 生命值信息
+        info = f"{CHAR_INFO_KEY_HP} {self.hp_cur}"
+        if self.hp_max > 0:
+            info += f"/{self.hp_max}"
+        if self.hp_temp > 0:
+            info += f" ({self.hp_temp})"
+        # 生命骰信息
+        if self.hp_dice_type > 0:
+            info += f"\n{CHAR_INFO_KEY_HP_DICE} {self.hp_dice_num}/{self.hp_dice_max} D{self.hp_dice_type}"
+        return info

--- a/docs/beta_merge_reference/character_dnd5e_split/money.py
+++ b/docs/beta_merge_reference/character_dnd5e_split/money.py
@@ -1,0 +1,29 @@
+import json
+
+from core.data import JsonObject, custom_json_object
+
+
+@custom_json_object
+class MoneyInfo(JsonObject):
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.gold = 0
+        self.silver = 0
+        self.copper = 0

--- a/docs/beta_merge_reference/character_dnd5e_split/spell.py
+++ b/docs/beta_merge_reference/character_dnd5e_split/spell.py
@@ -1,0 +1,29 @@
+from typing import List
+import json
+
+from core.data import JsonObject, custom_json_object
+
+
+@custom_json_object
+class SpellInfo(JsonObject):
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.slot_num: List[int] = [0] * 9  # 当前法术位数量
+        self.slot_max: List[int] = [0] * 9  # 最大法术位数量

--- a/docs/beta_merge_reference/common/log_db.py
+++ b/docs/beta_merge_reference/common/log_db.py
@@ -1,0 +1,184 @@
+import os
+import sqlite3
+from typing import Any, Dict, Iterable, List, Optional
+
+from core.config import DATA_PATH
+from utils.logger import dice_log
+
+LOG_DIR = os.path.join(DATA_PATH, "log")
+LOG_DB_PATH = os.path.join(LOG_DIR, "log.db")
+
+
+def _ensure_dir() -> None:
+    if not os.path.isdir(LOG_DIR):
+        os.makedirs(LOG_DIR, exist_ok=True)
+        dice_log(f"[LogDB] 创建日志目录: {LOG_DIR}")
+
+
+def get_connection() -> sqlite3.Connection:
+    """Get a sqlite3 connection and ensure schema exists.
+    Callers are responsible to close the connection.
+    """
+    _ensure_dir()
+    init_needed = not os.path.exists(LOG_DB_PATH)
+    conn = sqlite3.connect(LOG_DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+        conn.execute("PRAGMA foreign_keys=ON;")
+    except Exception:
+        pass
+    if init_needed:
+        _init_schema(conn)
+    else:
+        _init_schema(conn)  # idempotent
+    return conn
+
+
+def _init_schema(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    # 日志表：只存元数据与状态
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS logs (
+            id TEXT PRIMARY KEY,
+            group_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            recording INTEGER NOT NULL DEFAULT 0,
+            record_begin_at TEXT NOT NULL,
+            last_warn TEXT NOT NULL,
+            filter_outside INTEGER NOT NULL DEFAULT 0,
+            filter_command INTEGER NOT NULL DEFAULT 0,
+            filter_bot INTEGER NOT NULL DEFAULT 0,
+            filter_media INTEGER NOT NULL DEFAULT 0,
+            filter_forum_code INTEGER NOT NULL DEFAULT 0,
+            upload_time TEXT,
+            upload_file TEXT,
+            upload_note TEXT,
+            url TEXT
+        );
+        """
+    )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_logs_group ON logs(group_id);")
+
+    # 记录表：存每条消息
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS records (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            log_id TEXT NOT NULL,
+            time TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            nickname TEXT,
+            content TEXT NOT NULL,
+            source TEXT NOT NULL, -- 'bot' or 'user'
+            message_id TEXT,
+            FOREIGN KEY(log_id) REFERENCES logs(id) ON DELETE CASCADE
+        );
+        """
+    )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_records_log ON records(log_id);")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_records_msg ON records(message_id);")
+    conn.commit()
+
+
+def insert_record(conn: sqlite3.Connection, log_id: str, *, time: str, user_id: str,
+                  nickname: str, content: str, source: str, message_id: Optional[str]) -> None:
+    conn.execute(
+        "INSERT INTO records(log_id, time, user_id, nickname, content, source, message_id) VALUES (?,?,?,?,?,?,?)",
+        (log_id, time, user_id, nickname, content, source, message_id),
+    )
+
+
+def fetch_records(conn: sqlite3.Connection, log_id: str) -> List[Dict[str, Any]]:
+    cur = conn.execute(
+        "SELECT time, user_id, nickname, content, source, message_id FROM records WHERE log_id=? ORDER BY id ASC",
+        (log_id,),
+    )
+    return [dict(row) for row in cur.fetchall()]
+
+
+def delete_records_by_message_id(conn: sqlite3.Connection, log_id: str, message_id: str) -> int:
+    cur = conn.execute(
+        "DELETE FROM records WHERE log_id=? AND message_id=?",
+        (log_id, message_id),
+    )
+    return cur.rowcount or 0
+
+
+def delete_records_for_log(conn: sqlite3.Connection, log_id: str) -> None:
+    conn.execute("DELETE FROM records WHERE log_id=?", (log_id,))
+
+
+def delete_log(conn: sqlite3.Connection, log_id: str) -> None:
+    conn.execute("DELETE FROM logs WHERE id=?", (log_id,))
+
+
+def upsert_log(conn: sqlite3.Connection, payload: Dict[str, Any]) -> None:
+    # Upsert by primary key id
+    conn.execute(
+        """
+        INSERT INTO logs (
+            id, group_id, name, created_at, updated_at, recording, record_begin_at, last_warn,
+            filter_outside, filter_command, filter_bot, filter_media, filter_forum_code,
+            upload_time, upload_file, upload_note, url
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ON CONFLICT(id) DO UPDATE SET
+            group_id=excluded.group_id,
+            name=excluded.name,
+            created_at=excluded.created_at,
+            updated_at=excluded.updated_at,
+            recording=excluded.recording,
+            record_begin_at=excluded.record_begin_at,
+            last_warn=excluded.last_warn,
+            filter_outside=excluded.filter_outside,
+            filter_command=excluded.filter_command,
+            filter_bot=excluded.filter_bot,
+            filter_media=excluded.filter_media,
+            filter_forum_code=excluded.filter_forum_code,
+            upload_time=excluded.upload_time,
+            upload_file=excluded.upload_file,
+            upload_note=excluded.upload_note,
+            url=excluded.url
+        ;
+        """,
+        (
+            payload.get("id"), payload.get("group_id"), payload.get("name"), payload.get("created_at"),
+            payload.get("updated_at"), int(bool(payload.get("recording", 0))), payload.get("record_begin_at"),
+            payload.get("last_warn"), int(bool(payload.get("filter_outside", 0))), int(bool(payload.get("filter_command", 0))),
+            int(bool(payload.get("filter_bot", 0))), int(bool(payload.get("filter_media", 0))), int(bool(payload.get("filter_forum_code", 0))),
+            payload.get("upload_time"), payload.get("upload_file"), payload.get("upload_note"), payload.get("url"),
+        ),
+    )
+
+
+def get_logs_by_group(conn: sqlite3.Connection, group_id: str) -> List[Dict[str, Any]]:
+    cur = conn.execute("SELECT * FROM logs WHERE group_id=? ORDER BY created_at ASC", (group_id,))
+    return [dict(row) for row in cur.fetchall()]
+
+
+def get_log_by_id(conn: sqlite3.Connection, log_id: str) -> Optional[Dict[str, Any]]:
+    cur = conn.execute("SELECT * FROM logs WHERE id=?", (log_id,))
+    row = cur.fetchone()
+    return dict(row) if row else None
+
+
+def get_log_id_by_name(conn: sqlite3.Connection, group_id: str, name: str) -> Optional[str]:
+    cur = conn.execute("SELECT id FROM logs WHERE group_id=? AND LOWER(name)=LOWER(?)", (group_id, name))
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def set_recording(conn: sqlite3.Connection, log_id: str, recording: bool) -> None:
+    conn.execute("UPDATE logs SET recording=? WHERE id=?", (1 if recording else 0, log_id))
+
+
+def update_log_upload(conn: sqlite3.Connection, log_id: str, upload: Dict[str, Any]) -> None:
+    conn.execute(
+        "UPDATE logs SET upload_time=?, upload_file=?, upload_note=?, url=? WHERE id=?",
+        (upload.get("time"), upload.get("file"), upload.get("note"), upload.get("url"), log_id),
+    )
+

--- a/docs/beta_merge_reference/common/macro_command.py
+++ b/docs/beta_merge_reference/common/macro_command.py
@@ -1,0 +1,140 @@
+from typing import List, Tuple, Any, Optional
+
+from core.bot import Bot, BotMacro, MACRO_COMMAND_SPLIT
+from core.data import DataManagerError, DC_MACRO
+from core.command.const import *
+from core.command import UserCommandBase, custom_user_command
+from core.command import BotCommandBase, BotSendMsgCommand
+from core.communication import MessageMetaData, PrivateMessagePort, GroupMessagePort
+from core.config import CFG_COMMAND_SPLIT
+
+LOC_DEFINE_SUCCESS = "define_success"
+LOC_DEFINE_FAIL = "define_fail"
+LOC_DEFINE_LIST = "define_list"
+LOC_DEFINE_INFO = "define_info"
+LOC_DEFINE_DEL = "define_delete"
+
+CFG_DEFINE_LEN_MAX = "define_length_max"
+CFG_DEFINE_NUM_MAX = "define_number_max"
+
+
+@custom_user_command(readable_name="宏指令", priority=DPP_COMMAND_PRIORITY_DEFAULT,
+                     flag=DPP_COMMAND_FLAG_MACRO)
+class MacroCommand(UserCommandBase):
+    """
+    定义和查看宏指令, 关键字为define
+    """
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_DEFINE_SUCCESS, "Define {macro} as {target}, args are: {args}",
+                                         "成功定义宏, macro为宏, target为目标字符串, args为参数列表")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_FAIL, "Fail to define macro, reason is {error}",
+                                         "未成功定义宏, error为失败原因")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_LIST, "Macro list:\n{macro_list}",
+                                         f"查看当前宏列表, macro_list中的每一个元素由{LOC_DEFINE_INFO}定义")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_INFO, "Keywords: {macro} Args: {args} -> {target}",
+                                         f"宏列表中每一个元素的信息, macro为宏, args为参数列表, target为目标字符串")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_DEL, "Delete macro: {macro}",
+                                         f"删除宏, macro为宏关键字")
+
+        bot.cfg_helper.register_config(CFG_DEFINE_LEN_MAX, "300", "每个用户可以定义的宏的上限长度")
+        bot.cfg_helper.register_config(CFG_DEFINE_NUM_MAX, "50", "每个用户可以定义的宏上限数量")
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        should_proc: bool = msg_str.startswith(".define")
+        should_pass: bool = False
+        return should_proc, should_pass, msg_str[7:].strip()
+
+    def process_msg(self, msg_str: str, meta: MessageMetaData, hint: Any) -> List[BotCommandBase]:
+        port = GroupMessagePort(meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
+        # 解析语句
+        arg_str: str = hint
+        feedback: str = ""
+
+        macro_list: List[BotMacro]
+        try:
+            macro_list = self.bot.data_manager.get_data(DC_MACRO, [meta.user_id])
+        except DataManagerError:
+            macro_list = []
+
+        if not arg_str:
+            def format_macro_info(i, macro):
+                return f"{i + 1}. " + self.format_loc(LOC_DEFINE_INFO, macro=macro.key, args=macro.args, target=macro.target)
+            macro_list_str = "\n".join((format_macro_info(i, macro) for i, macro in enumerate(macro_list)))
+            feedback = self.format_loc(LOC_DEFINE_LIST, macro_list=macro_list_str)
+        elif arg_str.startswith("del"):
+            macro_key = arg_str[3:].strip()
+            if macro_key == "all":
+                self.bot.data_manager.delete_data(DC_MACRO, [meta.user_id])
+                feedback = self.format_loc(LOC_DEFINE_DEL, macro=str([macro.key for macro in macro_list]))
+            else:
+                del_index = -1
+                for i, macro in enumerate(macro_list):
+                    if macro.key == macro_key:
+                        del_index = i
+                        break
+                if del_index != -1:
+                    del macro_list[del_index]
+                    self.bot.data_manager.set_data(DC_MACRO, [meta.user_id], macro_list)
+                    feedback = self.format_loc(LOC_DEFINE_DEL, macro=macro_key)
+                else:
+                    feedback = self.format_loc(LOC_DEFINE_FAIL, error=f"找不到关键字为{macro_key}的宏")
+        else:  # 定义新宏
+            macro_new: Optional[BotMacro] = None
+            macro_len_limit = int(self.bot.cfg_helper.get_config(CFG_DEFINE_LEN_MAX)[0])
+            macro_num_limit = int(self.bot.cfg_helper.get_config(CFG_DEFINE_NUM_MAX)[0])
+            try:
+                assert len(arg_str) <= macro_len_limit
+                macro_new = BotMacro()
+                macro_new.initialize(arg_str, self.bot.cfg_helper.get_config(CFG_COMMAND_SPLIT)[0])
+            except ValueError as e:
+                feedback = self.format_loc(LOC_DEFINE_FAIL, error=e)
+            except AssertionError:
+                feedback = self.format_loc(LOC_DEFINE_FAIL, error=f"自定义宏长度超出上限: {macro_len_limit}字符")
+            if len(macro_list) >= macro_num_limit:
+                feedback = self.format_loc(LOC_DEFINE_FAIL, error=f"自定义宏数量超出上限: {macro_num_limit} 请先删除已有宏")
+                macro_new = None
+            if macro_new.key == "all":
+                feedback = self.format_loc(LOC_DEFINE_FAIL, error=f"宏关键字为保留字: {macro_new.key}")
+                macro_new = None
+
+            if macro_new:
+                # 先移除同名宏
+                for macro_prev in macro_list:
+                    if macro_prev.key == macro_new.key:
+                        macro_list.remove(macro_prev)
+                macro_list.append(macro_new)
+                self.bot.data_manager.set_data(DC_MACRO, [meta.user_id], macro_list)
+                feedback = self.format_loc(LOC_DEFINE_SUCCESS, macro=macro_new.key, args=macro_new.args, target=macro_new.target)
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword == "define":  # help后的接着的内容
+            feedback: str = "宏的定义方法:" \
+                            "\t[关键字][参数列表, 形如(参数1,参数2,...), 可选][空格][目标字符串]\n" \
+                            "\t目标字符串中与参数同名的字符串将在使用宏时被替换为给定的参数\n" \
+                            "\t在定义时给定参数就必须在使用时给出, 否则不会被认定为宏\n" \
+                            f"\t用{MACRO_COMMAND_SPLIT}来表示指令分隔符, {MACRO_COMMAND_SPLIT}左右的空格和换行将会被忽略\n" \
+                            "\t注意:\n" \
+                            "\t\t第一个空格的位置非常关键, 用来区分替换前的内容和替换后的内容\n" \
+                            "\t\t参数名字不要重名, 宏可以嵌套, 但不会处理递归(即不可重入), 先定义的宏会先处理\n" \
+                            "\t示例:\n" \
+                            "\t\t.define 一颗D20 .rd20\n" \
+                            f"\t\t.define 掷骰两次(表达式,原因) .r 表达式 原因 {MACRO_COMMAND_SPLIT} .r 表达式 原因\n" \
+                            "宏的使用方法:\n" \
+                            "\t[关键字][用:分隔给定参数]\n" \
+                            "\t输入: 一颗D20 这是一颗d20  ->  等同于:  .rd20 这是一颗d20\n" \
+                            "\t输入: 掷骰两次:d20+2:某种原因  -> 等同于: 执行指令.r d20+2 某种原因 + 执行指令.r d20+2 某种原因\n" \
+                            "查看当前定义的宏:\n" \
+                            "\t.define\n" \
+                            "删除某个已经定义的宏:\n" \
+                            "\t.define del [关键字]\n" \
+                            "删除所有宏:\n" \
+                            "\t.define del all"
+            return feedback
+        return ""
+
+    def get_description(self) -> str:
+        return ".define 定义指令宏"  # help指令中返回的内容

--- a/docs/beta_merge_reference/common/point_command.py
+++ b/docs/beta_merge_reference/common/point_command.py
@@ -1,0 +1,148 @@
+from typing import List, Tuple, Any, Optional, Literal
+
+from core.bot import Bot
+from core.data import DataChunkBase, custom_data_chunk, DataManagerError, DC_USER_DATA
+from core.command.const import *
+from core.command import UserCommandBase, custom_user_command
+from core.command import BotCommandBase, BotSendMsgCommand
+from core.communication import MessageMetaData, PrivateMessagePort, GroupMessagePort
+from core.config import CFG_MASTER
+
+
+LOC_POINT_SHOW = "point_show"
+LOC_POINT_LACK = "point_lack"
+LOC_POINT_CHECK = "point_check"
+LOC_POINT_EDIT = "point_edit"
+LOC_POINT_EDIT_ERROR = "point_edit_error"
+
+CFG_POINT_INIT = "point_init"
+CFG_POINT_ADD = "point_add"
+CFG_POINT_MAX = "point_max"
+CFG_POINT_LIMIT = "point_limit"
+
+DC_POINT = "point"
+DCK_POINT_CUR = "current"
+DCK_POINT_TODAY = "today"
+
+
+# 存放点数数据
+@custom_data_chunk(identifier=DC_POINT)
+class _(DataChunkBase):
+    def __init__(self):
+        super().__init__()
+
+
+@custom_user_command(readable_name="点数指令", priority=DPP_COMMAND_PRIORITY_DEFAULT,
+                     flag=DPP_COMMAND_FLAG_INFO)
+class PointCommand(UserCommandBase):
+    """
+    .point 和.m point指令
+    """
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_POINT_SHOW, "Point of {name}: {point}", "用户查看点数的回复")
+        bot.loc_helper.register_loc_text(LOC_POINT_LACK, "Cannot cost point: {reason}", "用户扣除点数失败的回复")
+        bot.loc_helper.register_loc_text(LOC_POINT_CHECK, "Point of {id}: {result}", "Master查看某人的点数")
+        bot.loc_helper.register_loc_text(LOC_POINT_EDIT, "Point: {result}", "Master调整某人的点数")
+        bot.loc_helper.register_loc_text(LOC_POINT_EDIT_ERROR, "Error when editing points: {error}", "Master调整某人的点数时出现错误")
+
+        bot.cfg_helper.register_config(CFG_POINT_INIT, "100", "新用户初始拥有的点数")
+        bot.cfg_helper.register_config(CFG_POINT_ADD, "100", "每天给活跃用户增加的点数")
+        bot.cfg_helper.register_config(CFG_POINT_MAX, "500", "用户能持有的点数上限")
+        bot.cfg_helper.register_config(CFG_POINT_LIMIT, "300", "每天使用点数的上限")
+
+    def tick_daily(self) -> List[BotCommandBase]:
+        # 根据用户当日是否掷骰决定是否增加点数(暂定)
+        from module.roll import DCP_USER_DATA_ROLL_A_UID, DCP_ROLL_TIME_A_ID_ROLL, DCK_ROLL_TODAY
+        point_init = int(self.bot.cfg_helper.get_config(CFG_POINT_INIT)[0])
+        point_add = int(self.bot.cfg_helper.get_config(CFG_POINT_ADD)[0])
+        point_max = int(self.bot.cfg_helper.get_config(CFG_POINT_MAX)[0])
+        user_ids = self.bot.data_manager.get_keys(DC_USER_DATA, [])
+        dcp_today_roll_total_a_uid = DCP_USER_DATA_ROLL_A_UID + DCP_ROLL_TIME_A_ID_ROLL + [DCK_ROLL_TODAY]
+        for user_id in user_ids:
+            try:
+                roll_time = self.bot.data_manager.get_data(DC_USER_DATA, [user_id] + dcp_today_roll_total_a_uid)
+                assert roll_time > 0
+            except (DataManagerError, AssertionError):
+                continue
+            prev_point = self.bot.data_manager.get_data(DC_POINT, [user_id, DCK_POINT_CUR], default_val=point_init)
+            # 若已经超过上限, 说明是Master手动调整的, 不进行修改, 否则增加point_add
+            cur_point = prev_point if prev_point > point_max else min(point_max, prev_point + point_add)
+            self.bot.data_manager.set_data(DC_POINT, [user_id, DCK_POINT_CUR], cur_point)
+            self.bot.data_manager.set_data(DC_POINT, [user_id, DCK_POINT_TODAY], 0)
+        return []
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        should_proc: bool = False
+        should_pass: bool = False
+        if msg_str.startswith(".point"):
+            return True, should_pass, ("show", None)
+        elif msg_str.startswith(".m"):
+            msg_str = msg_str[2:].lstrip()
+            master_list = self.bot.cfg_helper.get_config(CFG_MASTER)
+            if msg_str.startswith("point") and meta.user_id in master_list:
+                return True, should_pass, ("mod", msg_str[5:].strip())
+        return should_proc, should_pass, None
+
+    def process_msg(self, msg_str: str, meta: MessageMetaData, hint: Any) -> List[BotCommandBase]:
+        port = GroupMessagePort(meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
+        # 解析语句
+        cmd_type: Literal["show", "mod"] = hint[0]
+        msg_str: Optional[str] = hint[1]
+        feedback: str = ""
+        point_init = int(self.bot.cfg_helper.get_config(CFG_POINT_INIT)[0])
+        if cmd_type == "show":
+            cur_point = self.bot.data_manager.get_data(DC_POINT, [meta.user_id, DCK_POINT_CUR], default_val=point_init)
+            max_point = int(self.bot.cfg_helper.get_config(CFG_POINT_MAX)[0])
+            nickname = self.bot.get_nickname(meta.user_id, meta.group_id)
+            feedback = self.format_loc(LOC_POINT_SHOW, name=nickname, point=f"{cur_point}/{max_point}")
+        elif cmd_type == "mod":
+            if "=" in msg_str:
+                target_id, target_point = msg_str.split("=", 1)
+                try:
+                    target_point = int(target_point)
+                    nickname = self.bot.get_nickname(meta.user_id, target_id)
+                    prev_point = self.bot.data_manager.get_data(DC_POINT, [target_id, DCK_POINT_CUR], default_val=point_init)
+                    self.bot.data_manager.set_data(DC_POINT, [target_id, DCK_POINT_CUR], target_point)
+                    feedback = self.format_loc(LOC_POINT_EDIT, result=f"{target_id}({nickname}) {prev_point}->{target_point}")
+                except ValueError:
+                    feedback = self.format_loc(LOC_POINT_EDIT_ERROR, error=str(ValueError))
+            else:
+                target_id = msg_str
+                nickname = self.bot.get_nickname(meta.user_id, target_id)
+                prev_point = self.bot.data_manager.get_data(DC_POINT, [target_id, DCK_POINT_CUR], default_val=point_init)
+                feedback = self.format_loc(LOC_POINT_EDIT, result=f"{target_id}({nickname}): {prev_point}")
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword == "point":  # help后的接着的内容
+            feedback: str = "输入.point查看当前点数, 点数在使用消耗较大的指令时消耗"
+            master_list = self.bot.cfg_helper.get_config(CFG_MASTER)
+            if meta.user_id in master_list:
+                feedback += "\n.m point [目标账号] 查看对方点数" \
+                            "\n.m point [目标账号]=[目标数值] 将目标账号的点数设为指定数值"
+            return feedback
+        return ""
+
+    def get_description(self) -> str:
+        return ".point 查看当前点数"  # help指令中返回的内容
+
+
+def try_use_point(bot: Bot, user_id: str, point: int) -> str:
+    """尝试为user_id扣除点数, 点数不足返回失败原因, 扣除成功返回空字符串"""
+    point_init = int(bot.cfg_helper.get_config(CFG_POINT_INIT)[0])
+    point_limit = int(bot.cfg_helper.get_config(CFG_POINT_LIMIT)[0])
+
+    if point < 0:
+        return bot.loc_helper.format_loc_text(LOC_POINT_LACK, reason=f"{point} < 0")
+    prev_point = bot.data_manager.get_data(DC_POINT, [user_id, DCK_POINT_CUR], default_val=point_init)
+    today_point = bot.data_manager.get_data(DC_POINT, [user_id, DCK_POINT_TODAY], 0)
+    if prev_point < point:
+        return bot.loc_helper.format_loc_text(LOC_POINT_LACK, reason=f"当前:{prev_point} < {point}")
+    if today_point + point > point_limit:
+        return bot.loc_helper.format_loc_text(LOC_POINT_LACK, reason=f"今日已使用:{prev_point} + {point} > {point_limit}")
+    cur_point = prev_point - point
+    bot.data_manager.set_data(DC_POINT, [user_id, DCK_POINT_CUR], cur_point)
+    return ""

--- a/docs/beta_merge_reference/common/variable_command.py
+++ b/docs/beta_merge_reference/common/variable_command.py
@@ -1,0 +1,167 @@
+"""
+变量指令, 如.set
+"""
+
+import re
+from typing import Dict, List, Tuple, Any, Literal, Optional
+from core.bot import Bot, BotVariable
+from core.data import DataManagerError, DC_VARIABLE
+from core.command.const import *
+from core.command import UserCommandBase, custom_user_command
+from core.command import BotCommandBase, BotSendMsgCommand
+from core.communication import MessageMetaData, PrivateMessagePort, GroupMessagePort
+
+
+from module.roll import exec_roll_exp, RollDiceError
+
+LOC_VAR_SET = "var_set"
+LOC_VAR_GET = "var_get"
+LOC_VAR_GET_ALL = "var_get_all"
+LOC_VAR_DEL = "var_del"
+LOC_VAR_ERROR = "var_error"
+
+
+@custom_user_command(readable_name="变量指令", priority=0,  # priority要大于搜索, 否则set会被s覆盖
+                     flag=DPP_COMMAND_FLAG_MACRO, group_only=True)
+class VariableCommand(UserCommandBase):
+    """
+    用户自定义变量 包括.set .get .del
+    """
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_VAR_SET, "set variable {name} as {val}", "设置变量, name为变量名, val为数值")
+        bot.loc_helper.register_loc_text(LOC_VAR_GET, "{name} = {val}", "获取变量, name为变量名, val为数值")
+        bot.loc_helper.register_loc_text(LOC_VAR_GET_ALL, "All Variables:\n{info}", "获取所有变量, info为逐条变量信息")
+        bot.loc_helper.register_loc_text(LOC_VAR_DEL, "Delete variable: {name}", "删除所有变量, name为变量名")
+        bot.loc_helper.register_loc_text(LOC_VAR_ERROR, "Error when process var: {error}", "error为处理变量时发生的错误")
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        should_proc: bool = False
+        should_pass: bool = False
+        for cmd_type in ["set", "get", "del"]:
+            if msg_str.startswith(f".{cmd_type}"):
+                should_proc = True
+                return should_proc, should_pass, (cmd_type, msg_str[4:].strip())
+        return should_proc, should_pass, None
+
+    def process_msg(self, msg_str: str, meta: MessageMetaData, hint: Any) -> List[BotCommandBase]:
+        port = GroupMessagePort(meta.group_id) if meta.group_id else PrivateMessagePort(meta.user_id)
+        # 解析语句
+        cmd_type: Literal["set", "get", "del"]
+        arg_str: str
+        cmd_type, arg_str = hint
+        feedback: str
+
+        try:
+            cur_var_list = self.bot.data_manager.get_keys(DC_VARIABLE, [meta.user_id, meta.group_id])
+        except DataManagerError:
+            cur_var_list = []
+
+        if cmd_type == "set":
+            # 判断操作类型
+            set_type_list = ["=", "+", "-"]
+            set_type: Optional[Literal["=", "+", "-"]]
+            # 此处any为Literal["=", "+", "-"]
+            set_info_tmp: List[Tuple[any, int]] = [(s_type, arg_str.find(s_type)) for s_type in set_type_list if arg_str.find(s_type) != -1]
+            if not set_info_tmp:
+                feedback = self.format_loc(LOC_VAR_ERROR, error=f"至少包含{set_type_list}其中之一")
+                return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+            set_info_tmp.sort(key=lambda x: x[1])
+            set_type = set_info_tmp[0][0]
+            split_index = set_info_tmp[0][1]
+            var_name, var_val_str = arg_str[:split_index].strip(), arg_str[split_index+1:].strip()
+            # 验证变量名
+            try:
+                assert_valid_variable_name(var_name)
+            except ValueError as e:
+                feedback = self.format_loc(LOC_VAR_ERROR, error=f"{var_name}: {e.args}")
+                return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+            # 获取修改值
+            try:
+                var_val: int = int(var_val_str)
+            except ValueError:
+                try:
+                    var_val: int = exec_roll_exp(var_val_str).get_val()
+                except RollDiceError as e:   # ToDo 支持依赖其他变量
+                    feedback = self.format_loc(LOC_VAR_ERROR, error=f"{var_val_str}: {e.info}")
+                    return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+            if set_type == "=":
+                bot_var = BotVariable()
+                bot_var.initialize(var_name, var_val)
+                self.bot.data_manager.set_data(DC_VARIABLE, [meta.user_id, meta.group_id, var_name], bot_var)
+                feedback = self.format_loc(LOC_VAR_SET, name=var_name, val=var_val)
+            else:
+                if var_name not in cur_var_list:
+                    feedback = self.format_loc(LOC_VAR_ERROR, error=f"{var_name}不存在, 当前可用变量: {list(cur_var_list)}")
+                    return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+                bot_var: BotVariable = self.bot.data_manager.get_data(DC_VARIABLE, [meta.user_id, meta.group_id, var_name])
+                if set_type == "+":
+                    feedback = self.format_loc(LOC_VAR_SET, name=var_name, val=f"{bot_var.val}+{var_val}={bot_var.val+var_val}")
+                    bot_var.val = bot_var.val + var_val
+                else:  # set_type == "-"
+                    feedback = self.format_loc(LOC_VAR_SET, name=var_name, val=f"{bot_var.val}-{var_val}={bot_var.val-var_val}")
+                    bot_var.val = bot_var.val - var_val
+                self.bot.data_manager.set_data(DC_VARIABLE, [meta.user_id, meta.group_id, var_name], bot_var)
+        elif cmd_type == "get":
+            var_name = arg_str
+            if var_name:
+                if var_name not in cur_var_list:
+                    feedback = self.format_loc(LOC_VAR_ERROR, error=f"{var_name}不存在, 当前可用变量: {list(cur_var_list)}")
+                    return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+                bot_var: BotVariable = self.bot.data_manager.get_data(DC_VARIABLE, [meta.user_id, meta.group_id, var_name])
+                feedback = self.format_loc(LOC_VAR_GET, name=var_name, val=bot_var.val)
+            else:
+                bot_var_dict: Dict[str, BotVariable]
+                try:
+                    bot_var_dict = self.bot.data_manager.get_data(DC_VARIABLE, [meta.user_id, meta.group_id])
+                except DataManagerError:
+                    bot_var_dict = {}
+                if not bot_var_dict:
+                    info = "暂无任何变量"
+                else:
+                    var_info = [f"{var.name}={var.val}" for var in bot_var_dict.values()]
+                    info = "; ".join(var_info)
+                feedback = self.format_loc(LOC_VAR_GET_ALL, info=info)
+        else:  # cmd_type == "del"
+            var_name = arg_str
+            if not var_name:
+                feedback = self.format_loc(LOC_VAR_ERROR, error="请指定变量名")
+            elif var_name == "all":
+                self.bot.data_manager.delete_data(DC_VARIABLE, [meta.user_id, meta.group_id])
+                feedback = self.format_loc(LOC_VAR_DEL, name="; ".join(cur_var_list))
+            elif var_name not in cur_var_list:
+                feedback = self.format_loc(LOC_VAR_ERROR, error=f"{var_name}不存在, 当前可用变量: {list(cur_var_list)}")
+            else:
+                self.bot.data_manager.delete_data(DC_VARIABLE, [meta.user_id, meta.group_id, var_name])
+                feedback = self.format_loc(LOC_VAR_DEL, name=var_name)
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        feedback = ""
+        if keyword == "set":  # help后的接着的内容
+            feedback: str = ".set [变量名] [=/+/-] [数值或掷骰表达式]" \
+                            "\n通过=设置变量后可以对变量进行加减操作, 为每个群独立记录变量" \
+                            "\n变量名不能含有空格或换行" \
+                            "\n可以在语句中通过%变量名%来引用存在的变量"
+        elif keyword == "get":
+            feedback: str = ".get [变量名]" \
+                            "\n查看目标变量名, 不输入变量名则获取所有当前变量"
+        elif keyword == "del":
+            feedback: str = ".del [变量名]" \
+                            "\n删除目标变量名, 若目标变量名为\"all\"则删除所有变量"
+        return feedback
+
+    def get_description(self) -> str:
+        return ".set/get/del 记录和修改变量"  # help指令中返回的内容
+
+
+def assert_valid_variable_name(name: str):
+    if not name:
+        raise ValueError("变量名不能为空")
+    # 变量名中不能包含空格或换行
+    if re.search(r"\s", name):
+        raise ValueError("变量名中不能含有空格")
+    if name in ["all"]:
+        raise ValueError("变量名为保留字")

--- a/docs/beta_merge_reference/core_bot/macro.py
+++ b/docs/beta_merge_reference/core_bot/macro.py
@@ -1,0 +1,84 @@
+import json
+from typing import Dict, List
+import re
+
+from core.data import JsonObject, custom_json_object
+
+MACRO_COMMAND_SPLIT = "%%"
+MACRO_PARSE_LIMIT = 500  # 宏展开以后的长度限制
+
+
+@custom_json_object
+class BotMacro(JsonObject):
+    """
+    用户自定义的宏, 相当于字符串替换
+    宏的定义方法:
+        [关键字][参数列表, 形如(参数1,参数2,...), 可选][空格][目标字符串]
+        目标字符串中与参数同名的字符串将在使用宏时被替换为给定的参数
+        在定义时给定参数就必须在使用时给出, 否则不会被认定为宏
+        用{MACRO_COMMAND_SPLIT}来表示指令分隔符, {MACRO_COMMAND_SPLIT}左右的空格和换行将会被忽略
+        注意:
+            第一个空格的位置非常关键, 用来区分替换前的内容和替换后的内容
+            参数名字不要重名, 宏可以嵌套, 但不会处理递归(即不可重入), 先定义的宏会先处理
+        示例:
+        一颗D20 .rd20
+        掷骰两次(表达式,原因) .r 表达式 原因 {MACRO_COMMAND_SPLIT} .r 表达式 原因
+    宏的使用方法:
+        [关键字][用:分隔给定参数]
+        输入: 一颗D20 这是一颗d20  ->  等同于:  .rd20 这是一颗d20
+        输入: 掷骰两次:d20+2:某种原因  -> 等同于: 执行指令.r d20+2 某种原因 + 执行指令.r d20+2 某种原因
+    """
+    def serialize(self) -> str:
+        json_dict = {"raw": self.raw, "split": self.command_split}
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict = json.loads(json_str)
+        self.initialize(json_dict["raw"], json_dict["split"])
+
+    def __init__(self):
+        self.raw: str = ""  # 定义宏时的字符串
+        self.key: str = ""  # 宏的关键字
+        self.args: List[str] = []  # 宏的参数, 为空则不需要参数
+        self.target: str = ""  # 将宏关键字替换为的对象
+        self.command_split: str = ""
+        self.pattern: re.Pattern = re.compile("")
+
+    def initialize(self, raw: str, command_split: str):
+        self.raw = raw  # 定义宏时的字符串
+        self.command_split = command_split
+        # 解析定义字符串
+        if self.raw.find(" ") == -1:
+            raise ValueError("宏定义中缺少空格")
+        key_args, target = self.raw.split(" ", 1)
+        key_args: str = key_args.strip()
+        target: str = target.strip()
+        if key_args.endswith(")"):
+            par_index = key_args.find("(")
+            if par_index == -1:
+                raise ValueError("参数列表缺少左括号!")
+            self.key, self.args = key_args[:par_index], key_args[par_index+1:-1].split(",")
+        else:
+            self.key, self.args = key_args, []
+
+        for arg in self.args:
+            target = target.replace(arg, "{"+arg+"}")
+        target = target.replace(MACRO_COMMAND_SPLIT, self.command_split)
+        re_pattern = ":".join([self.key] + ["(.*)"]*len(self.args))
+        self.pattern = re.compile(re_pattern)
+        self.target = target
+
+    def process(self, input_str: str):
+        def handle_macro(match):
+            res = self.target
+            if self.args:
+                kwargs: Dict[str, str] = {}
+                for i in range(len(self.args)):
+                    kwargs[self.args[i]] = match.group(i+1)
+                res = res.format(**kwargs)
+            return res
+
+        return self.pattern.sub(handle_macro, input_str)
+
+    def __repr__(self):
+        return f"Macro({self.key}, Args:{self.args} -> {self.target})"

--- a/docs/beta_merge_reference/core_bot/variable.py
+++ b/docs/beta_merge_reference/core_bot/variable.py
@@ -1,0 +1,44 @@
+import json
+from typing import Union
+import re
+
+from core.data import JsonObject, custom_json_object
+
+VAR_DEP_PATTERN: re.Pattern = re.compile(r"%(.+)%")
+
+
+@custom_json_object
+class BotVariable(JsonObject):
+    """
+    用户自定义的变量, 代表一个数字, 可以依赖其他变量
+    """
+    def serialize(self) -> str:
+        json_dict = {"name": self.name, "val": self.val}
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict = json.loads(json_str)
+        self.initialize(json_dict["name"], json_dict["val"])
+
+    def __init__(self):
+        self.name = "VAR"
+        self.val: Union[int, str] = 0
+        self.dep = []
+        self.is_num: bool = True
+
+    def initialize(self, name: str, val: Union[int, str]):
+        self.name = name
+        self.val = val
+        if isinstance(val, int):
+            return
+        # 是字符串, 要依赖其他变量
+        assert isinstance(val, str)
+        self.is_num = False
+
+        def handle_dep(match):
+            self.dep.append(match.group(1))
+            return match.group(0)
+        self.val = VAR_DEP_PATTERN.sub(handle_dep, val)
+
+    def __repr__(self):
+        return f"Var({self.name} = {self.val})"

--- a/docs/beta_merge_reference/dice_hub/data.py
+++ b/docs/beta_merge_reference/dice_hub/data.py
@@ -1,0 +1,60 @@
+from typing import Dict, Any, List
+import json
+import datetime
+
+from core.data import custom_data_chunk, DataChunkBase, custom_json_object, JsonObject
+from utils.time import get_current_date_str, get_current_date_raw, datetime_to_str
+
+DC_HUB = "dicehub"
+DCK_HUB_FRIEND = "friend"
+
+
+@custom_data_chunk(identifier=DC_HUB, include_json_object=True)
+class _(DataChunkBase):
+    def __init__(self):
+        super().__init__()
+
+
+@custom_json_object
+class HubFriendInfo(JsonObject):
+    """
+    好友机器人信息
+    """
+
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                self.__setattr__(key, value)
+
+    def __init__(self):
+        self.id: str = ""  # 账号
+        self.name: str = ""  # 昵称
+        self.master: str = ""  # master账号
+        self.version: str = ""  # 当前DicePP版本号
+        self.distance: int = 0  # 与自身需要几次转发才能达到
+
+        self.init_time: str = ""  # 初始化时间
+        self.update_time: str = ""  # 最近一次更新对方信息的时间
+        self.sync_time: str = ""  # 上一次向对方同步自己信息的时间, 若distance不为0, 则该值无作用
+        self.sync_fail_times: int = 0
+
+        self.sync_info: Dict[str, Any] = {}  # 同步信息
+
+    def initialize(self, id_str: str, name_str: str, master_id: str, version: str, distance: int = 0):
+        self.id = id_str
+        self.name = name_str
+        self.master = master_id
+        self.version = version
+        self.distance = distance
+
+        self.init_time = get_current_date_str()
+        self.update_time = self.init_time
+        self.sync_time = datetime_to_str(get_current_date_raw() - datetime.timedelta(days=1))
+        self.sync_fail_times = 0
+
+        self.sync_info = {}

--- a/docs/beta_merge_reference/dice_hub/encrypt.py
+++ b/docs/beta_merge_reference/dice_hub/encrypt.py
@@ -1,0 +1,116 @@
+import os
+from typing import Tuple
+import rsa
+import base64
+import zlib
+
+RSA_LEN = 1024
+ENCRYPT_SEG_LEN = RSA_LEN // 8
+CONTENT_SEG_LEN = ENCRYPT_SEG_LEN - 11
+
+HEADER_LEN = 1
+MAX_TEXT_LEN = 2 ** (8 * HEADER_LEN) * CONTENT_SEG_LEN - 1
+
+BYTE_TO_INT_RULE = {"byteorder": "big", "signed": False}
+INT_TO_BYTE_RULE = {"length": HEADER_LEN, **BYTE_TO_INT_RULE}
+
+ENCODE_STYLE = "utf-8"
+
+
+def encrypt_rsa(text: str, public_key: rsa.PublicKey) -> str:
+    byte_data = text.encode(ENCODE_STYLE)
+    byte_data = zlib.compress(byte_data)
+    assert len(byte_data) < MAX_TEXT_LEN
+    seg_num = len(byte_data) // CONTENT_SEG_LEN + 1
+    header = (seg_num - 1).to_bytes(**INT_TO_BYTE_RULE)
+    result = header
+    for seg_index in range(seg_num):
+        seg_data = byte_data[seg_index * CONTENT_SEG_LEN:(seg_index + 1) * CONTENT_SEG_LEN]
+        result += rsa.encrypt(seg_data, public_key)
+    result = base64.b64encode(result)
+    return result.decode(ENCODE_STYLE)
+
+
+def decrypt_rsa(rsa_str: str, private_key: rsa.PrivateKey) -> str:
+    decode_data = rsa_str.encode(ENCODE_STYLE)
+    decode_data = base64.b64decode(decode_data)
+    header, decode_data = decode_data[:HEADER_LEN], decode_data[HEADER_LEN:]
+    seg_num = int.from_bytes(header, **BYTE_TO_INT_RULE) + 1
+    result = b""
+    for seg_index in range(seg_num):
+        seg_data = decode_data[seg_index * ENCRYPT_SEG_LEN:(seg_index + 1) * ENCRYPT_SEG_LEN]
+        try:
+            result += rsa.decrypt(seg_data, private_key)
+        except rsa.pkcs1.DecryptionError:
+            raise ValueError("RSA Fail")
+    try:
+        result = zlib.decompress(result)
+    except zlib.error:
+        raise ValueError("Z-lib Error")
+    return result.decode(ENCODE_STYLE)
+
+
+def create_rsa_key(name: str, path: str) -> Tuple[rsa.PublicKey, rsa.PrivateKey]:
+    public_key, private_key = rsa.newkeys(RSA_LEN)
+    try:
+        save_rsa_public_key(public_key, name, path)
+        save_rsa_private_key(private_key, name, path)
+    except PermissionError as e:
+        raise e
+    return public_key, private_key
+
+
+def save_rsa_public_key(public_key: rsa.PublicKey, name: str, path: str) -> str:
+    public_path = os.path.join(path, name) + ".pub"
+    try:
+        with open(public_path, "w") as f:
+            f.write(save_rsa_public_key_as_str(public_key))
+    except PermissionError as e:
+        raise e
+    return public_path
+
+
+def save_rsa_private_key(private_key: rsa.PrivateKey, name: str, path: str) -> str:
+    private_path = os.path.join(path, name)
+    try:
+        with open(private_path, "w") as f:
+            f.write(save_rsa_private_key_as_str(private_key))
+    except PermissionError as e:
+        raise e
+    return private_path
+
+
+def load_rsa_public_key(name: str, path: str) -> rsa.PublicKey:
+    public_path = os.path.join(path, name) + ".pub"
+    try:
+        with open(public_path, "r") as f:
+            key_str = f.read()
+    except FileNotFoundError:
+        raise ValueError()
+    return load_rsa_public_key_from_str(key_str)
+
+
+def load_rsa_private_key(name: str, path: str) -> rsa.PrivateKey:
+    private_path = os.path.join(path, name)
+    try:
+        with open(private_path, "r") as f:
+            key_str = f.read()
+    except FileNotFoundError:
+        raise ValueError()
+    return load_rsa_private_key_from_str(key_str)
+
+
+def load_rsa_public_key_from_str(key_str: str) -> rsa.PublicKey:
+    return rsa.PublicKey.load_pkcs1(key_str.encode(ENCODE_STYLE))
+
+
+def load_rsa_private_key_from_str(key_str: str) -> rsa.PrivateKey:
+    return rsa.PrivateKey.load_pkcs1(key_str.encode(ENCODE_STYLE))
+
+
+def save_rsa_public_key_as_str(public_key: rsa.PublicKey) -> str:
+    return public_key.save_pkcs1().decode(ENCODE_STYLE)
+
+
+def save_rsa_private_key_as_str(private_key: rsa.PrivateKey) -> str:
+    return private_key.save_pkcs1().decode(ENCODE_STYLE)

--- a/docs/beta_merge_reference/initiative/initiative_entity.py
+++ b/docs/beta_merge_reference/initiative/initiative_entity.py
@@ -1,0 +1,28 @@
+import json
+
+from core.data import JsonObject, custom_json_object
+
+
+@custom_json_object
+class InitEntity(JsonObject):
+    def serialize(self) -> str:
+        json_dict = self.__dict__
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                self.__setattr__(key, value)
+
+    def __init__(self):
+        self.name: str = ""  # 先攻条目名称
+        self.owner: str = ""  # 拥有者id, 为空代表是npc
+        self.init: int = 0  # 先攻数值
+
+    def get_info(self) -> str:
+        info = f"{self.name} 先攻:{self.init}"
+        return info
+
+    def __repr__(self):
+        return f"InitEntity({self.name},{self.init},{self.owner if self.owner else None})"

--- a/docs/beta_merge_reference/initiative/initiative_list.py
+++ b/docs/beta_merge_reference/initiative/initiative_list.py
@@ -1,0 +1,158 @@
+from typing import Dict, List
+import json
+
+from core.data import custom_data_chunk, DataChunkBase
+from core.data import JsonObject, custom_json_object
+from utils.time import get_current_date_str
+
+from module.initiative.initiative_entity import InitEntity
+
+DC_INIT = "initiative"
+
+INIT_LIST_SIZE = 30  # 一个先攻列表的容量
+
+
+@custom_data_chunk(identifier=DC_INIT, include_json_object=True)
+class _(DataChunkBase):
+    def __init__(self):
+        super().__init__()
+        self.version: int = 0
+
+    def introspect(self) -> None:
+        if self.version == 0:
+            self.root = {}  # 无效所有数据
+        self.version = 1
+
+
+@custom_json_object
+class InitList(JsonObject):
+    def serialize(self) -> str:
+        json_dict = dict(self.__dict__)
+        assert "entities" in json_dict.keys()
+        for key in json_dict.keys():
+            value = json_dict[key]
+            if key == "entities":
+                json_dict[key] = [entity.serialize() for entity in self.entities]
+            if isinstance(value, JsonObject):
+                json_dict[key] = value.serialize()
+        return json.dumps(json_dict)
+
+    def deserialize(self, json_str: str) -> None:
+        json_dict: dict = json.loads(json_str)
+        assert "entities" in json_dict.keys()
+        for key, value in json_dict.items():
+            if key in self.__dict__:
+                value_init = self.__getattribute__(key)
+                if key == "entities":
+                    # value may be a list of serialized InitEntity strings, or
+                    # legacy dicts/strings. Handle all cases defensively.
+                    self.entities = []
+                    for entity_item in value:
+                        entity = InitEntity()
+                        try:
+                            # If stored as a JSON string representing the object
+                            if isinstance(entity_item, str):
+                                # try to parse as serialized InitEntity
+                                try:
+                                    entity.deserialize(entity_item)
+                                except Exception:
+                                    # fallback: treat as plain name
+                                    entity.name = entity_item
+                            elif isinstance(entity_item, dict):
+                                # older format: dict of attributes
+                                for k, v in entity_item.items():
+                                    try:
+                                        setattr(entity, k, v)
+                                    except Exception:
+                                        pass
+                            else:
+                                # other types: coerce to string name
+                                entity.name = str(entity_item)
+                        except Exception:
+                            # ensure we still append a usable entity
+                            try:
+                                entity.name = str(entity_item)
+                            except Exception:
+                                entity.name = ""
+                        self.entities.append(entity)
+                elif isinstance(value_init, JsonObject):
+                    value_init.deserialize(value)
+                else:
+                    self.__setattr__(key, value)
+
+    def __init__(self):
+        self.entities: List[InitEntity] = []
+        self.mod_time = get_current_date_str()
+        self.round = 1
+        self.turn = 1
+        self.turns_in_round = 1
+        self.first_turn = True
+
+    def __repr__(self):
+        return f"InitList({self.entities}, {self.mod_time})"
+
+    def add_entity(self, entity_name: str, owner_id: str, init: int) -> None:
+        """
+        创造一个先攻条目并加入到先攻列表中.
+        Args:
+            entity_name: 条目名称
+            owner_id: 为空代表无主的NPC, 不为空代表PC
+            init: 生成先攻所需的完整掷骰表达式
+        """
+        # 检查有没有同名条目, 有则删掉旧的
+        replace_same_name = sum([entity.name == entity_name for entity in self.entities])
+        if replace_same_name:
+            self.del_entity(entity_name)
+
+        if len(self.entities) >= INIT_LIST_SIZE:
+            raise InitiativeError(f"先攻列表大小超出限制, 至多存在{INIT_LIST_SIZE}个条目")
+
+        entity: InitEntity = InitEntity()
+        entity.name = entity_name
+        entity.owner = owner_id
+        entity.init = init
+        self.entities.append(entity)
+        self.entities = sorted(self.entities, key=lambda x: -x.init)
+        self.turns_in_round = len(self.entities)
+        # 重排顺序
+        if not self.first_turn:
+            for index, entity in enumerate(self.entities):
+                if entity.name == entity_name and self.turn >= index+1: # 添加者在当前回合之前行动，回合数+1（不可能出现因此轮数更替情况）
+                    self.turn += 1
+        # 更新时间
+        self.mod_time = get_current_date_str()
+
+    def del_entity(self, entity_name: str) -> None:
+        """
+        将一个先攻条目根据名称从列表中删除, 如果没有这样的条目或是存在多个同名条目则抛出异常
+        Args:
+            entity_name: 条目名称
+        """
+        # 检查同名条目
+        all_index = [index for index, entity in enumerate(self.entities) if entity.name == entity_name]
+        if len(all_index) == 0:
+            raise InitiativeError(f"先攻列表中不存在名称为{entity_name}的条目")
+        if len(all_index) > 1:
+            raise InitiativeError(f"先攻列表中存在多个名称为{entity_name}的条目")
+        del self.entities[all_index[0]]
+        self.turns_in_round = len(self.entities)
+        # 重排顺序
+        if not self.first_turn: # 首回合意味着没使用过ed
+            if self.turn > self.turns_in_round: # 删除后，当前超出了上限
+                self.turn -= self.turns_in_round
+                self.round += 1
+            elif self.turn > all_index[0]+1: # 删除者在当前回合之前行动，回合数-1（不可能出现当前回合1还删除比1小的情况）
+                self.turn -= 1
+        # 更新时间
+        self.mod_time = get_current_date_str()
+
+
+class InitiativeError(Exception):
+    """
+    Initiative模块产生的异常, 说明操作失败的原因, 应当在Command内捕获
+    """
+    def __init__(self, info: str):
+        self.info = info
+
+    def __str__(self):
+        return f"[Initiative] [Error] {self.info}"

--- a/docs/beta_merge_reference/query/query_database.py
+++ b/docs/beta_merge_reference/query/query_database.py
@@ -1,0 +1,246 @@
+from typing import List, Dict, Any
+import os
+import json
+import re
+import openpyxl
+import sqlite3
+from openpyxl.comments import Comment
+
+from core.data import custom_data_chunk, DataChunkBase
+from core.data import JsonObject, custom_json_object
+from utils.time import get_current_date_str
+
+from utils.localdata import read_xlsx, update_xlsx, col_based_workbook_to_dict, create_parent_dir, get_empty_col_based_workbook
+#from module.query import QUERY_DATA_FIELD, QUERY_DATA_FIELD_LIST, QUERY_REDIRECT_FIELD, QUERY_REDIRECT_FIELD_LIST
+
+#QIF = QUERY_ITEM_FIELD 太长了还是缩写的好。
+#数据库常规六件套
+QIF_NAME = "Name"  # 名称（无需唯一）
+QIF_NAME_EN = "NameEN"  # 英文名称
+QIF_FROM = "From"  # 来源
+QIF_CATALOGUE = "Catalogue"  # 分类
+QIF_TAG = "Tag"  # 标签列表
+QIF_CONTENT = "Content"  # 查询内容
+#旧版限定
+QIF_KEY = "Key"  # 唯一关键字
+QIF_SYNONYM = "Synonym"  # 同义词
+QIF_DESCRIPTION = "Description"  # 简述
+
+# 老式梨骰查询表的格式
+QIF_OLD = [QIF_KEY, QIF_SYNONYM, QIF_CONTENT, QIF_DESCRIPTION, QIF_CATALOGUE, QIF_TAG]
+# 新式梨骰查询表的格式
+QIF = [QIF_NAME, QIF_NAME_EN, QIF_FROM, QIF_CATALOGUE, QIF_TAG, QIF_CONTENT]
+# 新式梨骰私设表的格式
+QIF_HB = [QIF_NAME, QIF_NAME_EN, QIF_CATALOGUE, QIF_TAG, QIF_CONTENT]
+
+QUERY_DATA_FIELD = "名称,英文,来源,分类,标签,内容"
+QUERY_DATA_FIELD_LIST = ["名称","英文","来源","分类","标签","内容"]
+QUERY_REDIRECT_FIELD = "名称,重定向"
+QUERY_REDIRECT_FIELD_LIST = ["名称","重定向"]
+
+# 已连接的数据库DICT
+CONNECTED_QUERY_DATABASES: Dict[str, sqlite3.Connection] = {}
+DATABASE_CURSOR: Dict[str, sqlite3.Cursor] = {}
+
+
+def _apply_low_memory_pragmas(conn: sqlite3.Connection) -> None:
+    """Tune sqlite runtime memory footprint for low-memory servers."""
+    try:
+        cache_kb = int(os.getenv("DPP_SQLITE_CACHE_KB", "1024").strip() or "1024")
+    except Exception:
+        cache_kb = 1024
+    if cache_kb <= 0:
+        cache_kb = 1024
+
+    try:
+        mmap_mb = int(os.getenv("DPP_SQLITE_MMAP_MB", "0").strip() or "0")
+    except Exception:
+        mmap_mb = 0
+    if mmap_mb < 0:
+        mmap_mb = 0
+
+    try:
+        # Negative cache_size uses KiB units.
+        conn.execute(f"PRAGMA cache_size=-{cache_kb}")
+        conn.execute(f"PRAGMA mmap_size={mmap_mb * 1024 * 1024}")
+        conn.execute("PRAGMA temp_store=FILE")
+    except Exception:
+        pass
+
+def create_empty_sqlite_database(path: str):
+    """创建空白查询数据库"""
+    try:
+        db = sqlite3.connect(path)
+        cur = db.cursor()
+        cur.execute(
+            "CREATE TABLE data (" + ",".join([(field + " TEXT DEFAULT ('')") for field in QUERY_DATA_FIELD_LIST]) + ");")
+        cur.execute("CREATE INDEX [From] ON data (来源 ASC);")
+        cur.execute("CREATE INDEX Catalogue ON data (分类);")
+        cur.execute(
+            "CREATE TABLE redirect (" + ",".join([(field + " TEXT DEFAULT ('')") for field in QUERY_REDIRECT_FIELD_LIST]) + ");")
+        db.close()
+    except PermissionError:
+        return False
+    return True
+
+def create_query_database(path: str) -> str:
+    """创建一个新的查询数据库"""
+    create_parent_dir(path)  # 若父文件夹不存在需先创建父文件夹
+    db = os.path.basename(path)[:-3]
+    if create_empty_sqlite_database(path):
+        CONNECTED_QUERY_DATABASES[db] = sqlite3.connect(path)
+        _apply_low_memory_pragmas(CONNECTED_QUERY_DATABASES[db])
+        return f"已创建{path}"
+    else:
+        return f"创建{path}时遇到错误: 权限不足"
+
+def connect_query_database(path: str) -> str:
+    """连接查询数据库"""
+    error_info: List[str] = []
+    if path.endswith(".db"):
+        if os.path.exists(path):  # 存在数据库则尝试连接数据库
+            db = os.path.basename(path)[:-3]
+            if db not in CONNECTED_QUERY_DATABASES.keys():
+                try:
+                    CONNECTED_QUERY_DATABASES[db] = sqlite3.connect(path)
+                    _apply_low_memory_pragmas(CONNECTED_QUERY_DATABASES[db])
+                    DATABASE_CURSOR[db] = CONNECTED_QUERY_DATABASES[db].cursor()
+                    CONNECTED_QUERY_DATABASES[db].row_factory = sqlite3.Row
+                    CONNECTED_QUERY_DATABASES[db].create_function('regexp', 2, regexp)
+                except PermissionError:
+                    error_info.append(f"读取{path}时遇到错误: 权限不足")
+                    return
+            else:  # 已加载
+                error_info.append(f"已加载过该数据库。")
+        else:  # 创建一个模板文件
+            error_info.append(create_query_database(path))
+    elif path.endswith(".db-journal"): #跳过他，无需处理
+        return "\n".join(error_info)
+    elif path:  # 是文件夹
+        if os.path.exists(path):  # 遍历文件夹下所有文件
+            try:
+                inner_paths = os.listdir(path)
+                for inner_path in inner_paths:
+                    inner_path = os.path.join(path, inner_path)
+                    error_info.append(connect_query_database(inner_path))
+            except FileNotFoundError as e:  # 文件夹不存在
+                error_info.append(f"读取{path}时遇到错误: {e}")
+        else:  # 创建空文件夹
+            create_parent_dir(path)
+    return "\n".join(error_info)
+    
+def disconnect_query_database(db: str) -> None:
+    """取消连接查询数据库"""
+    CONNECTED_QUERY_DATABASES[db].close()
+    del CONNECTED_QUERY_DATABASES[db]
+    del DATABASE_CURSOR[db]
+
+def regexp(pattern: str, input: str):
+    """SQL用的正则表达式公式函数"""
+    p = re.compile(str(pattern),re.I)
+    return bool(re.search(p, input))
+        
+def regexp_normalize(string: str) -> str:
+    """用于将正则表达式的任何公式文本改为原义"""
+    new_string: str = ""
+    for char in string:
+        if char in "$()*+.[?\\^{|":
+            new_string += "\\" + char
+        else:
+            new_string += char
+    return new_string
+
+def load_data_from_xlsx(wb: openpyxl.Workbook, sql_cur: Any,xlsx_name: str, xlsx_mode: int = 0) -> bool:
+    """将数据从xlsx中读取出来"""
+    def try_load_data(data: str,default_var: str = "") -> str:
+        return str(data).strip() if data else default_var
+    
+    data_dict: dict
+    if xlsx_mode == 0:
+        data_dict = col_based_workbook_to_dict(wb, QIF_OLD, [])
+    elif xlsx_mode == 1:
+        data_dict = col_based_workbook_to_dict(wb, QIF, [])
+    elif xlsx_mode == 2:
+        sql_cur.execute("DELETE FROM data WHERE 来源 LIKE '私设:" + xlsx_name.replace("'","''") + "'")
+        data_dict = col_based_workbook_to_dict(wb, QIF_HB, [])
+    edit_cmd_data = []
+    edit_cmd_redirect = []
+    
+    if len(data_dict.keys()) == 0:
+        return False
+    
+    for sheet_name in data_dict.keys():
+        # 逐行生成查询条目的新增指令
+        sheet_data = data_dict[sheet_name]
+        if xlsx_mode == 0:  #老式梨骰查询表
+            item_num = len(sheet_data[QIF_KEY])
+            for item_index in range(item_num):
+                # 获取信息
+                item = [try_load_data(sheet_data[QIF_OLD[sub_index]][item_index]) for sub_index in range(6)]
+                
+                if len(item[0]) == 0:
+                    continue
+                en_name = ""
+                content_lines = (item[2].strip()).splitlines()
+                if len(content_lines) > 1:
+                    for char in content_lines[0]:
+                        if ord(char) < 128:
+                            en_name += char
+                    en_name = en_name.strip()
+                    if len(en_name) == 0:
+                        for char in content_lines[1]:
+                            if ord(char) < 128:
+                                en_name += char
+                        item[3] = "\n".join(content_lines[2:])
+                    else:
+                        item[3] = "\n".join(content_lines[1:])
+                tags = ((item[5].strip()).replace(" ","")).split()
+                for index in range(len(tags)):
+                    if tags[index].startswith("#"):
+                        tags[index] = tags[index][1:]
+                catas = item[4].split("/")
+                book = "未知"
+                if len(catas) > 1:
+                    book = catas[0]
+                    item[4] = catas[1]
+                    tags += catas[1:]
+                elif len(catas) == 1:
+                    book = catas[0]
+                    item[4] = ""
+                edit_cmd_data.append((item[0],en_name,book,item[4]," ".join(tags),item[3]))
+                syns = item[1].split("/")
+                for syn in syns:
+                    edit_cmd_redirect.append((syn,item[0]))
+        elif xlsx_mode == 1:  #新式梨骰查询表
+            item_num = len(sheet_data[QIF_NAME])
+            for item_index in range(item_num):
+                # 获取信息
+                item = [try_load_data(sheet_data[QIF[sub_index]][item_index]) for sub_index in range(6)]
+                if len(item[0]) == 0:
+                    continue
+                edit_cmd_data.append((item[0],item[1],item[2],item[3],item[4],item[5]))
+        elif xlsx_mode == 2:  #新式梨骰私设表
+            item_num = len(sheet_data[QIF_NAME])
+            for item_index in range(item_num):
+                # 获取信息
+                item = [try_load_data(sheet_data[QIF_HB[sub_index]][item_index]) for sub_index in range(5)]
+                if len(item[0]) == 0:
+                    continue
+                edit_cmd_data.append((item[0],item[1],"私设:"+xlsx_name,item[2],item[3],item[4]))
+    if len(edit_cmd_data) == 0:
+        return False
+    sql_cur.executemany('INSERT INTO data VALUES(?,?,?,?,?,?)',edit_cmd_data)
+    sql_cur.executemany('INSERT INTO redirect VALUES(?,?)',edit_cmd_redirect)
+    return True
+
+def load_data_from_xlsx_to_sqlite(xlsx_path: str, database_path: str, xlsx_mode: int) -> bool:
+    """将数据从xlsx中读取出来，存入查询数据库"""
+    connect_query_database(database_path)
+    db = os.path.basename(database_path)[:-3]
+    wb = read_xlsx(xlsx_path)
+    xlsx_name = os.path.basename(xlsx_path)[:-5]
+    load = False
+    if wb:
+        load = load_data_from_xlsx(wb,DATABASE_CURSOR[db],xlsx_name,xlsx_mode)
+        CONNECTED_QUERY_DATABASES[db].commit()
+    return load

--- a/docs/beta_merge_reference/utils/bot_presence.py
+++ b/docs/beta_merge_reference/utils/bot_presence.py
@@ -1,0 +1,89 @@
+import json
+import os
+import threading
+import time
+from typing import Any, Dict
+
+from core.config import DATA_PATH
+
+
+_ADMIN_DIR = os.path.join(DATA_PATH, "Admin")
+_STATUS_FILE = os.path.join(_ADMIN_DIR, "bot_presence.json")
+_LOCK = threading.Lock()
+
+
+def _ensure_admin_dir() -> None:
+    if not os.path.isdir(_ADMIN_DIR):
+        os.makedirs(_ADMIN_DIR, exist_ok=True)
+
+
+def _read_all_unlocked() -> Dict[str, Any]:
+    if not os.path.exists(_STATUS_FILE):
+        return {"bots": {}}
+    try:
+        with open(_STATUS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return {"bots": {}}
+    if not isinstance(data, dict):
+        return {"bots": {}}
+    bots = data.get("bots")
+    if not isinstance(bots, dict):
+        data["bots"] = {}
+    return data
+
+
+def _write_all_unlocked(data: Dict[str, Any]) -> None:
+    _ensure_admin_dir()
+    tmp = _STATUS_FILE + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, _STATUS_FILE)
+
+
+def update_presence(
+    account: str,
+    *,
+    state: str,
+    nickname: str = "",
+    reason: str = "",
+) -> Dict[str, Any]:
+    now = int(time.time())
+    aid = str(account or "").strip()
+    if not aid:
+        return {}
+
+    with _LOCK:
+        data = _read_all_unlocked()
+        bots = data.setdefault("bots", {})
+        item = bots.get(aid)
+        if not isinstance(item, dict):
+            item = {}
+        if nickname:
+            item["nickname"] = str(nickname)
+        item["account"] = aid
+        item["state"] = state
+        item["reason"] = reason
+        item["heartbeat_ts"] = now
+        item["updated_at"] = now
+        bots[aid] = item
+        data["updated_at"] = now
+        _write_all_unlocked(data)
+        return item
+
+
+def heartbeat(account: str, nickname: str = "") -> Dict[str, Any]:
+    return update_presence(account, state="online", nickname=nickname, reason="heartbeat")
+
+
+def mark_online(account: str, nickname: str = "") -> Dict[str, Any]:
+    return update_presence(account, state="online", nickname=nickname, reason="connect")
+
+
+def mark_offline(account: str, reason: str = "disconnect") -> Dict[str, Any]:
+    return update_presence(account, state="offline", reason=reason)
+
+
+def get_presence_snapshot() -> Dict[str, Any]:
+    with _LOCK:
+        return _read_all_unlocked()


### PR DESCRIPTION
## 概述

把作者 β 分支的独有源码作为**只读快照**归档到 `docs/beta_merge_reference/`，并在 `docs/beta_merge_guide.md` 写下每个模块的移植决策（已移植 / 已拒绝 / 待评估）。

这个 PR **不引入任何运行时行为变更**，纯文档/参考材料。

## 归档内容（27 文件）

```
docs/beta_merge_reference/
├── character_coc/        β 的 COC 模块（实际是 dnd5e 复制品，见拒绝说明）
├── character_dnd5e_split/ β 把 dnd5e 拆细分文件的版本
├── common/               β 独有的 macro/variable/point/log_db
├── core_bot/             β 的 macro+variable 数据结构
├── dice_hub/             β 的 data+encrypt
├── initiative/           β 的 initiative_entity+list 抽象
├── query/                β 的 query_database
└── utils/                β 的 bot_presence
```

## 拒绝合并的原因（写在指南里）

| 模块 | 决策 |
|---|---|
| `character/coc/` | 拒绝 — 实际是 dnd5e 的复制粘贴（字段、技能、检定逻辑全相同），未实现 COC7。α DND5E 已覆盖 |
| `log_db` | 不合并 — α 已有 LogRepository |
| `bot_presence` | 不合并 — admin WebUI 已用实例运行状态覆盖 |
| `initiative` 拆分 | 不合并 — α 实现能工作，没必要重构 |
| `dice_hub encrypt` | 待评估 — 看 α 是否有需求 |

## 相关 PR

这是「拆分自 #43」的 4 个 PR 之一。其他 3 个：
- `feat/deploy-bootstrap`（部署引导脚本）
- `feat/admin-webui`（WebUI 管理后台）
- `feat/macro-variable-point`（β 命令移植，含 R1/R2/R3 修复）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)