### PR TITLE
feat(homebrew): data layer + migration v5 + QueryStore extension (per #50)

### DIFF
--- a/src/plugins/DicePP/adapter/nonebot_adapter.py
+++ b/src/plugins/DicePP/adapter/nonebot_adapter.py
@@ -19,7 +19,7 @@ from core.bot import Bot as DicePPBot
 from core.communication import MessageMetaData, MessageSender, GroupMemberInfo, GroupInfo
 from core.communication import NoticeData, FriendAddNoticeData, GroupIncreaseNoticeData
 from core.communication import RequestData, FriendRequestData, JoinGroupRequestData, InviteGroupRequestData
-from core.command import BotCommandBase, BotSendMsgCommand, BotDelayCommand, BotLeaveGroupCommand, BotSendForwardMsgCommand, BotSendFileCommand
+from core.command import BotCommandBase, BotSendMsgCommand, BotDelayCommand, BotLeaveGroupCommand, BotSendForwardMsgCommand, BotSendFileCommand, BotSetGroupCardCommand
 from utils.logger import dice_log
 
 from module.common.log_command import delete_log_record_by_message_id
@@ -97,6 +97,7 @@ class NoneBotClientProxy(ClientProxy):
             BotLeaveGroupCommand: self._handle_leave_group,
             BotSendForwardMsgCommand: self._handle_send_forward_msg,
             BotSendFileCommand: self._handle_send_file,
+            BotSetGroupCardCommand: self._handle_set_group_card,
             BotDelayCommand: self._handle_delay,
         }
 
@@ -221,6 +222,15 @@ class NoneBotClientProxy(ClientProxy):
             except Exception as ex_outer:
                 dice_log(f"[OneBot][Upload][Unexpected] group={target.group_id} file={real_name} err={ex_outer}")
                 await self.bot.send_group_msg(group_id=int(target.group_id), message="文件发送失败！")
+
+    async def _handle_set_group_card(self, command: BotSetGroupCardCommand) -> None:
+        # OneBot v11 标准 API set_group_card；需要骰娘在该群有管理员权限，否则 ActionFailed
+        await self.bot.call_api(
+            "set_group_card",
+            group_id=int(command.group_id),
+            user_id=int(command.user_id),
+            card=command.card,
+        )
 
     async def _handle_delay(self, command: BotDelayCommand) -> None:
         await asyncio.sleep(command.seconds)

--- a/src/plugins/DicePP/core/bot/dicebot.py
+++ b/src/plugins/DicePP/core/bot/dicebot.py
@@ -556,6 +556,14 @@ class Bot:
 
         msg = preprocess_msg(msg)  # 转换中文符号, 转换小写等等
 
+        # 展开用户定义的宏（.define）：在命令分发前把消息文本里能匹配的宏替换掉。
+        # apply_user_macros 内部对没定义宏的用户会快速返回原文，对错误也会兜底返回原文。
+        try:
+            from module.common.macro_command import apply_user_macros
+            msg = await apply_user_macros(self, meta.user_id, msg)
+        except Exception:
+            dice_log(f"[Macro] [Expand] 宏展开失败，回退原始消息: {get_exception_info()}")
+
         bot_commands: List[BotCommandBase] = []
 
         # 统计信息 —— 从 SQLite 读取，失败则创建默认值

--- a/src/plugins/DicePP/core/bot/dicebot.py
+++ b/src/plugins/DicePP/core/bot/dicebot.py
@@ -783,6 +783,15 @@ class Bot:
                     if feedback:
                         bot_commands += [BotSendMsgCommand(self.account, choice(feedback.split("|")), [GroupMessagePort(data.group_id)])]
 
+                # 队伍模式：若该群启用了 team 且新成员不在 team 中，自动改群名片为 ob
+                try:
+                    from module.common.team_command import auto_rename_ob_for_new_member
+                    bot_commands += await auto_rename_ob_for_new_member(
+                        self, data.group_id, data.user_id
+                    )
+                except Exception:
+                    dice_log(f"[Team] [Notice] 自动改名 ob 失败: {get_exception_info()}")
+
         if self.proxy:
             for command in bot_commands:
                 await self.proxy.process_bot_command(command)

--- a/src/plugins/DicePP/core/command/__init__.py
+++ b/src/plugins/DicePP/core/command/__init__.py
@@ -1,5 +1,5 @@
 from core.command.const import *
-from core.command.bot_cmd import BotCommandBase, BotSendMsgCommand, BotLeaveGroupCommand, BotDelayCommand, BotSendForwardMsgCommand, BotSendFileCommand
+from core.command.bot_cmd import BotCommandBase, BotSendMsgCommand, BotLeaveGroupCommand, BotDelayCommand, BotSendForwardMsgCommand, BotSendFileCommand, BotSetGroupCardCommand
 from core.command.user_cmd import CommandError, UserCommandBase, custom_user_command, CommandRegistry, use_registry, DEFAULT_REGISTRY
 from core.command.parse_result import (
     CommandParseResult, MentionInfo, MessageSegment, ParseIssue

--- a/src/plugins/DicePP/core/command/bot_cmd.py
+++ b/src/plugins/DicePP/core/command/bot_cmd.py
@@ -89,6 +89,27 @@ class BotSendForwardMsgCommand(BotCommandBase):
         s += '\n\t'.join([str(target) for target in self.targets])
         return s
 
+class BotSetGroupCardCommand(BotCommandBase):
+    """设置群成员名片（群内限定，需要骰娘有群管理员权限）
+
+    用于 .team 系列指令自动把非 team 成员改名为 "ob"。OneBot v11 对应
+    API: set_group_card(group_id, user_id, card)。卡片为空字符串时清除
+    群名片，恢复显示用户原昵称。
+    """
+
+    def __init__(self, bot_id: str, group_id: str, user_id: str, card: str):
+        self.bot_id = bot_id
+        self.group_id = group_id
+        self.user_id = user_id
+        self.card = card
+
+    def __str__(self):
+        return (f"Bot \033[0;37m{self.bot_id}\033[0m set group "
+                f"\033[0;33m{self.group_id}\033[0m member "
+                f"\033[0;33m{self.user_id}\033[0m card to "
+                f"\033[0;33m{self.card!r}\033[0m")
+
+
 class BotSendFileCommand(BotCommandBase):
     """
     上传文件（群内限定）

--- a/src/plugins/DicePP/core/config/basic.py
+++ b/src/plugins/DicePP/core/config/basic.py
@@ -29,6 +29,15 @@ class Paths:
         return cls.DATA_BOTS_DIR / bot_id
 
     @classmethod
+    def group_homebrew_dir(cls, bot_id: str, group_id: str) -> Path:
+        """群级私设资料库目录：data/bots/<bot_id>/group_homebrew/<group_id>/
+
+        独立于 .mode 切换 —— 私设始终对该群可见，不受当前模式影响。
+        目录里放多个 .db 文件（schema 与 QueryStore 公共库相同）+ meta.json。
+        """
+        return cls.bot_data_dir(bot_id) / "group_homebrew" / group_id
+
+    @classmethod
     def ensure_dirs(cls) -> None:
         for d in [
             cls.CONFIG_DIR, cls.CONFIG_BOTS_DIR,

--- a/src/plugins/DicePP/core/config/pydantic_models.py
+++ b/src/plugins/DicePP/core/config/pydantic_models.py
@@ -333,6 +333,14 @@ class ModeConfig(BaseModel):
     default: str = "DND5E2024"
 
 
+class PointConfig(BaseModel):
+    """用户点数系统配置（.point 指令）"""
+    init: int = Field(default=100, ge=0, description="新用户初始拥有的点数")
+    add: int = Field(default=100, ge=0, description="每天给活跃用户增加的点数")
+    max: int = Field(default=500, ge=0, description="用户能持有的点数上限")
+    limit_daily: int = Field(default=300, ge=0, description="每天使用点数的上限")
+
+
 class BotConfig(BaseModel):
     """Top-level configuration model for a single Bot instance."""
 
@@ -374,3 +382,4 @@ class BotConfig(BaseModel):
     query: QueryConfig = Field(default_factory=QueryConfig)
     log: LogConfig = Field(default_factory=LogConfig)
     mode: ModeConfig = Field(default_factory=ModeConfig)
+    point: PointConfig = Field(default_factory=PointConfig)

--- a/src/plugins/DicePP/core/data/database.py
+++ b/src/plugins/DicePP/core/data/database.py
@@ -27,6 +27,7 @@ from .models import (
     UserVariable,
     UserFavor,
     UserMacro,
+    GroupMacro,
 )
 
 
@@ -59,6 +60,7 @@ class BotDatabase:
         self._macro: Optional[Repository[UserMacro]] = None
         self._point: Optional[Repository[UserPoint]] = None
         self._group_team: Optional[Repository[GroupTeam]] = None
+        self._group_macro: Optional[Repository[GroupMacro]] = None
         self.query: QueryStore = QueryStore()
         self._migration_runner: Optional[MigrationRunner] = None
 
@@ -176,6 +178,12 @@ class BotDatabase:
             raise RuntimeError("Database not connected. Call connect() first.")
         return self._group_team
 
+    @property
+    def group_macro(self) -> Repository[GroupMacro]:
+        if self._group_macro is None:
+            raise RuntimeError("Database not connected. Call connect() first.")
+        return self._group_macro
+
     async def connect(self) -> None:
         # allow idempotent connect() (some packaged runs may receive events early)
         if self._db is not None and self._log_db is not None:
@@ -227,6 +235,7 @@ class BotDatabase:
         self._macro = None
         self._point = None
         self._group_team = None
+        self._group_macro = None
         self._migration_runner = None
 
         # 关闭 query 数据库连接
@@ -354,4 +363,8 @@ class BotDatabase:
 
         self._group_team = Repository[GroupTeam](
             self._db, GroupTeam, "group_team", ["group_id"]
+        )
+
+        self._group_macro = Repository[GroupMacro](
+            self._db, GroupMacro, "group_macro", ["group_id", "key"]
         )

--- a/src/plugins/DicePP/core/data/database.py
+++ b/src/plugins/DicePP/core/data/database.py
@@ -13,6 +13,7 @@ from .models import (
     InitList,
     DNDCharacter,
     UserNickname,
+    UserPoint,
     GroupConfig,
     GroupActivate,
     GroupWelcome,
@@ -24,6 +25,7 @@ from .models import (
     NPCHealth,
     UserVariable,
     UserFavor,
+    UserMacro,
 )
 
 
@@ -53,6 +55,8 @@ class BotDatabase:
         self._npc_health: Optional[Repository[NPCHealth]] = None
         self._variable: Optional[Repository[UserVariable]] = None
         self._favor: Optional[Repository[UserFavor]] = None
+        self._macro: Optional[Repository[UserMacro]] = None
+        self._point: Optional[Repository[UserPoint]] = None
         self.query: QueryStore = QueryStore()
         self._migration_runner: Optional[MigrationRunner] = None
 
@@ -152,6 +156,18 @@ class BotDatabase:
             raise RuntimeError("Database not connected. Call connect() first.")
         return self._favor
 
+    @property
+    def macro(self) -> Repository[UserMacro]:
+        if self._macro is None:
+            raise RuntimeError("Database not connected. Call connect() first.")
+        return self._macro
+
+    @property
+    def point(self) -> Repository[UserPoint]:
+        if self._point is None:
+            raise RuntimeError("Database not connected. Call connect() first.")
+        return self._point
+
     async def connect(self) -> None:
         # allow idempotent connect() (some packaged runs may receive events early)
         if self._db is not None and self._log_db is not None:
@@ -200,6 +216,8 @@ class BotDatabase:
         self._npc_health = None
         self._variable = None
         self._favor = None
+        self._macro = None
+        self._point = None
         self._migration_runner = None
 
         # 关闭 query 数据库连接
@@ -315,4 +333,12 @@ class BotDatabase:
 
         self._favor = Repository[UserFavor](
             self._db, UserFavor, "favor", ["user_id", "group_id"]
+        )
+
+        self._macro = Repository[UserMacro](
+            self._db, UserMacro, "macros", ["user_id", "key"]
+        )
+
+        self._point = Repository[UserPoint](
+            self._db, UserPoint, "point", ["user_id"]
         )

--- a/src/plugins/DicePP/core/data/database.py
+++ b/src/plugins/DicePP/core/data/database.py
@@ -17,6 +17,7 @@ from .models import (
     GroupConfig,
     GroupActivate,
     GroupWelcome,
+    GroupTeam,
     ChatRecord,
     BotControl,
     UserStat,
@@ -57,6 +58,7 @@ class BotDatabase:
         self._favor: Optional[Repository[UserFavor]] = None
         self._macro: Optional[Repository[UserMacro]] = None
         self._point: Optional[Repository[UserPoint]] = None
+        self._group_team: Optional[Repository[GroupTeam]] = None
         self.query: QueryStore = QueryStore()
         self._migration_runner: Optional[MigrationRunner] = None
 
@@ -168,6 +170,12 @@ class BotDatabase:
             raise RuntimeError("Database not connected. Call connect() first.")
         return self._point
 
+    @property
+    def group_team(self) -> Repository[GroupTeam]:
+        if self._group_team is None:
+            raise RuntimeError("Database not connected. Call connect() first.")
+        return self._group_team
+
     async def connect(self) -> None:
         # allow idempotent connect() (some packaged runs may receive events early)
         if self._db is not None and self._log_db is not None:
@@ -218,6 +226,7 @@ class BotDatabase:
         self._favor = None
         self._macro = None
         self._point = None
+        self._group_team = None
         self._migration_runner = None
 
         # 关闭 query 数据库连接
@@ -341,4 +350,8 @@ class BotDatabase:
 
         self._point = Repository[UserPoint](
             self._db, UserPoint, "point", ["user_id"]
+        )
+
+        self._group_team = Repository[GroupTeam](
+            self._db, GroupTeam, "group_team", ["group_id"]
         )

--- a/src/plugins/DicePP/core/data/migrations/__init__.py
+++ b/src/plugins/DicePP/core/data/migrations/__init__.py
@@ -8,6 +8,7 @@ from .v1_baseline import BaselineMigrationV1
 from .v2_hub_config import HubConfigMigrationV2
 from .v3_macros_points import MacrosPointsMigrationV3
 from .v4_group_team import GroupTeamMigrationV4
+from .v5_group_homebrew import GroupHomebrewMigrationV5
 
 
 def default_registry() -> MigrationRegistry:
@@ -17,6 +18,7 @@ def default_registry() -> MigrationRegistry:
             HubConfigMigrationV2(),
             MacrosPointsMigrationV3(),
             GroupTeamMigrationV4(),
+            GroupHomebrewMigrationV5(),
         ]
     )
 

--- a/src/plugins/DicePP/core/data/migrations/__init__.py
+++ b/src/plugins/DicePP/core/data/migrations/__init__.py
@@ -7,6 +7,7 @@ from .runner import MigrationExecutionError, MigrationRunResult, MigrationRunner
 from .v1_baseline import BaselineMigrationV1
 from .v2_hub_config import HubConfigMigrationV2
 from .v3_macros_points import MacrosPointsMigrationV3
+from .v4_group_team import GroupTeamMigrationV4
 
 
 def default_registry() -> MigrationRegistry:
@@ -15,6 +16,7 @@ def default_registry() -> MigrationRegistry:
             BaselineMigrationV1(),
             HubConfigMigrationV2(),
             MacrosPointsMigrationV3(),
+            GroupTeamMigrationV4(),
         ]
     )
 

--- a/src/plugins/DicePP/core/data/migrations/__init__.py
+++ b/src/plugins/DicePP/core/data/migrations/__init__.py
@@ -6,6 +6,7 @@ from .registry import MigrationRegistry, MigrationRegistryError, build_registry
 from .runner import MigrationExecutionError, MigrationRunResult, MigrationRunner
 from .v1_baseline import BaselineMigrationV1
 from .v2_hub_config import HubConfigMigrationV2
+from .v3_macros_points import MacrosPointsMigrationV3
 
 
 def default_registry() -> MigrationRegistry:
@@ -13,6 +14,7 @@ def default_registry() -> MigrationRegistry:
         [
             BaselineMigrationV1(),
             HubConfigMigrationV2(),
+            MacrosPointsMigrationV3(),
         ]
     )
 

--- a/src/plugins/DicePP/core/data/migrations/v3_macros_points.py
+++ b/src/plugins/DicePP/core/data/migrations/v3_macros_points.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from .base import Migration, MigrationContext
+
+
+class MacrosPointsMigrationV3(Migration):
+    """添加 macros 和 point 表（β 业务移植）"""
+
+    def __init__(self) -> None:
+        super().__init__(
+            version=3,
+            name="v3_macros_points",
+            description="Add macros and point tables (ported from β).",
+        )
+
+    async def up(self, ctx: MigrationContext) -> None:
+        await ctx.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS macros (
+                user_id TEXT,
+                key TEXT,
+                data TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (user_id, key)
+            )
+            """
+        )
+        await ctx.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS point (
+                user_id TEXT,
+                data TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (user_id)
+            )
+            """
+        )

--- a/src/plugins/DicePP/core/data/migrations/v4_group_team.py
+++ b/src/plugins/DicePP/core/data/migrations/v4_group_team.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from .base import Migration, MigrationContext
+
+
+class GroupTeamMigrationV4(Migration):
+    """添加 group_team 表（跑团队伍管理）"""
+
+    def __init__(self) -> None:
+        super().__init__(
+            version=4,
+            name="v4_group_team",
+            description="Add group_team table for .team commands.",
+        )
+
+    async def up(self, ctx: MigrationContext) -> None:
+        await ctx.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS group_team (
+                group_id TEXT PRIMARY KEY,
+                data TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )

--- a/src/plugins/DicePP/core/data/migrations/v5_group_homebrew.py
+++ b/src/plugins/DicePP/core/data/migrations/v5_group_homebrew.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from .base import Migration, MigrationContext
+
+
+class GroupHomebrewMigrationV5(Migration):
+    """添加 group_macro 表（群级宏；附加查询数据库走文件系统而非 BotDatabase）"""
+
+    def __init__(self) -> None:
+        super().__init__(
+            version=5,
+            name="v5_group_homebrew",
+            description="Add group_macro table for group-level macros (homebrew).",
+        )
+
+    async def up(self, ctx: MigrationContext) -> None:
+        await ctx.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS group_macro (
+                group_id TEXT,
+                key TEXT,
+                data TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (group_id, key)
+            )
+            """
+        )

--- a/src/plugins/DicePP/core/data/models/__init__.py
+++ b/src/plugins/DicePP/core/data/models/__init__.py
@@ -32,6 +32,7 @@ from .extended import (
     UserVariable,
     UserFavor,
     UserMacro,
+    GroupMacro,
 )
 from .hub_config import HubConfig
 
@@ -64,6 +65,7 @@ __all__ = [
     "UserVariable",
     "UserFavor",
     "UserMacro",
+    "GroupMacro",
     "GroupTeam",
     # 角色常量
     "CHAR_INFO_KEY_HP",

--- a/src/plugins/DicePP/core/data/models/__init__.py
+++ b/src/plugins/DicePP/core/data/models/__init__.py
@@ -18,6 +18,7 @@ from .character import (
 )
 from .extended import (
     UserNickname,
+    UserPoint,
     GroupConfig,
     GroupActivate,
     GroupWelcome,
@@ -29,6 +30,7 @@ from .extended import (
     NPCHealth,
     UserVariable,
     UserFavor,
+    UserMacro,
 )
 from .hub_config import HubConfig
 
@@ -47,6 +49,7 @@ __all__ = [
     "DNDCharacter",
     # 扩展模型
     "UserNickname",
+    "UserPoint",
     "GroupConfig",
     "GroupActivate",
     "GroupWelcome",
@@ -57,6 +60,9 @@ __all__ = [
     "MetaStat",
     "NPCHealth",
     "HubConfig",
+    "UserVariable",
+    "UserFavor",
+    "UserMacro",
     # 角色常量
     "CHAR_INFO_KEY_HP",
     "CHAR_INFO_KEY_HP_DICE",

--- a/src/plugins/DicePP/core/data/models/__init__.py
+++ b/src/plugins/DicePP/core/data/models/__init__.py
@@ -22,6 +22,7 @@ from .extended import (
     GroupConfig,
     GroupActivate,
     GroupWelcome,
+    GroupTeam,
     ChatRecord,
     BotControl,
     UserStat,
@@ -63,6 +64,7 @@ __all__ = [
     "UserVariable",
     "UserFavor",
     "UserMacro",
+    "GroupTeam",
     # 角色常量
     "CHAR_INFO_KEY_HP",
     "CHAR_INFO_KEY_HP_DICE",

--- a/src/plugins/DicePP/core/data/models/extended.py
+++ b/src/plugins/DicePP/core/data/models/extended.py
@@ -113,3 +113,20 @@ class GroupTeam(BaseModel):
     members: list[str] = Field(default_factory=list)
     auto_rename_ob: bool = True
     last_update: datetime = Field(default_factory=datetime.now)
+
+
+class GroupMacro(BaseModel):
+    """群级宏
+
+    跟 UserMacro 类似但作用域为整个群。主持人 `.hb 宏 X = Y` 后，
+    群里所有成员的消息都会被 X→Y 替换。在 process_message 中群宏
+    先于用户宏执行（让群宏铺路，用户宏在此基础上进一步定制）。
+    """
+    group_id: str
+    key: str
+    raw: str = ""
+    args: list[str] = Field(default_factory=list)
+    target: str = ""
+    command_split: str = ""
+    creator_id: str = ""   # 审计：哪位主持人创建的
+    last_update: datetime = Field(default_factory=datetime.now)

--- a/src/plugins/DicePP/core/data/models/extended.py
+++ b/src/plugins/DicePP/core/data/models/extended.py
@@ -100,3 +100,16 @@ class UserMacro(BaseModel):
     args: list[str] = Field(default_factory=list)
     target: str = ""          # 替换后的目标字符串（含 {arg} 占位）
     command_split: str = ""   # bot 当前的指令分隔符（用于把 %% 替换回去）
+
+
+class GroupTeam(BaseModel):
+    """群级玩家队伍
+
+    跑团群里区分玩家（PC）和观众（OB）。team 内的用户保留原名；
+    team 外的用户被自动改群名片为 "ob"（需要骰娘有群管理员权限）。
+    触发时机：.team set 时全量刷新；新成员进群时单独改一次。
+    """
+    group_id: str
+    members: list[str] = Field(default_factory=list)
+    auto_rename_ob: bool = True
+    last_update: datetime = Field(default_factory=datetime.now)

--- a/src/plugins/DicePP/core/data/models/extended.py
+++ b/src/plugins/DicePP/core/data/models/extended.py
@@ -86,3 +86,17 @@ class UserFavor(BaseModel):
     group_id: str
     favor_value: int = 0
     last_update: datetime = Field(default_factory=datetime.now)
+
+
+class UserMacro(BaseModel):
+    """用户自定义宏（指令文本替换）
+
+    一个 user_id + key 对应一条宏。key 是宏的关键字，target 是替换目标。
+    args 描述宏的参数列表（用括号 "(a,b)" 在 raw 里声明），命中时按位置替换。
+    """
+    user_id: str
+    key: str
+    raw: str = ""             # 用户原始定义字符串
+    args: list[str] = Field(default_factory=list)
+    target: str = ""          # 替换后的目标字符串（含 {arg} 占位）
+    command_split: str = ""   # bot 当前的指令分隔符（用于把 %% 替换回去）

--- a/src/plugins/DicePP/core/data/query_store.py
+++ b/src/plugins/DicePP/core/data/query_store.py
@@ -125,6 +125,58 @@ class QueryStore:
     def list_databases(self) -> List[str]:
         return list(self._conns.keys())
 
+    # ── 群级私设（homebrew）支持 ─────────────────────────────────────────
+    # 群私设 db 用 "__hb__<group_id>__<filename>" 命名空间，避免与公共
+    # query 库冲突。这些 db 文件存在 data/bots/<bot_id>/group_homebrew/
+    # <group_id>/ 下，独立于 .mode 切换；search() 调用时会自动追加群里
+    # 已加载的所有 hb db，并按 "私设优先" 合并结果。
+
+    _HB_PREFIX = "__hb__"
+
+    @classmethod
+    def _hb_db_name(cls, group_id: str, filename: str) -> str:
+        base = filename[:-3] if filename.endswith(".db") else filename
+        return f"{cls._HB_PREFIX}{group_id}__{base}"
+
+    @classmethod
+    def is_homebrew_db(cls, db_name: str) -> bool:
+        return db_name.startswith(cls._HB_PREFIX)
+
+    @classmethod
+    def homebrew_group_of(cls, db_name: str) -> Optional[str]:
+        if not cls.is_homebrew_db(db_name):
+            return None
+        rest = db_name[len(cls._HB_PREFIX):]
+        parts = rest.split("__", 1)
+        return parts[0] if parts else None
+
+    async def connect_group_homebrew(self, group_id: str, dir_path: str) -> List[str]:
+        """加载某群的私设目录下所有 .db 文件，返回加载成功的 db_name 列表。"""
+        loaded: List[str] = []
+        if not group_id or not dir_path or not os.path.isdir(dir_path):
+            return loaded
+        for fname in sorted(os.listdir(dir_path)):
+            if not fname.endswith(".db"):
+                continue
+            full = os.path.join(dir_path, fname)
+            db_name = self._hb_db_name(group_id, fname)
+            if db_name in self._conns:
+                continue
+            try:
+                conn = await aiosqlite.connect(full)
+                await conn.execute("PRAGMA journal_mode=WAL;")
+                await conn.create_function("regexp", 2, regexp)
+                self._conns[db_name] = conn
+                loaded.append(db_name)
+            except (PermissionError, OSError):
+                continue
+        return loaded
+
+    def list_group_databases(self, group_id: str) -> List[str]:
+        """列出某群已加载的所有私设 db_name（不含公共库）。"""
+        prefix = f"{self._HB_PREFIX}{group_id}__"
+        return [n for n in self._conns if n.startswith(prefix)]
+
     async def disconnect_database(self, db_name: str) -> None:
         conn = self._conns.get(db_name)
         if conn is None:
@@ -628,22 +680,33 @@ class QueryStore:
             if not self.has_database(db):
                 raise QueryStoreError(f"数据库未加载: {db}")
 
-        # 主库搜索
-        all_results = await self._search_single_db(
-            databases[0], query_tokens, fulltext, max_total + 1, 0,
-        )
+        # 群聊内私设优先：先收集所有私设 db（databases[1:]）的结果，再追加公共
+        # 主库（databases[0]），同名条目以私设为准（先入为主，跳过后到的同名）
+        all_results: List[dict] = []
+        seen_names: Set[str] = set()
 
-        # 私设库合并（私设覆盖同名主库条目）
+        # 私设结果在前
         for hb_db in databases[1:]:
             hb_results = await self._search_single_db(
                 hb_db, query_tokens, fulltext, max_total + 1, 0,
             )
-            for hb in hb_results[::-1]:
-                for main in all_results[::-1]:
-                    if hb["name"] == main["name"]:
-                        all_results.remove(main)
-                if hb["content"].strip():
-                    all_results.append(hb)
+            for r in hb_results:
+                if not r.get("content", "").strip():
+                    continue
+                if r["name"] in seen_names:
+                    continue
+                seen_names.add(r["name"])
+                all_results.append(r)
+
+        # 公共主库追加，跳过被私设覆盖的同名条目
+        main_results = await self._search_single_db(
+            databases[0], query_tokens, fulltext, max_total + 1, 0,
+        )
+        for r in main_results:
+            if r["name"] in seen_names:
+                continue
+            seen_names.add(r["name"])
+            all_results.append(r)
 
         total = len(all_results)
         if total > max_total:

--- a/src/plugins/DicePP/module/common/__init__.py
+++ b/src/plugins/DicePP/module/common/__init__.py
@@ -8,3 +8,7 @@ from .welcome_command import WelcomeCommand, DC_WELCOME, LOC_WELCOME_DEFAULT
 from .master_command import MasterCommand, DC_CTRL
 from .log_command import LogCommand, LogRecorderCommand, LogStatCommand, DC_LOG_SESSION
 from .reload_config_command import ReloadConfigCommand
+# β 业务移植：宏 / 变量 / 点数
+from .macro_command import MacroCommand
+from .variable_command import VariableCommand
+from .point_command import PointCommand

--- a/src/plugins/DicePP/module/common/__init__.py
+++ b/src/plugins/DicePP/module/common/__init__.py
@@ -12,3 +12,5 @@ from .reload_config_command import ReloadConfigCommand
 from .macro_command import MacroCommand
 from .variable_command import VariableCommand
 from .point_command import PointCommand
+# 队伍指令 + 自动改名 ob
+from .team_command import TeamCommand

--- a/src/plugins/DicePP/module/common/macro_command.py
+++ b/src/plugins/DicePP/module/common/macro_command.py
@@ -1,0 +1,246 @@
+"""宏指令 (.define)
+
+用户可以自定义文本替换宏，简化常用骰子表达式。基于 α 的 Repository 模式
+重写自 β 的 module/common/macro_command.py。
+
+宏定义语法：
+  .define [关键字][(参数列表)][空格][目标字符串]
+
+示例：
+  .define 一颗D20 .r 1d20
+  .define 攻击(目标,武器) .r 1d20+5 攻击{目标}用{武器}
+
+宏的"展开执行"集成在 Bot.process_message 入口，详见
+`apply_user_macros()`。第一期实现增删查，展开逻辑预留 hook。
+"""
+import re
+from typing import Any, List, Optional, Tuple
+
+from core.bot import Bot
+from core.command import (
+    BotCommandBase,
+    BotSendMsgCommand,
+    UserCommandBase,
+    custom_user_command,
+)
+from core.command.const import (
+    DPP_COMMAND_FLAG_DEFAULT,
+    DPP_COMMAND_PRIORITY_DEFAULT,
+)
+from core.communication import (
+    GroupMessagePort,
+    MessageMetaData,
+    PrivateMessagePort,
+)
+from core.data.models import UserMacro
+
+
+MACRO_COMMAND_SPLIT = "%%"  # 用户在宏定义里用 %% 表示指令分隔符
+
+LOC_DEFINE_SUCCESS = "define_success"
+LOC_DEFINE_FAIL = "define_fail"
+LOC_DEFINE_LIST = "define_list"
+LOC_DEFINE_INFO = "define_info"
+LOC_DEFINE_DEL = "define_delete"
+
+CFG_DEFINE_LEN_MAX = "define_length_max"
+CFG_DEFINE_NUM_MAX = "define_number_max"
+
+
+# ─── 宏解析/编译 helpers ─────────────────────────────────────────────────
+
+def parse_macro_definition(raw: str, command_split: str) -> UserMacro:
+    """从 raw 字符串解析出 UserMacro 对象。出错抛 ValueError。"""
+    raw = (raw or "").strip()
+    if " " not in raw:
+        raise ValueError("宏定义中缺少空格，格式应为「关键字 目标字符串」")
+    key_args, target = raw.split(" ", 1)
+    key_args = key_args.strip()
+    target = target.strip()
+
+    if key_args.endswith(")"):
+        par_index = key_args.find("(")
+        if par_index == -1:
+            raise ValueError("参数列表缺少左括号")
+        key = key_args[:par_index]
+        args = [a for a in key_args[par_index + 1:-1].split(",") if a.strip()]
+    else:
+        key = key_args
+        args = []
+
+    if not key:
+        raise ValueError("宏关键字不能为空")
+    if key == "all" or key == "del":
+        raise ValueError(f"「{key}」是保留关键字")
+
+    # 把 args 出现的地方替换为 {arg} 占位，方便后续 str.format
+    transformed = target
+    for arg in args:
+        transformed = transformed.replace(arg, "{" + arg + "}")
+    transformed = transformed.replace(MACRO_COMMAND_SPLIT, command_split)
+
+    return UserMacro(
+        user_id="",  # 由调用方填充
+        key=key,
+        raw=raw,
+        args=args,
+        target=transformed,
+        command_split=command_split,
+    )
+
+
+def apply_macro_once(macro: UserMacro, text: str) -> str:
+    """对 text 应用一次宏替换。命中则返回展开后的字符串，否则返回原文。"""
+    pattern_str = ":".join([re.escape(macro.key)] + ["(.*)"] * len(macro.args))
+    try:
+        pattern = re.compile(pattern_str)
+    except re.error:
+        return text
+
+    def repl(m: re.Match) -> str:
+        if not macro.args:
+            return macro.target
+        kwargs = {a: m.group(i + 1) for i, a in enumerate(macro.args)}
+        try:
+            return macro.target.format(**kwargs)
+        except (KeyError, IndexError):
+            return m.group(0)
+
+    return pattern.sub(repl, text)
+
+
+async def apply_user_macros(bot: Bot, user_id: str, text: str,
+                            max_passes: int = 3, max_length: int = 500) -> str:
+    """对消息文本应用某用户的所有宏。最多 max_passes 轮、长度上限 max_length。
+
+    集成在 Bot.process_message 入口，preprocess_msg 之后、命令分发之前。
+    bot.db.macro 在 db 未 connect 时会 raise RuntimeError，调用方需自行兜底。
+    """
+    if not user_id or not text:
+        return text
+    macros: List[UserMacro] = await bot.db.macro.list_by(user_id=user_id)
+    if not macros:
+        return text
+
+    out = text
+    for _ in range(max_passes):
+        prev = out
+        for m in macros:
+            out = apply_macro_once(m, out)
+            if len(out) > max_length:
+                return prev  # 超长则回退
+        if out == prev:
+            break
+    return out
+
+
+# ─── 命令实现 ───────────────────────────────────────────────────────────
+
+@custom_user_command(readable_name="宏指令", priority=DPP_COMMAND_PRIORITY_DEFAULT,
+                     flag=DPP_COMMAND_FLAG_DEFAULT)
+class MacroCommand(UserCommandBase):
+    """.define 系列：定义、查看、删除用户的宏"""
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_DEFINE_SUCCESS,
+            "已定义宏 {macro}（参数：{args}）-> {target}",
+            "成功定义宏的回复")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_FAIL,
+            "定义失败：{error}",
+            "定义宏失败的回复")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_LIST,
+            "你的宏列表：\n{macro_list}",
+            "查看宏列表的回复")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_INFO,
+            "{macro}（参数：{args}）-> {target}",
+            "宏列表中单个宏的展示")
+        bot.loc_helper.register_loc_text(LOC_DEFINE_DEL,
+            "已删除宏 {macro}",
+            "删除宏的回复")
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        should_proc = msg_str.startswith(".define")
+        should_pass = False
+        hint = msg_str[7:].strip() if should_proc else None
+        return should_proc, should_pass, hint
+
+    async def process_msg(self, msg_str: str, meta: MessageMetaData,
+                          hint: Any) -> List[BotCommandBase]:
+        port = (GroupMessagePort(meta.group_id)
+                if meta.group_id else PrivateMessagePort(meta.user_id))
+        arg_str: str = hint or ""
+
+        feedback = ""
+        macros = await self.bot.db.macro.list_by(user_id=meta.user_id)
+
+        if not arg_str:
+            # 查看
+            if not macros:
+                feedback = "你还没有定义任何宏。使用 .define 关键字 目标 来定义一个。"
+            else:
+                lines = []
+                for i, m in enumerate(macros):
+                    info = self.format_loc(LOC_DEFINE_INFO, macro=m.key,
+                                           args=",".join(m.args) or "无", target=m.target)
+                    lines.append(f"{i + 1}. {info}")
+                feedback = self.format_loc(LOC_DEFINE_LIST, macro_list="\n".join(lines))
+        elif arg_str.startswith("del"):
+            # 删除
+            key = arg_str[3:].strip()
+            if key == "all":
+                for m in macros:
+                    await self.bot.db.macro.delete(m.user_id, m.key)
+                feedback = self.format_loc(LOC_DEFINE_DEL,
+                                           macro=",".join(m.key for m in macros) or "(空)")
+            elif key:
+                found = next((m for m in macros if m.key == key), None)
+                if found:
+                    await self.bot.db.macro.delete(found.user_id, found.key)
+                    feedback = self.format_loc(LOC_DEFINE_DEL, macro=key)
+                else:
+                    feedback = self.format_loc(LOC_DEFINE_FAIL, error=f"找不到关键字为 {key} 的宏")
+            else:
+                feedback = self.format_loc(LOC_DEFINE_FAIL, error="del 后请跟宏关键字或 all")
+        else:
+            # 定义
+            split_token = ";"
+            try:
+                split_token = self.bot.config.command_split
+            except AttributeError:
+                pass
+            try:
+                length_max = 300
+                num_max = 50
+                if len(arg_str) > length_max:
+                    raise ValueError(f"宏定义长度超过 {length_max} 字符")
+                if len(macros) >= num_max:
+                    raise ValueError(f"宏数量已达上限 {num_max}，请先删除一些")
+                new_macro = parse_macro_definition(arg_str, split_token)
+                new_macro.user_id = meta.user_id
+                # 同名直接覆盖
+                await self.bot.db.macro.save(new_macro)
+                feedback = self.format_loc(LOC_DEFINE_SUCCESS, macro=new_macro.key,
+                                           args=",".join(new_macro.args) or "无",
+                                           target=new_macro.target)
+            except ValueError as e:
+                feedback = self.format_loc(LOC_DEFINE_FAIL, error=str(e))
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword == "define":
+            return (
+                "宏指令 .define 用于自定义文本替换：\n"
+                "  定义：.define 关键字[(参数1,参数2)] 目标字符串\n"
+                "  查看：.define\n"
+                "  删除：.define del 关键字  或  .define del all\n"
+                "\n示例：\n"
+                "  .define 一颗D20 .r 1d20\n"
+                "  .define 攻击(目标,武器) .r 1d20+5 攻击{目标}用{武器}\n"
+                f"\n用 {MACRO_COMMAND_SPLIT} 表示指令分隔符。"
+            )
+        return ""
+
+    def get_description(self) -> str:
+        return ".define 定义自定义宏"

--- a/src/plugins/DicePP/module/common/point_command.py
+++ b/src/plugins/DicePP/module/common/point_command.py
@@ -1,0 +1,160 @@
+"""点数指令 (.point)
+
+简单的用户点数系统：每天活跃用户自动获得点数，可用于游戏化奖励。
+基于 α 已有的 UserPoint 模型，新增 point Repository（v3 migration）。
+
+配置项通过 BotConfig.point 注入（pydantic_models.PointConfig），
+master 可通过修改 config 文件 + 热重载（reload_config 指令）调整。
+"""
+from datetime import datetime
+from typing import Any, List, Tuple
+
+from core.bot import Bot
+from core.command import (
+    BotCommandBase,
+    BotSendMsgCommand,
+    UserCommandBase,
+    custom_user_command,
+)
+from core.command.const import DPP_COMMAND_PRIORITY_DEFAULT
+from core.communication import (
+    GroupMessagePort,
+    MessageMetaData,
+    PrivateMessagePort,
+)
+from core.data.models import UserPoint
+
+
+LOC_POINT_SHOW   = "point_show"
+LOC_POINT_LACK   = "point_lack"
+LOC_POINT_CHECK  = "point_check"
+LOC_POINT_EDIT   = "point_edit"
+LOC_POINT_ERROR  = "point_edit_error"
+
+
+async def _get_or_create_point(bot: Bot, user_id: str, init_val: int) -> UserPoint:
+    p = await bot.db.point.get(user_id)
+    if p is None:
+        p = UserPoint(user_id=user_id, cur_point=init_val, today_point=0,
+                      last_update=datetime.now())
+        await bot.db.point.save(p)
+    return p
+
+
+@custom_user_command(readable_name="点数指令", priority=DPP_COMMAND_PRIORITY_DEFAULT)
+class PointCommand(UserCommandBase):
+    """.point 查看 / .point set <id> <val>（master） / .point get <id>（master）"""
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_POINT_SHOW,
+            "{name} 的点数：{point}（今日已用 {today}/{limit}）",
+            "用户查看自己的点数")
+        bot.loc_helper.register_loc_text(LOC_POINT_LACK,
+            "点数不足：{reason}",
+            "扣点失败")
+        bot.loc_helper.register_loc_text(LOC_POINT_CHECK,
+            "{id} 的点数：{point}",
+            "管理员查询其他用户点数")
+        bot.loc_helper.register_loc_text(LOC_POINT_EDIT,
+            "已调整：{id} 的点数 {old} → {new}",
+            "管理员调整其他用户点数")
+        bot.loc_helper.register_loc_text(LOC_POINT_ERROR,
+            "点数处理出错：{error}",
+            "出错")
+
+    # ── 内部封装：从 BotConfig 取实时配置，支持热重载 ────────────────────
+    @property
+    def _cfg(self):
+        return self.bot.config.point
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        if msg_str.startswith(".point"):
+            return True, False, msg_str[6:].strip()
+        return False, False, None
+
+    async def process_msg(self, msg_str: str, meta: MessageMetaData,
+                          hint: Any) -> List[BotCommandBase]:
+        port = (GroupMessagePort(meta.group_id)
+                if meta.group_id else PrivateMessagePort(meta.user_id))
+        arg = hint or ""
+        is_master = getattr(meta, "permission", 0) >= 3
+        cfg = self._cfg
+
+        try:
+            if not arg:
+                # 查询自己
+                p = await _get_or_create_point(self.bot, meta.user_id, cfg.init)
+                self._refresh_daily(p)
+                await self.bot.db.point.save(p)
+                feedback = self.format_loc(
+                    LOC_POINT_SHOW,
+                    name=meta.nickname or meta.user_id,
+                    point=p.cur_point, today=p.today_point,
+                    limit=cfg.limit_daily,
+                )
+            elif arg.startswith("set") and is_master:
+                # .point set <user_id> <value>
+                parts = arg[3:].strip().split()
+                if len(parts) != 2:
+                    raise ValueError("用法：.point set <user_id> <value>")
+                target_id, value_str = parts
+                value = int(value_str)
+                p = await _get_or_create_point(self.bot, target_id, cfg.init)
+                old = p.cur_point
+                # 上限放宽到 max * 10 给 master 临时调整余地
+                p.cur_point = max(0, min(value, cfg.max * 10))
+                p.last_update = datetime.now()
+                await self.bot.db.point.save(p)
+                feedback = self.format_loc(
+                    LOC_POINT_EDIT, id=target_id, old=old, new=p.cur_point
+                )
+            elif arg.startswith("get") and is_master:
+                # .point get <user_id>
+                target_id = arg[3:].strip()
+                if not target_id:
+                    raise ValueError("用法：.point get <user_id>")
+                p = await self.bot.db.point.get(target_id)
+                point_val = p.cur_point if p else 0
+                feedback = self.format_loc(
+                    LOC_POINT_CHECK, id=target_id, point=point_val
+                )
+            else:
+                feedback = ("用法：\n"
+                            "  .point          查看自己的点数\n"
+                            "  .point set <id> <值>  (管理员) 设置\n"
+                            "  .point get <id>       (管理员) 查询")
+        except ValueError as e:
+            feedback = self.format_loc(LOC_POINT_ERROR, error=str(e))
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    def _refresh_daily(self, p: UserPoint) -> None:
+        """跨天则重置 today_point 并补发每日点数。
+
+        tick_daily 是同步接口而 DB 操作是 async，无法在 tick_daily 里直接
+        async-save。改用"懒补发"：用户下次访问 .point 时检测到跨天，
+        就重置 today_point 并按需 +cfg.add（不超 cfg.max）。
+        """
+        cfg = self._cfg
+        now = datetime.now()
+        if p.last_update.date() != now.date():
+            if p.cur_point <= cfg.max:
+                p.cur_point = min(cfg.max, p.cur_point + cfg.add)
+            p.today_point = 0
+            p.last_update = now
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword == "point":
+            cfg = self._cfg
+            return (
+                "点数指令：\n"
+                f"  .point          查看自己的点数（初始 {cfg.init}，每日补 {cfg.add}，上限 {cfg.max}）\n"
+                f"  每日消耗上限 {cfg.limit_daily} 点\n"
+                "  .point set <user_id> <值>   (管理员) 设置\n"
+                "  .point get <user_id>        (管理员) 查询"
+            )
+        return ""
+
+    def get_description(self) -> str:
+        return ".point 查询/管理点数"

--- a/src/plugins/DicePP/module/common/team_command.py
+++ b/src/plugins/DicePP/module/common/team_command.py
@@ -1,0 +1,290 @@
+"""队伍指令 .team
+
+跑团群里区分玩家（PC）和观众（OB）。team 内的成员保留原名；team 外
+的人会被自动改群名片为 "ob"（前提：骰娘在该群有管理员权限）。
+
+子指令：
+  .team set @玩家1 @玩家2 ...   一次添加多名玩家到本群 team
+  .team del @玩家                移除玩家
+  .team clr                       清空本群 team
+  .team show                      列出 team 成员
+  .team desc                      列出 team 成员 HP/AC/被动察觉
+  .team call [消息]               @ 所有 team 成员
+
+自动改名 OB 触发时机：
+  - .team set 时全量刷新一次
+  - 新成员进群时单独改一次（在 dicebot.process_notice 里调用
+    auto_rename_ob_for_new_member()）
+
+群主、群管理员、骰娘自身永远不会被改名。
+"""
+import re
+from datetime import datetime
+from typing import Any, List, Tuple
+
+from core.bot import Bot
+from core.command import (
+    BotCommandBase,
+    BotSendMsgCommand,
+    BotSetGroupCardCommand,
+    UserCommandBase,
+    custom_user_command,
+)
+from core.command.const import DPP_COMMAND_FLAG_DEFAULT, DPP_COMMAND_PRIORITY_DEFAULT
+from core.communication import (
+    GroupMessagePort,
+    MessageMetaData,
+    PrivateMessagePort,
+)
+from core.data.models import GroupTeam
+
+
+OB_CARD = "ob"
+
+# preprocess_msg 会把消息转小写，所以匹配时也用小写形式 "[cq:at,qq=NUM]"
+# 用 IGNORECASE 兼容 raw_msg（保留原大小写）和 plain_msg（小写）
+_AT_RE = re.compile(r'\[cq:at,qq=(\d+)\]', re.IGNORECASE)
+_QQ_RE = re.compile(r'(?<!\d)(\d{5,11})(?!\d)')
+
+
+def _extract_user_ids(text: str) -> List[str]:
+    """从消息文本里提取所有 QQ 号（CQ:at 优先；裸数字回退）。去重保序。"""
+    seen: List[str] = []
+    if not text:
+        return seen
+    for m in _AT_RE.finditer(text):
+        uid = m.group(1)
+        if uid not in seen:
+            seen.append(uid)
+    # 移除 CQ 码部分再扫裸数字，避免重复
+    stripped = _AT_RE.sub('', text)
+    for m in _QQ_RE.finditer(stripped):
+        uid = m.group(1)
+        if uid not in seen:
+            seen.append(uid)
+    return seen
+
+
+async def _get_team(bot: Bot, group_id: str) -> GroupTeam:
+    team = await bot.db.group_team.get(group_id)
+    if team is None:
+        team = GroupTeam(group_id=group_id, members=[], auto_rename_ob=True)
+    return team
+
+
+async def _save_team(bot: Bot, team: GroupTeam) -> None:
+    team.last_update = datetime.now()
+    await bot.db.group_team.save(team)
+
+
+async def _build_rename_ob_commands(bot: Bot, group_id: str,
+                                    team_members: List[str]) -> List[BotCommandBase]:
+    """对群里非 team、非管理员、非骰娘自身的成员发改名指令（且当前名片不是 ob）。"""
+    if bot.proxy is None:
+        return []
+    try:
+        all_members = await bot.proxy.get_group_member_list(group_id)
+    except (OSError, RuntimeError, AttributeError):
+        return []
+
+    cmds: List[BotCommandBase] = []
+    team_set = set(team_members)
+    bot_id = bot.account
+    for m in all_members:
+        uid = str(m.user_id)
+        if uid == bot_id:
+            continue
+        if uid in team_set:
+            continue
+        if getattr(m, "role", "member") in ("owner", "admin"):
+            continue
+        cur = (getattr(m, "card", "") or "").strip().lower()
+        if cur == OB_CARD:
+            continue
+        cmds.append(BotSetGroupCardCommand(
+            bot_id=bot_id, group_id=group_id, user_id=uid, card=OB_CARD,
+        ))
+    return cmds
+
+
+async def auto_rename_ob_for_new_member(bot: Bot, group_id: str,
+                                        user_id: str) -> List[BotCommandBase]:
+    """新成员进群时调用：若群启用 team 且新成员不在 team 中，改名 ob。
+
+    供 dicebot.process_notice 在 GroupIncreaseNoticeData 分支末尾调用。
+    """
+    try:
+        team = await bot.db.group_team.get(group_id)
+    except RuntimeError:
+        return []
+    if team is None or not team.auto_rename_ob:
+        return []
+    if user_id == bot.account or user_id in team.members:
+        return []
+    return [BotSetGroupCardCommand(
+        bot_id=bot.account, group_id=group_id, user_id=user_id, card=OB_CARD,
+    )]
+
+
+@custom_user_command(readable_name="队伍指令", priority=DPP_COMMAND_PRIORITY_DEFAULT,
+                     flag=DPP_COMMAND_FLAG_DEFAULT, group_only=True)
+class TeamCommand(UserCommandBase):
+    """跑团群队伍管理 + 自动改名 ob"""
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        if msg_str.startswith(".team"):
+            # 用 raw_msg 解析以保留 CQ:at 大小写；hint 传 raw_msg 中 .team 后的部分
+            raw_arg = ""
+            try:
+                idx = meta.raw_msg.lower().find(".team")
+                if idx >= 0:
+                    raw_arg = meta.raw_msg[idx + 5:].strip()
+            except AttributeError:
+                raw_arg = msg_str[5:].strip()
+            return True, False, raw_arg
+        return False, False, None
+
+    async def process_msg(self, msg_str: str, meta: MessageMetaData,
+                          hint: Any) -> List[BotCommandBase]:
+        port = (GroupMessagePort(meta.group_id)
+                if meta.group_id else PrivateMessagePort(meta.user_id))
+        if not meta.group_id:
+            return [BotSendMsgCommand(self.bot.account, ".team 仅限群聊使用", [port])]
+
+        arg = (hint or "").strip()
+        parts = arg.split(None, 1)
+        sub = parts[0].lower() if parts else ""
+        rest = parts[1] if len(parts) > 1 else ""
+
+        if sub == "set":
+            return await self._handle_set(meta, rest, port)
+        if sub == "del":
+            return await self._handle_del(meta, rest, port)
+        if sub in ("clr", "clear"):
+            return await self._handle_clr(meta, port)
+        if sub == "show":
+            return await self._handle_show(meta, port)
+        if sub == "desc":
+            return await self._handle_desc(meta, port)
+        if sub == "call":
+            return await self._handle_call(meta, rest, port)
+        return [BotSendMsgCommand(self.bot.account, self._help_text(), [port])]
+
+    async def _handle_set(self, meta: MessageMetaData, rest: str,
+                          port) -> List[BotCommandBase]:
+        ids = _extract_user_ids(rest)
+        if not ids:
+            return [BotSendMsgCommand(self.bot.account,
+                "请 @ 一个或多个玩家。例：.team set @玩家A @玩家B", [port])]
+        team = await _get_team(self.bot, meta.group_id)
+        added: List[str] = []
+        for uid in ids:
+            if uid not in team.members:
+                team.members.append(uid)
+                added.append(uid)
+        await _save_team(self.bot, team)
+
+        cmds: List[BotCommandBase] = []
+        if team.auto_rename_ob:
+            cmds.extend(await _build_rename_ob_commands(self.bot, meta.group_id, team.members))
+
+        if added:
+            head = f"已添加 {len(added)} 位玩家（team 当前共 {len(team.members)} 位）：{', '.join(added)}"
+        else:
+            head = f"team 中已有这 {len(ids)} 位玩家（共 {len(team.members)} 位）"
+        if cmds:
+            head += f"\n同步改名 {len(cmds)} 位非 team 成员为 ob"
+        cmds.insert(0, BotSendMsgCommand(self.bot.account, head, [port]))
+        return cmds
+
+    async def _handle_del(self, meta: MessageMetaData, rest: str,
+                          port) -> List[BotCommandBase]:
+        ids = _extract_user_ids(rest)
+        if not ids:
+            return [BotSendMsgCommand(self.bot.account, "请 @ 要移除的玩家", [port])]
+        team = await _get_team(self.bot, meta.group_id)
+        removed: List[str] = []
+        for uid in ids:
+            if uid in team.members:
+                team.members.remove(uid)
+                removed.append(uid)
+        await _save_team(self.bot, team)
+        msg = (f"已从 team 移出 {len(removed)} 位：{', '.join(removed)}（共 {len(team.members)} 位）"
+               if removed else "team 中找不到这些玩家")
+        return [BotSendMsgCommand(self.bot.account, msg, [port])]
+
+    async def _handle_clr(self, meta: MessageMetaData,
+                          port) -> List[BotCommandBase]:
+        team = await _get_team(self.bot, meta.group_id)
+        n = len(team.members)
+        team.members = []
+        await _save_team(self.bot, team)
+        return [BotSendMsgCommand(self.bot.account,
+                                  f"已清空本群 team（原有 {n} 位玩家）", [port])]
+
+    async def _handle_show(self, meta: MessageMetaData,
+                           port) -> List[BotCommandBase]:
+        team = await _get_team(self.bot, meta.group_id)
+        if not team.members:
+            return [BotSendMsgCommand(self.bot.account,
+                "本群 team 为空。用 .team set @玩家 添加。", [port])]
+        lines = [f"本群 team（{len(team.members)} 人）："]
+        for uid in team.members:
+            try:
+                nick = await self.bot.get_nickname(uid, meta.group_id) or uid
+            except (RuntimeError, AttributeError):
+                nick = uid
+            lines.append(f"  · {nick} ({uid})")
+        return [BotSendMsgCommand(self.bot.account, "\n".join(lines), [port])]
+
+    async def _handle_desc(self, meta: MessageMetaData,
+                           port) -> List[BotCommandBase]:
+        team = await _get_team(self.bot, meta.group_id)
+        if not team.members:
+            return [BotSendMsgCommand(self.bot.account, "本群 team 为空", [port])]
+        lines = ["本群 team 状态："]
+        for uid in team.members:
+            try:
+                nick = await self.bot.get_nickname(uid, meta.group_id) or uid
+            except (RuntimeError, AttributeError):
+                nick = uid
+            char = await self.bot.db.characters_dnd.get(meta.group_id, uid)
+            if char and char.is_init:
+                hp = char.hp_info.hp_cur
+                hp_max = char.hp_info.hp_max
+                # α 的 DNDCharacter 当前没有 AC 和 被动察觉 字段，按 0 占位（C3 移植角色卡时可补）
+                ac = getattr(char, "ac", 0) or 0
+                pp = getattr(char, "passive_perception", 0) or 0
+                lines.append(f"  · {nick}：HP {hp}/{hp_max} | AC {ac} | 被动察觉 {pp}")
+            else:
+                lines.append(f"  · {nick}：未设置角色卡")
+        return [BotSendMsgCommand(self.bot.account, "\n".join(lines), [port])]
+
+    async def _handle_call(self, meta: MessageMetaData, rest: str,
+                           port) -> List[BotCommandBase]:
+        team = await _get_team(self.bot, meta.group_id)
+        if not team.members:
+            return [BotSendMsgCommand(self.bot.account, "本群 team 为空", [port])]
+        ats = " ".join(f"[CQ:at,qq={uid}]" for uid in team.members)
+        body = rest.strip() if rest else "请集合"
+        return [BotSendMsgCommand(self.bot.account, f"{ats}\n{body}", [port])]
+
+    def _help_text(self) -> str:
+        return (
+            "队伍指令 .team —— 跑团群里管理玩家（PC）/ 观众（OB）：\n"
+            "  .team set @玩家1 @玩家2 ...   添加玩家到 team\n"
+            "  .team del @玩家                移除\n"
+            "  .team clr                       清空\n"
+            "  .team show                      列出成员\n"
+            "  .team desc                      列出成员 HP/AC/被动察觉\n"
+            "  .team call [消息]               @ 所有 team 成员\n"
+            "骰娘有群管理员权限时，team 外的人会自动改群名片为 ob"
+        )
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword == "team":
+            return self._help_text()
+        return ""
+
+    def get_description(self) -> str:
+        return ".team 队伍管理 + 观众改名"

--- a/src/plugins/DicePP/module/common/variable_command.py
+++ b/src/plugins/DicePP/module/common/variable_command.py
@@ -1,0 +1,205 @@
+"""变量指令 (.set / .get / .del)
+
+用户在群内定义临时变量，可用于辅助跑团。基于 α 已有的 UserVariable
++ variable Repository。重写自 β 的 module/common/variable_command.py。
+
+支持：
+  .set 变量名 = 数值或骰子表达式
+  .set 变量名 + 5      累加
+  .set 变量名 - 3      累减
+  .get 变量名          查看
+  .get                 查看所有
+  .del 变量名          删除
+  .del all             清空全部
+"""
+import re
+from typing import Any, List, Optional, Tuple
+
+from core.bot import Bot
+from core.command import (
+    BotCommandBase,
+    BotSendMsgCommand,
+    UserCommandBase,
+    custom_user_command,
+)
+from core.command.const import DPP_COMMAND_FLAG_DEFAULT
+from core.communication import (
+    GroupMessagePort,
+    MessageMetaData,
+    PrivateMessagePort,
+)
+from core.data.models import UserVariable
+
+try:
+    from module.roll import exec_roll_exp, RollDiceError  # type: ignore
+except ImportError:  # pragma: no cover
+    exec_roll_exp = None  # type: ignore
+    RollDiceError = Exception  # type: ignore
+
+
+LOC_VAR_SET = "var_set"
+LOC_VAR_GET = "var_get"
+LOC_VAR_GET_ALL = "var_get_all"
+LOC_VAR_DEL = "var_del"
+LOC_VAR_ERROR = "var_error"
+
+_VAR_NAME_RE = re.compile(r"^[A-Za-z_一-鿿][A-Za-z0-9_一-鿿]*$")
+
+# 严格匹配 .set / .get / .del 必须后跟空白或行尾，避免误判 .search / .delete 等
+# 例如 ".set"、".set x = 1" 命中，".search foo"、".delete bar" 不命中
+_VAR_CMD_RE = re.compile(r"^\.(set|get|del)(?:\s+(.*))?$")
+
+
+def _validate_var_name(name: str) -> None:
+    if not name:
+        raise ValueError("变量名不能为空")
+    if len(name) > 32:
+        raise ValueError("变量名过长（上限 32 字符）")
+    if not _VAR_NAME_RE.match(name):
+        raise ValueError("变量名只能由中文/字母/数字/下划线组成且不能以数字开头")
+
+
+def _eval_value(expr: str) -> int:
+    expr = expr.strip()
+    try:
+        return int(expr)
+    except ValueError:
+        pass
+    if exec_roll_exp is None:
+        raise ValueError("无法解析数值表达式")
+    try:
+        return exec_roll_exp(expr).get_val()
+    except RollDiceError as e:  # type: ignore[attr-defined]
+        raise ValueError(getattr(e, "info", str(e)))
+
+
+@custom_user_command(readable_name="变量指令", priority=1,
+                     flag=DPP_COMMAND_FLAG_DEFAULT, group_only=False)
+class VariableCommand(UserCommandBase):
+    """.set / .get / .del 用户自定义变量
+
+    Priority=1 让本指令早于 query (priority=2)、roll 等执行；配合严格的
+    `^\\.(set|get|del)(?:\\s+(.*))?$` 正则确保 `.search` `.delete` 等不会
+    被误判，双重防护避免与 `.s*` 前缀命令冲突（β 注释中提到的风险）。
+    """
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+        bot.loc_helper.register_loc_text(LOC_VAR_SET, "设置变量 {name} = {val}",
+                                         "设置变量的回复")
+        bot.loc_helper.register_loc_text(LOC_VAR_GET, "{name} = {val}",
+                                         "查询变量的回复")
+        bot.loc_helper.register_loc_text(LOC_VAR_GET_ALL, "你的变量列表：\n{info}",
+                                         "查询所有变量的回复")
+        bot.loc_helper.register_loc_text(LOC_VAR_DEL, "已删除变量 {name}",
+                                         "删除变量的回复")
+        bot.loc_helper.register_loc_text(LOC_VAR_ERROR, "变量处理出错：{error}",
+                                         "出错的回复")
+
+    def can_process_msg(self, msg_str: str, meta: MessageMetaData) -> Tuple[bool, bool, Any]:
+        m = _VAR_CMD_RE.match(msg_str)
+        if not m:
+            return False, False, None
+        cmd_type = m.group(1)
+        arg_str = (m.group(2) or "").strip()
+        return True, False, (cmd_type, arg_str)
+
+    async def process_msg(self, msg_str: str, meta: MessageMetaData,
+                          hint: Any) -> List[BotCommandBase]:
+        port = (GroupMessagePort(meta.group_id)
+                if meta.group_id else PrivateMessagePort(meta.user_id))
+        cmd_type, arg_str = hint
+        group_id = meta.group_id or "_private"
+        feedback = ""
+
+        try:
+            if cmd_type == "set":
+                feedback = await self._handle_set(meta.user_id, group_id, arg_str)
+            elif cmd_type == "get":
+                feedback = await self._handle_get(meta.user_id, group_id, arg_str)
+            elif cmd_type == "del":
+                feedback = await self._handle_del(meta.user_id, group_id, arg_str)
+        except ValueError as e:
+            feedback = self.format_loc(LOC_VAR_ERROR, error=str(e))
+
+        return [BotSendMsgCommand(self.bot.account, feedback, [port])]
+
+    async def _handle_set(self, user_id: str, group_id: str, arg_str: str) -> str:
+        if not arg_str:
+            raise ValueError("用法：.set 变量名 = 数值 或 .set 变量名 +/- 数值")
+        # 找到第一个 = / + / - 作为操作符
+        op_idx = -1
+        op = ""
+        for i, ch in enumerate(arg_str):
+            if ch in ("=", "+", "-"):
+                op_idx = i
+                op = ch
+                break
+        if op_idx <= 0:
+            raise ValueError("必须用 = 或 +/- 分隔变量名和数值")
+        name = arg_str[:op_idx].strip()
+        val_str = arg_str[op_idx + 1:].strip()
+        _validate_var_name(name)
+        val = _eval_value(val_str)
+
+        if op == "=":
+            await self.bot.db.variable.save(UserVariable(
+                user_id=user_id, group_id=group_id, name=name, val=val
+            ))
+            return self.format_loc(LOC_VAR_SET, name=name, val=val)
+        else:
+            existing = await self.bot.db.variable.get(user_id, group_id, name)
+            if not existing:
+                raise ValueError(f"变量 {name} 不存在，请先用 = 赋值")
+            delta = val if op == "+" else -val
+            existing.val += delta
+            await self.bot.db.variable.save(existing)
+            return self.format_loc(LOC_VAR_SET, name=name,
+                                   val=f"{existing.val - delta} {op} {val} = {existing.val}")
+
+    async def _handle_get(self, user_id: str, group_id: str, arg_str: str) -> str:
+        if not arg_str:
+            items = await self.bot.db.variable.list_by(user_id=user_id, group_id=group_id)
+            if not items:
+                return "你还没有定义任何变量。用 .set 变量名 = 数值 来定义。"
+            info = "\n".join(f"  {v.name} = {v.val}" for v in items)
+            return self.format_loc(LOC_VAR_GET_ALL, info=info)
+        name = arg_str.strip()
+        _validate_var_name(name)
+        item = await self.bot.db.variable.get(user_id, group_id, name)
+        if not item:
+            raise ValueError(f"变量 {name} 不存在")
+        return self.format_loc(LOC_VAR_GET, name=name, val=item.val)
+
+    async def _handle_del(self, user_id: str, group_id: str, arg_str: str) -> str:
+        if not arg_str:
+            raise ValueError("用法：.del 变量名 或 .del all")
+        if arg_str == "all":
+            items = await self.bot.db.variable.list_by(user_id=user_id, group_id=group_id)
+            for v in items:
+                await self.bot.db.variable.delete(v.user_id, v.group_id, v.name)
+            return self.format_loc(LOC_VAR_DEL, name=f"(共 {len(items)} 个)")
+        name = arg_str.strip()
+        _validate_var_name(name)
+        existing = await self.bot.db.variable.get(user_id, group_id, name)
+        if not existing:
+            raise ValueError(f"变量 {name} 不存在")
+        await self.bot.db.variable.delete(user_id, group_id, name)
+        return self.format_loc(LOC_VAR_DEL, name=name)
+
+    def get_help(self, keyword: str, meta: MessageMetaData) -> str:
+        if keyword in ("set", "get", "del", "var"):
+            return (
+                "变量指令：\n"
+                "  .set 变量名 = 数值          赋值（数值可以是骰子表达式如 2d6+3）\n"
+                "  .set 变量名 + 数值          累加\n"
+                "  .set 变量名 - 数值          累减\n"
+                "  .get 变量名                 查看单个\n"
+                "  .get                        查看所有\n"
+                "  .del 变量名                 删除单个\n"
+                "  .del all                    清空所有"
+            )
+        return ""
+
+    def get_description(self) -> str:
+        return ".set/.get/.del 自定义变量"


### PR DESCRIPTION
## 概述

私设规则系统重写的**第 1 阶段**：纯数据层 + query 引擎扩展。零运行时行为变更 —— 让后续命令/UI PR 有干净的基础设施可用。

按 #50 设计稿 + maintainer 反馈实施：
- **不做跨群共享** ✅ 每群独立目录
- **私设独立于 .mode** ✅ 不绑定模式
- **群聊内私设优先** ✅ search() 私设结果在前 + 同名覆盖

## 改动

### 新模型 `GroupMacro`

群级宏（区别于已有的 `UserMacro`）。`(group_id, key)` 主键，含 `creator_id` 用于审计。后续 PR 会让群宏在 `process_message` 入口先于用户宏展开。

### Migration `v5_group_homebrew`

创建 `group_macro` 表。注册到 `default_registry`，老用户升级时自动跑。

### `Paths.group_homebrew_dir(bot_id, group_id)`

新路径 helper：`data/bots/<bot>/group_homebrew/<group>/`。该目录独立于 `.mode` 切换 —— 私设始终对该群可见。

### `QueryStore` 扩展

新方法（不破坏现有 API）：
- `connect_group_homebrew(group_id, dir_path)` — 加载某群目录下所有 .db
- `list_group_databases(group_id)` — 列该群已加载的 hb db
- `is_homebrew_db / homebrew_group_of / _hb_db_name` — 命名空间助手

命名规则 `__hb__<group>__<file>` 避免和公共 query 库冲突。

### `QueryStore.search()` 改为「私设优先」

旧实现：主库结果先，私设追加在末尾，同名时私设覆盖。
新实现：私设结果先，按 name 去重；主库追加，跳过被私设覆盖的同名。

对调用方完全兼容 —— 仍然是 `search(databases=[main, hb1, hb2, ...], query_tokens=...)`，只是结果顺序变了，且首条同名条目以 hb 为准。

## 文件清单

| 类型 | 文件 |
|---|---|
| 新增 | `core/data/migrations/v5_group_homebrew.py` |
| 修改 | `core/data/models/extended.py` 加 `GroupMacro` |
| 修改 | `core/data/models/__init__.py` 导出 |
| 修改 | `core/data/database.py` 加 `group_macro: Repository[GroupMacro]` |
| 修改 | `core/data/migrations/__init__.py` 注册 v5 |
| 修改 | `core/data/query_store.py` 加群私设支持 + search 重写 |
| 修改 | `core/config/basic.py` 加 `Paths.group_homebrew_dir` |

## 兼容性

- 老调用方 `QueryStore.search([main_db])` 完全等价行为（私设列表为空）
- 老调用方 `search([main_db, single_hb])` 结果集相同（去重逻辑等价），只是顺序变成 hb 在前
- v5 migration 只新增表，不动现有表

## 依赖

base on `feat/team-management` (#48) 因为它已经有 v4 migration；本 PR 加 v5。

## Sister PRs

- `feat/homebrew-commands` — `.hb add/del/list/宏/db` 命令族 + 群宏执行
- `feat/homebrew-admin-ui` — admin WebUI「私设」tab + xlsx 上传

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)