### PR TITLE
fix(initiative): make .init del case-insensitive (Alex/alex bug)

### DIFF
--- a/src/plugins/DicePP/module/initiative/initiative_command.py
+++ b/src/plugins/DicePP/module/initiative/initiative_command.py
@@ -482,25 +482,41 @@ class InitiativeCommand(UserCommandBase):
     def get_description(self) -> str:
         return ".ri 投掷先攻 .init 操作先攻列表"
     
-    def find_valid_entities(self,name_list: List[str],global_list: List[str]) -> Tuple[List[str],str]:
-        # O(N*M)暴力搜索寻找匹配对象
+    def find_valid_entities(self, name_list: List[str], global_list: List[str]) -> Tuple[List[str], str]:
+        """大小写无关匹配先攻条目名（精确 + 模糊）。
+
+        修复 .init del 「哥布林A 删不掉」的 bug：preprocess_msg 把用户消息
+        统一转小写，但 entity.name 可能因为不同来源（PC 群昵称、`.init
+        import` 导入、`.ri` 复数自动后缀外的手动命名）保留了大小写，导致
+        直接 `e_name == name` 永远 False。统一在 lower() 空间比较即可。
+        """
         result_list: List[str] = []
         feedback: str = ""
+        # lower_to_origs: 同 lower-key 的所有原始大小写（一般 1 个，理论上可能多个）
+        lower_to_origs: Dict[str, List[str]] = {}
+        for orig in global_list:
+            lower_to_origs.setdefault(orig.lower(), []).append(orig)
+
         for name in name_list:
-            match_num = sum([e_name == name for e_name in global_list])  
-            if match_num == 1:  # 正好有一个同名条目
-                result_list.append(name)
-            elif match_num == 0:  # 没有同名条目, 进入模糊搜索
-                possible_res: List[str] = match_substring(name, global_list)
-                if len(possible_res) == 0:  # 还是没有结果, 提示用户
+            name_lower = name.lower()
+            if name_lower in lower_to_origs:
+                origs = lower_to_origs[name_lower]
+                if len(origs) == 1:
+                    result_list.append(origs[0])
+                else:
+                    # 极端情况：同 lower 不同大小写共存（如 "Alex" 和 "alex"），按设计不应出现
+                    feedback += self.format_loc(LOC_INIT_ERROR,
+                        error_info=f"列表中存在大小写不同的同名条目 {origs}, 联系开发者") + "\n"
+            else:
+                # 模糊匹配：大小写无关 substring
+                possible_res: List[str] = [orig for orig in global_list if name_lower in orig.lower()]
+                if len(possible_res) == 0:
                     feedback += self.format_loc(LOC_INIT_ENTITY_NOT_FOUND, name=name) + "\n"
-                elif len(possible_res) > 1:  # 多个可能的结果, 提示用户
+                elif len(possible_res) > 1:
                     feedback += self.format_loc(LOC_INIT_ENTITY_VAGUE, name=name, name_list=possible_res) + "\n"
-                elif len(possible_res) == 1:
+                else:
                     result_list.append(possible_res[0])
-            else: #if match_num > 1:  # 多于一个同名条目, 按设计是不可能出现的, 需要排查原因
-                feedback += self.format_loc(LOC_INIT_ERROR, error_info=f"列表中存在同名条目{name}, 联系开发者") + "\n"
-        return (result_list,feedback)
+        return (result_list, feedback)
 
     async def add_initiative_entities(self, result_dict: Dict[str, Tuple[int, str]], owner_id: str, group_id: str) -> str:
         """


### PR DESCRIPTION
## 概述

修复 `.init del` 对带大写字母的先攻条目无法删除的 bug。

## 复现

```
.ri Alex   (PC 群昵称 "Alex")
.init      → 列表显示 "Alex 12"
.init del Alex
```

实际表现：bot 回 `没有名为 alex 的先攻条目`。

## 根因

`dicebot.process_message` 入口 `preprocess_msg(msg)` 把整条消息统一转小写。
- `.ri Alex` 添加时，entity.name 直接用 `self.bot.get_nickname(...)` 取，**保留 PC 群昵称的原大小写** → 存的是 `Alex`
- `.init del Alex` 被预处理成 `.init del alex`，arg_str = `alex`
- `find_valid_entities` 用 `e_name == name` 直接比较 → `"Alex" == "alex"` 永远 False
- 落进模糊匹配，又用大小写敏感的 `match_substring`，还是匹不上
- 最终返回 `LOC_INIT_ENTITY_NOT_FOUND`

其他可能引入大小写不一致 entity.name 的来源：
- `.init import` 导入的外部数据
- 跨版本迁移过来的旧数据

## 修复

`find_valid_entities` 改为在 `lower()` 空间比较：
- 精确匹配：建 `lower_to_origs: Dict[str, List[str]]` 索引，命中后用原始大小写归还
- 模糊匹配：substring 检查也在 lower 空间做

副作用：所有调用 `find_valid_entities` 的子指令（del / first / swap）都变成大小写无关，对玩家更友好。

边界处理：若列表里同时存在 `"Alex"` 和 `"alex"`（理论上不应发生 —— `.ri` 复数后缀只生成 a/b/c 小写），返回错误提示并联系开发者，避免静默错删。

## 文件改动

仅一处：`src/plugins/DicePP/module/initiative/initiative_command.py:find_valid_entities`，29 insertions / 13 deletions。

## 兼容性

- 旧用法 `.init del 哥布林a`（小写存小写删）继续 work
- 新用法 `.init del 哥布林A`（大小写不匹配）现在能正常删
- 没有数据库 schema 改动
- 没有依赖其他 PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
