### PR TITLE
fix(initiative): .init del 大小写无关匹配，修复 PC 昵称含大写时无法删除的 bug

### DIFF
--- a/src/plugins/DicePP/module/initiative/initiative_command.py
+++ b/src/plugins/DicePP/module/initiative/initiative_command.py
@@ -8,7 +8,7 @@ from core.communication import MessageMetaData, PrivateMessagePort, GroupMessage
 from module.roll import RollResult, RollExpression, preprocess_roll_exp, parse_roll_exp, RollDiceError, is_roll_exp, sift_roll_exp_and_reason
 
 from core.data.models import InitList, InitEntity, InitiativeError, HPInfo
-from utils.string import match_substring
+
 
 LOC_INIT_ROLL = "initiative_roll"
 LOC_INIT_INFO = "initiative_info"
@@ -296,7 +296,7 @@ class InitiativeCommand(UserCommandBase):
         # 先找到先攻数据是否存在
         init_data: InitList
         init_data = await self.bot.db.initiative.get(meta.group_id)
-        if init_data is None:
+        if init_data is None or len(init_data.entities) == 0:
             feedback = self.format_loc(LOC_INIT_INFO_NOT_EXIST)
             return [BotSendMsgCommand(self.bot.account, feedback, [port])]
 
@@ -482,25 +482,41 @@ class InitiativeCommand(UserCommandBase):
     def get_description(self) -> str:
         return ".ri 投掷先攻 .init 操作先攻列表"
     
-    def find_valid_entities(self,name_list: List[str],global_list: List[str]) -> Tuple[List[str],str]:
-        # O(N*M)暴力搜索寻找匹配对象
+    def find_valid_entities(self, name_list: List[str], global_list: List[str]) -> Tuple[List[str], str]:
+        """大小写无关匹配先攻条目名（精确 + 模糊）。
+
+        修复 .init del 「哥布林A 删不掉」的 bug：preprocess_msg 把用户消息
+        统一转小写，但 entity.name 可能因为不同来源（PC 群昵称、`.init
+        import` 导入、`.ri` 复数自动后缀外的手动命名）保留了大小写，导致
+        直接 `e_name == name` 永远 False。统一在 lower() 空间比较即可。
+        """
         result_list: List[str] = []
         feedback: str = ""
+        # lower_to_origs: 同 lower-key 的所有原始大小写（一般 1 个，理论上可能多个）
+        lower_to_origs: Dict[str, List[str]] = {}
+        for orig in global_list:
+            lower_to_origs.setdefault(orig.lower(), []).append(orig)
+
         for name in name_list:
-            match_num = sum([e_name == name for e_name in global_list])  
-            if match_num == 1:  # 正好有一个同名条目
-                result_list.append(name)
-            elif match_num == 0:  # 没有同名条目, 进入模糊搜索
-                possible_res: List[str] = match_substring(name, global_list)
-                if len(possible_res) == 0:  # 还是没有结果, 提示用户
+            name_lower = name.lower()
+            if name_lower in lower_to_origs:
+                origs = lower_to_origs[name_lower]
+                if len(origs) == 1:
+                    result_list.append(origs[0])
+                else:
+                    # 极端情况：同 lower 不同大小写共存（如 "Alex" 和 "alex"），按设计不应出现
+                    feedback += self.format_loc(LOC_INIT_ERROR,
+                        error_info=f"列表中存在大小写不同的同名条目 {origs}, 联系开发者") + "\n"
+            else:
+                # 模糊匹配：大小写无关 substring
+                possible_res: List[str] = [orig for orig in global_list if name_lower in orig.lower()]
+                if len(possible_res) == 0:
                     feedback += self.format_loc(LOC_INIT_ENTITY_NOT_FOUND, name=name) + "\n"
-                elif len(possible_res) > 1:  # 多个可能的结果, 提示用户
+                elif len(possible_res) > 1:
                     feedback += self.format_loc(LOC_INIT_ENTITY_VAGUE, name=name, name_list=possible_res) + "\n"
-                elif len(possible_res) == 1:
+                else:
                     result_list.append(possible_res[0])
-            else: #if match_num > 1:  # 多于一个同名条目, 按设计是不可能出现的, 需要排查原因
-                feedback += self.format_loc(LOC_INIT_ERROR, error_info=f"列表中存在同名条目{name}, 联系开发者") + "\n"
-        return (result_list,feedback)
+        return (result_list, feedback)
 
     async def add_initiative_entities(self, result_dict: Dict[str, Tuple[int, str]], owner_id: str, group_id: str) -> str:
         """

--- a/tests/module/initiative/test_initiative_command.py
+++ b/tests/module/initiative/test_initiative_command.py
@@ -238,6 +238,45 @@ class TestInitiativeList(_InitBotBase):
         assert len(cmds) > 0, "Should have response"
         assert any(word in result for word in ["没有", "不存在", "找不到", "not found"])
 
+    async def test_init_del__case_insensitive_exact_match(self):
+        """Delete entry whose PC nickname has uppercase (e.g. "Alex") via lowercase input.
+
+        preprocess_msg lowercases user input, so ".init del Alex" becomes
+        ".init del alex", but the entity name stored from get_nickname() retains
+        the original case.  Exact match must work despite case mismatch.
+        """
+        # PC with mixed-case nickname "Alex" rolls
+        await self._send_group(".ri", user_id="user1", nickname="Alex", dice_values=[15])
+
+        # Verify entry exists with original case in list
+        cmds1, result1 = await self._send_group(".init")
+        assert "Alex" in result1, f"Expected Alex in list, got: {result1}"
+
+        # Delete with all-lowercase (simulating preprocess_msg behaviour)
+        cmds2, result2 = await self._send_group(".init del alex")
+        assert len(cmds2) > 0, "Should have response"
+        assert any(word in result2 for word in ["删除", "移除"]), f"应返回删除确认: {result2}"
+
+        # Verify entry is gone
+        cmds3, result3 = await self._send_group(".init")
+        assert "Alex" not in result3, f"Alex should be deleted, got: {result3}"
+
+    async def test_init_del__case_insensitive_fuzzy_match(self):
+        """Fuzzy match works case-insensitively.
+
+        Partial lowercase input "al" should match "Alex" via substring in lower() space.
+        """
+        await self._send_group(".ri", user_id="user1", nickname="Alex", dice_values=[15])
+
+        # Fuzzy partial match with different case
+        cmds, result = await self._send_group(".init del al")
+        assert len(cmds) > 0, "Should have response"
+        assert any(word in result for word in ["删除", "移除"]), f"应返回删除确认: {result}"
+
+        # Verify entry is gone
+        cmds2, result2 = await self._send_group(".init")
+        assert "Alex" not in result2, f"Alex should be deleted, got: {result2}"
+
     async def test_init__swap_changes_order(self):
         """swap changes the order of names in list."""
         # Add two entries


### PR DESCRIPTION
## 概述

修复 `.init del` 对带大写字母的先攻条目无法删除的 bug。

## 复现

```
.ri Alex   (PC 群昵称 "Alex")
.init      → 列表显示 "Alex 12"
.init del Alex
```

实际表现：bot 回 `没有名为 alex 的先攻条目`。

## 根因

`dicebot.process_message` 入口 `preprocess_msg(msg)` 把整条消息统一转小写。
- `.ri Alex` 添加时，entity.name 直接用 `self.bot.get_nickname(...)` 取，**保留 PC 群昵称的原大小写** → 存的是 `Alex`
- `.init del Alex` 被预处理成 `.init del alex`，arg_str = `alex`
- `find_valid_entities` 用 `e_name == name` 直接比较 → `"Alex" == "alex"` 永远 False

## 修复

- `find_valid_entities` 改为在 `lower()` 空间比较（精确 + 模糊匹配）
- 删除未使用的 `match_substring` import
- 修复删除最后一条先攻后空 `entities` 越界崩溃（`IndexError`）
- 新增两个大小写无关删除的回归测试

## 兼容性

- 旧用法继续 work
- 无数据库 schema 改动
- 无依赖其他 PR